### PR TITLE
Bug fix: Install first the npm package

### DIFF
--- a/deploy/build_rpanion.sh
+++ b/deploy/build_rpanion.sh
@@ -20,6 +20,7 @@ NPM_INSTALL_EXIT_CODE=0
 # Loop through the retries
 for i in $(seq 1 $MAX_RETRIES); do
   echo "Running npm install (attempt $i)..."
+  sudo apt install -y npm
   npm install
   NPM_INSTALL_EXIT_CODE=$?
 


### PR DESCRIPTION
I was trying to install the Rpanion and I received a bug message in the npm installation. Then i discovered and fix. First it's needed to install the npm package with "apt install npm" then we have to install the react-scripts with the "npm install"