### PR TITLE
Update RasPi3-4-deploy.sh

### DIFF
--- a/deploy/RasPi3-4-deploy.sh
+++ b/deploy/RasPi3-4-deploy.sh
@@ -17,6 +17,9 @@ sudo raspi-config nonint do_serial 2
 sudo raspi-config nonint do_hostname rpanion
 sudo perl -pe 's/raspberrypi/rpanion/' -i /etc/hosts
 
+## Blob for Compute Modules which support dual CSI cameras
+sudo wget http://goo.gl/U4t12b -O /boot/dt-blob.bin
+
 ## Power switch config for Pi-Connect
 echo "" | sudo tee -a /boot/config.txt >/dev/null
 echo "# Power switch" | sudo tee -a /boot/config.txt >/dev/null
@@ -58,5 +61,8 @@ cd ../../
 
 ## and build & run Rpanion
 ./deploy/build.sh
+
+## Clean out packages no longer required
+sudo apt autoremove --purge -y
 
 sudo reboot


### PR DESCRIPTION
This adds the dual camera dt-blob for Compute Module 3/3+, enabling two CSI ports.  Also added an autoremove to clear out packages no longer required (just for tidiness).
the script seems broken at the moment, but not due this change.