### PR TITLE
update NODE_OPTIONS in build script

### DIFF
--- a/deploy/build_rpanion.sh
+++ b/deploy/build_rpanion.sh
@@ -7,7 +7,7 @@ cd ../
 
 # If less than 500Mb RAM, need to tell NodeJS to reduce memory usage during build
 if [ $(free -m | awk '/^Mem:/{print $2}') -le 500 ]; then
-    set NODE_OPTIONS=--max-old-space-size=256
+    export NODE_OPTIONS="--max-old-space-size=256"
 fi
     
 # Run npm install with 3 re-tries, because I have dns issues sometimes


### PR DESCRIPTION
seems that ./build-rpanion.sh was not completed on raspizero.
running it manually returned an error, out of heap memory.
I verified the code that checks for RAM size, that's working. 
it seems the build proceeded without reducing heap size anyway.
this change worked for me: 
- updated `set` to `export` for install session
- encapsulated value in quotes to ensure it gets saved correctly from inside script