### PR TITLE
Add hostname as a API information

### DIFF
--- a/server/aboutInfo.js
+++ b/server/aboutInfo.js
@@ -6,7 +6,7 @@ var winston = require('./winstonconfig')(module)
 function getSoftwareInfo (callback) {
   // get the OS, Node.js and Rpanion-server versions
   si.osInfo(function (data) {
-    return callback('' + data.distro + ' - ' + data.release, process.version, process.env.npm_package_version, null)
+    return callback('' + data.distro + ' - ' + data.release, process.version, process.env.npm_package_version, data.hostname, null)
   })
 }
 

--- a/server/aboutInfo.test.js
+++ b/server/aboutInfo.test.js
@@ -4,10 +4,11 @@ const aboutPage = require('./aboutInfo')
 describe('About Functions', function () {
   describe('#getSoftwareInfo()', function () {
     it('should get software info', function (done) {
-      aboutPage.getSoftwareInfo(function (OSV, NodeV, RpanionV, err) {
+      aboutPage.getSoftwareInfo(function (OSV, NodeV, RpanionV, hostname, err) {
         assert.notEqual(OSV, '')
         assert.notEqual(NodeV, '')
         assert.notEqual(RpanionV, '')
+        assert.notEqual(hostname, '')
         assert.equal(err, null)
         done()
       })

--- a/server/index.js
+++ b/server/index.js
@@ -22,6 +22,7 @@ const path = require('path')
 
 const io = require('socket.io')(http, { cookie: false })
 const { check, validationResult, oneOf } = require('express-validator')
+const { hostname } = require('os')
 
 // Init settings before running the other classes
 settings.init({
@@ -222,14 +223,14 @@ app.post('/api/logenable', [check('enable').isBoolean()], function (req, res) {
 })
 
 app.get('/api/softwareinfo', (req, res) => {
-  aboutPage.getSoftwareInfo((OSV, NodeV, RpanionV, err) => {
+  aboutPage.getSoftwareInfo((OSV, NodeV, RpanionV, hostname, err) => {
     if (!err) {
       res.setHeader('Content-Type', 'application/json')
-      res.send(JSON.stringify({ OSVersion: OSV, Nodejsversion: NodeV, rpanionversion: RpanionV }))
-      winston.info('/api/softwareinfo OS:' + OSV + ' Node:' + NodeV + ' Rpanion:' + RpanionV)
+      res.send(JSON.stringify({ OSVersion: OSV, Nodejsversion: NodeV, rpanionversion: RpanionV, hostname: hostname}))
+      winston.info('/api/softwareinfo OS:' + OSV + ' Node:' + NodeV + ' Rpanion:' + RpanionV + ' Hostname: ' + hostname)
     } else {
       res.setHeader('Content-Type', 'application/json')
-      res.send(JSON.stringify({ OSVersion: err, Nodejsversion: err, rpanionversion: err }))
+      res.send(JSON.stringify({ OSVersion: err, Nodejsversion: err, rpanionversion: err, hostname: err }))
       winston.error('Error in /api/softwareinfo ', { message: err })
     }
   })

--- a/src/about.js
+++ b/src/about.js
@@ -72,6 +72,7 @@ class AboutPage extends basePage {
         <p>Disk Space: {this.state.diskSpaceStatus}</p>
         {this.HATInfo()}
         <h2>About Software</h2>
+        <p>OS hostname: {this.state.hostname}</p>
         <p>OS version: {this.state.OSVersion}</p>
         <p>Node.js version: {this.state.Nodejsversion}</p>
         <p>Rpanion-server version: {this.state.rpanionversion}</p>


### PR DESCRIPTION
It makes the OS hostname accessible outside. 

One of the possible uses is to use Rpanion in several quads and identify the vehicles by their hostnames.