### PR TITLE
Fixes for RPi OS Bulleye

### DIFF
--- a/deploy/RasPi2-3-4-deploy.sh
+++ b/deploy/RasPi2-3-4-deploy.sh
@@ -26,10 +26,10 @@ echo "dtoverlay=gpio-poweroff" | sudo tee -a /boot/config.txt >/dev/null
 ## Packages
 sudo apt update
 sudo apt upgrade -y
-sudo apt install -y libgstreamer-plugins-base1.0* libgstreamer1.0-dev libgstrtspserver-1.0-dev gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly gstreamer1.0-plugins-base-apps network-manager python3 python3-dev python3-gst-1.0 python3-pip dnsmasq git ninja-build
+sudo apt install -y libgstreamer-plugins-base1.0* libgstreamer1.0-dev libgstrtspserver-1.0-dev gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly gstreamer1.0-plugins-base-apps network-manager python3 python3-dev python3-gst-1.0 python3-pip dnsmasq git ninja-build autoconf libtool
 
 sudo apt purge -y openresolv dhcpcd5 modemmanager
-sudo apt remove -y modemmanager
+sudo apt remove -y modemmanager nodejs nodejs-doc
 
 sudo systemctl disable dnsmasq
 


### PR DESCRIPTION
1) Line 32: NodeJS v14 over v12 had some issues here. I purpose to remove v12 and do a clean installation as I did after reading at https://github.com/nodesource/distributions/issues/1157

2) Line 29: Autogen.sh had some issues. Only some standard packages need to be forced in.