### PR TITLE
Add option to send MAVLink heartbeat messages

### DIFF
--- a/mavlink/mavManager.test.js
+++ b/mavlink/mavManager.test.js
@@ -55,9 +55,9 @@ describe('MAVLink Functions', function () {
     })
 
     udpStream.on('message', (msg, rinfo) => {
-      msg.should.eql(Buffer.from([0xfd, 0x21, 0x00, 0x00, 0x00, 0xff, 0x01, 0x4c, 0x00, 0x00, 0x00, 0x00, 0x14, 0x43, 0x00, 0x00, 0x00, 0x00,
+      msg.should.eql(Buffer.from([0xfd, 0x21, 0x00, 0x00, 0x00, 0x00, 0xBF, 0x4c, 0x00, 0x00, 0x00, 0x00, 0x14, 0x43, 0x00, 0x00, 0x00, 0x00,
         0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02,
-        0x00, 0x00, 0x01, 0x83, 0x49]))
+        0x00, 0x00, 0x01, 0xbf, 0x5b]))
       assert.equal(m.statusBytesPerSec.bytes, 2)
       m.close()
       udpStream.close()
@@ -80,7 +80,7 @@ describe('MAVLink Functions', function () {
     })
 
     udpStream.on('message', (msg, rinfo) => {
-      msg.should.eql(Buffer.from([253, 6, 0, 0, 0, 255, 1, 66, 0, 0, 4, 0, 0, 0, 0, 1, 30, 219]))
+      msg.should.eql(Buffer.from([253, 6, 0, 0, 0, 0, 191, 66, 0, 0, 4, 0, 0, 0, 0, 1, 171, 220]))
       m.close()
       udpStream.close()
       done()
@@ -102,7 +102,29 @@ describe('MAVLink Functions', function () {
     })
 
     udpStream.on('message', (msg, rinfo) => {
-      msg.should.eql(Buffer.from([253, 33, 0, 0, 0, 255, 1, 76, 0, 0, 0, 0, 128, 63, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 246, 0, 0, 0, 1, 135, 241]))
+      msg.should.eql(Buffer.from([253, 33, 0, 0, 0, 0, 191, 76, 0, 0, 0, 0, 128, 63, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 246, 0, 0, 0, 1, 187, 227]))
+      m.close()
+      udpStream.close()
+      done()
+    })
+
+    udpStream.send(Buffer.from([0xfd, 0x06]), 15000, '127.0.0.1', (error) => {
+      if (error) {
+        console.error(error)
+      }
+    })
+  })
+  
+  it('#heartbeatSend()', function (done) {
+    const m = new mavManager(2, '127.0.0.1', 15000)
+    const udpStream = udp.createSocket('udp4')
+
+    m.eventEmitter.on('linkready', (info) => {
+      m.sendHeartbeat()
+    })
+
+    udpStream.on('message', (msg, rinfo) => {
+      msg.should.eql(Buffer.from([253, 09, 00, 00, 00, 00, 191, 00, 00, 00, 00, 00, 00, 00, 18, 08, 00, 00, 02, 61, 244 ]))
       m.close()
       udpStream.close()
       done()

--- a/server/flightController.test.js
+++ b/server/flightController.test.js
@@ -17,7 +17,7 @@ describe('Flight Controller Functions', function () {
     settings.clear()
     const FC = new FCManagerClass(settings, winston)
 
-    await FC.getSerialDevices((err, devices, bauds, seldevice, selbaud, mavers, selmav, active, enableTCP, enableUDPB, UDPBPort, enableDSRequest) => {
+    await FC.getSerialDevices((err, devices, bauds, seldevice, selbaud, mavers, selmav, active, enableHeartbeat, enableTCP, enableUDPB, UDPBPort, enableDSRequest) => {
       assert.equal(err, null)
       assert.equal(devices.length, 0)
       assert.equal(bauds.length, 12)
@@ -26,6 +26,7 @@ describe('Flight Controller Functions', function () {
       assert.equal(mavers.length, 2)
       assert.equal(selmav.value, 2)
       assert.equal(active, false)
+      assert.equal(enableHeartbeat, false)
       assert.equal(enableTCP, false)
       assert.equal(enableUDPB, true)
       assert.equal(UDPBPort, 14550)
@@ -66,11 +67,11 @@ describe('Flight Controller Functions', function () {
     const FC = new FCManagerClass(settings, winston)
     FC.serialDevices.push({ value: '/dev/ttyS0', label: '/dev/ttyS0', pnpId: '456' })
 
-    FC.startStopTelemetry({ pnpId: '456' }, { value: 115200 }, { value: 2 }, true, false, 0, false, (err, isSuccess) => {
+    FC.startStopTelemetry({ pnpId: '456' }, { value: 115200 }, { value: 2 }, false, true, false, 0, false, (err, isSuccess) => {
       assert.equal(err, null)
       assert.equal(isSuccess, true)
 
-      FC.startStopTelemetry({ pnpId: '456' }, { value: 115200 }, { value: 2 }, true, false, 0, false, (err, isSuccess) => {
+      FC.startStopTelemetry({ pnpId: '456' }, { value: 115200 }, { value: 2 }, false, true, false, 0, false, (err, isSuccess) => {
         assert.equal(err, null)
         assert.equal(isSuccess, false)
         done()

--- a/server/index.js
+++ b/server/index.js
@@ -505,7 +505,7 @@ app.get('/api/FCOutputs', (req, res) => {
 
 app.get('/api/FCDetails', (req, res) => {
   res.setHeader('Content-Type', 'application/json')
-  fcManager.getSerialDevices((err, devices, bauds, seldevice, selbaud, mavers, selmav, active, enableTCP, enableUDPB, UDPBPort, enableDSRequest) => {
+  fcManager.getSerialDevices((err, devices, bauds, seldevice, selbaud, mavers, selmav, active, enableHeartbeat, enableTCP, enableUDPB, UDPBPort, enableDSRequest) => {
     // hacky way to pass through the
     if (!err) {
       console.log('Sending')
@@ -518,6 +518,7 @@ app.get('/api/FCDetails', (req, res) => {
         mavVersions: mavers,
         mavVersionSelected: selmav,
         baudRateSelected: selbaud,
+        enableHeartbeat,
         enableTCP,
         enableUDPB,
         UDPBPort,
@@ -534,6 +535,7 @@ app.get('/api/FCDetails', (req, res) => {
         mavVersions: mavers,
         mavVersionSelected: selmav,
         baudRateSelected: selbaud,
+        enableHeartbeat,
         enableTCP,
         enableUDPB,
         UDPBPort,
@@ -554,7 +556,7 @@ app.post('/api/updatemaster', function (req, res) {
   aboutPage.updateRS(io)
 })
 
-app.post('/api/FCModify', [check('device').isJSON(), check('baud').isJSON(), check('mavversion').isJSON(), check('enableTCP').isBoolean(), check('enableUDPB').isBoolean(), check('UDPBPort').isPort(), check('enableDSRequest').isBoolean()], function (req, res) {
+app.post('/api/FCModify', [check('device').isJSON(), check('baud').isJSON(), check('mavversion').isJSON(), check('enableHeartbeat').isBoolean(), check('enableTCP').isBoolean(), check('enableUDPB').isBoolean(), check('UDPBPort').isPort(), check('enableDSRequest').isBoolean()], function (req, res) {
   // User wants to start/stop FC telemetry
   const errors = validationResult(req)
   if (!errors.isEmpty()) {
@@ -562,7 +564,7 @@ app.post('/api/FCModify', [check('device').isJSON(), check('baud').isJSON(), che
     return res.status(422).json({ errors: errors.array() })
   }
 
-  fcManager.startStopTelemetry(JSON.parse(req.body.device), JSON.parse(req.body.baud), JSON.parse(req.body.mavversion), req.body.enableTCP, req.body.enableUDPB, req.body.UDPBPort, req.body.enableDSRequest, (err, isSuccess) => {
+  fcManager.startStopTelemetry(JSON.parse(req.body.device), JSON.parse(req.body.baud), JSON.parse(req.body.mavversion), req.body.enableHeartbeat, req.body.enableTCP, req.body.enableUDPB, req.body.UDPBPort, req.body.enableDSRequest, (err, isSuccess) => {
     if (!err) {
       res.setHeader('Content-Type', 'application/json')
       // console.log(isSuccess);

--- a/src/flightcontroller.js
+++ b/src/flightcontroller.js
@@ -18,6 +18,7 @@ class FCPage extends basePage {
       serialPortSelected: null,
       baudRateSelected: null,
       mavVersionSelected: null,
+      enableHeartbeat: null,
       enableTCP: null,
       FCStatus: {},
       UDPoutputs: [],
@@ -59,6 +60,10 @@ class FCPage extends basePage {
     this.setState({ mavVersionSelected: value });
   }
 
+  handleUseHeartbeatChange = (event) => {
+    this.setState({ enableHeartbeat: event.target.checked });
+  }
+
   handleUseTCPChange = (event) => {
     this.setState({ enableTCP: event.target.checked });
   }
@@ -87,6 +92,7 @@ class FCPage extends basePage {
         device: JSON.stringify(this.state.serialPortSelected),
         baud: JSON.stringify(this.state.baudRateSelected),
         mavversion: JSON.stringify(this.state.mavVersionSelected),
+        enableHeartbeat: this.state.enableHeartbeat,
         enableTCP: this.state.enableTCP,
         enableUDPB: this.state.enableUDPB,
         UDPBPort: this.state.UDPBPort,
@@ -238,10 +244,19 @@ class FCPage extends basePage {
           <div className="col-sm-7">
           <input type="checkbox" checked={this.state.enableDSRequest} disabled={this.state.telemetryStatus} onChange={this.handleDSRequest} />
           </div>
+        <br /> <br />
+        <p><i>Advertise RPanion as an onboard companion computer on the MAVLink network</i></p>
+        <div className="form-group row" style={{ marginBottom: '5px' }}>
+          <label className="col-sm-5 col-form-label">Enable MAVLink heartbeats</label>
+          <div className="col-sm-7">
+          <input type="checkbox" checked={this.state.enableHeartbeat} disabled={this.state.telemetryStatus} onChange={this.handleUseHeartbeatChange} />
+          </div>
+        </div>
+
         </div>
         <br />
         <h2>Status</h2>
-        <p>Packets Recieved: {this.state.FCStatus.numpackets} ({this.state.FCStatus.byteRate} bytes/sec)</p>
+        <p>Packets Received: {this.state.FCStatus.numpackets} ({this.state.FCStatus.byteRate} bytes/sec)</p>
         <p>Connection Status: {this.state.FCStatus.conStatus}</p>
         <p>Vehicle Type: {this.state.FCStatus.vehType}</p>
         <p>Vehicle Firmware: {this.state.FCStatus.FW}{this.state.FCStatus.fcVersion === '' ? '' : (', Version: ' + this.state.FCStatus.fcVersion)}</p>


### PR DESCRIPTION
This allows Rpanion to send out heartbeat messages advertising itself on the MAVLink network as a companion computer which is a component of the vehicle.

The changes to sendData() and the addition of sendHeartbeat() are a first step toward being able to respond to MAVLink commands, and advertising other devices that can accept commands (i.e., cameras).