### PR TITLE
Deploy: Install openresolv last

### DIFF
--- a/deploy/RasPi-ubuntu20-deploy.sh
+++ b/deploy/RasPi-ubuntu20-deploy.sh
@@ -50,7 +50,6 @@ echo "[keyfile]" | sudo tee -a /etc/NetworkManager/conf.d/10-globally-managed-de
 echo "unmanaged-devices=*,except:type:wifi,except:type:gsm,except:type:cdma,except:type:wwan,except:type:ethernet,type:vlan" | sudo tee -a /etc/NetworkManager/conf.d/10-globally-managed-devices.conf >/dev/null
 sudo service network-manager restart
 
-
 ## mavlink-router
 ./build_mavlinkrouter.sh
 
@@ -59,5 +58,8 @@ sudo service network-manager restart
 
 ## And re-enable
 sudo systemctl start unattended-upgrades.service
+
+## For wireguard. Must be installed last as it messes the DNS resolutions
+sudo apt install -y resolvconf
 
 sudo reboot

--- a/deploy/RasPi2-3-4-deploy.sh
+++ b/deploy/RasPi2-3-4-deploy.sh
@@ -39,4 +39,7 @@ sudo sed -i.bak -e '/^\[main\]/aauth-polkit=false' /etc/NetworkManager/NetworkMa
 ## and build & run Rpanion
 ./build_rpanion.sh
 
+## For wireguard. Must be installed last as it messes the DNS resolutions
+sudo apt install -y resolvconf
+
 sudo reboot

--- a/deploy/RasPiZero-deploy.sh
+++ b/deploy/RasPiZero-deploy.sh
@@ -54,6 +54,9 @@ sudo sed -i.bak -e '/^\[main\]/aauth-polkit=false' /etc/NetworkManager/NetworkMa
 ## NPM has a different directory here, so need the change service detials
 sudo perl -pi -w -e 's{/usr/bin/npm}{/usr/local/bin/npm}g;'  /etc/systemd/system/rpanion.service
 
+## For wireguard. Must be installed last as it messes the DNS resolutions
+sudo apt install -y resolvconf
+
 ## Create Wifi AP
 ./wifi_access_point.sh
 

--- a/deploy/install_common_libraries.sh
+++ b/deploy/install_common_libraries.sh
@@ -26,4 +26,4 @@ sudo apt-get install -y gpsbabel zip
 
 ## Zerotier and wireguard
 curl -s https://install.zerotier.com | sudo bash
-sudo apt install -y wireguard wireguard-tools resolvconf
+sudo apt install -y wireguard wireguard-tools

--- a/deploy/jetson-deploy.sh
+++ b/deploy/jetson-deploy.sh
@@ -32,5 +32,8 @@ sudo service network-manager restart
 ## and build & run Rpanion
 ./build_rpanion.sh
 
+## For wireguard. Must be installed last as it messes the DNS resolutions
+sudo apt install -y resolvconf
+
 sudo reboot
 

--- a/deploy/x86-ubuntu20-deploy.sh
+++ b/deploy/x86-ubuntu20-deploy.sh
@@ -37,5 +37,8 @@ sudo service network-manager restart
 ## and build & run Rpanion
 ./build.sh
 
+## For wireguard. Must be installed last as it messes the DNS resolutions
+sudo apt install -y resolvconf
+
 ## And re-enable
 sudo systemctl start unattended-upgrades.service


### PR DESCRIPTION
Turns out there _was_ an issue with the deploy scripts. The ``openresolv`` package messes up the DNS configuration, failing subsequent deploy steps.

Fixes #130 and #119