### PR TITLE
Ras Pi 5 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,12 +47,12 @@ cd ~/ && git clone --recursive https://github.com/stephendade/Rpanion-server.git
 
 ### Automatic (Raspberry Pi)
 
-For the Raspberry Pi 2, 3, 4 and Zero(2) run the below command on a fresh Raspberry Pi OS install
+For the Raspberry Pi 2, 3, 4,5 and Zero(2) run the below command on a fresh Raspberry Pi OS install
 to configure and install Rpanion-server with all required dependencies. Note this does not configure
 an initial Wifi hotspot.
 
 ```
-cd ./deploy && ./RasPi2-3-4-deploy.sh
+cd ./deploy && ./RasPi2-3-4-5-deploy.sh
 ```
 
 If running Ubuntu 20.04 OS on the Pi, use:

--- a/deploy/RasPi2-3-4-5-deploy.sh
+++ b/deploy/RasPi2-3-4-5-deploy.sh
@@ -9,8 +9,17 @@ git submodule update --init --recursive
 #sudo raspi-config nonint do_expand_rootfs
 sudo raspi-config nonint do_camera 0
 sudo raspi-config nonint do_ssh 0
-# Enable serial, disable console
-sudo raspi-config nonint do_serial 2
+
+## Pi5 uses a different UART for the 40-pin header (/dev/ttyAMA0)
+# See https://forums.raspberrypi.com/viewtopic.php?t=359132
+if [ -e "/proc/device-tree/compatible" ]; then
+    if grep -q "5-model-bbrcm" "/proc/device-tree/compatible"; then
+        echo "dtparam=uart0=on" | sudo tee -a /boot/config.txt >/dev/null
+    else
+        # Enable serial, disable console
+        sudo raspi-config nonint do_serial 2
+    fi
+fi
 
 ## Change hostname
 sudo raspi-config nonint do_hostname rpanion

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "dependencies": {
         "app-root-path": "^3.1.0",
         "bootstrap": "^5.3.1",
-        "detect-rpi": "^1.4.0",
         "express-fileupload": "^1.4.0",
         "express-rate-limit": "^6.9.0",
         "express-validator": "^7.0.1",
@@ -7257,11 +7256,6 @@
       "engines": {
         "node": ">= 4.2.1"
       }
-    },
-    "node_modules/detect-rpi": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/detect-rpi/-/detect-rpi-1.4.0.tgz",
-      "integrity": "sha512-EeAj8C7zCdjzNqJCYEVmKcBvu9DmxJncCOkwvAfa7J4I0ZLRywZ1jSeeqI2Kvx/2Gn2OOa1lSXSigZ4wy4M6Tg=="
     },
     "node_modules/detective": {
       "version": "5.2.1",
@@ -28288,11 +28282,6 @@
         "address": "^1.0.1",
         "debug": "^2.6.0"
       }
-    },
-    "detect-rpi": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/detect-rpi/-/detect-rpi-1.4.0.tgz",
-      "integrity": "sha512-EeAj8C7zCdjzNqJCYEVmKcBvu9DmxJncCOkwvAfa7J4I0ZLRywZ1jSeeqI2Kvx/2Gn2OOa1lSXSigZ4wy4M6Tg=="
     },
     "detective": {
       "version": "5.2.1",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "dependencies": {
     "app-root-path": "^3.1.0",
     "bootstrap": "^5.3.1",
-    "detect-rpi": "^1.4.0",
     "express-fileupload": "^1.4.0",
     "express-rate-limit": "^6.9.0",
     "express-validator": "^7.0.1",

--- a/python/gstcaps.py
+++ b/python/gstcaps.py
@@ -45,13 +45,18 @@ if is_raspberry_pi():
         from picamera2 import Picamera2
         for cam in Picamera2.global_camera_info():
             caps = []
-            caps.append({'value': "1920x1080", 'label': "1920x1080", 'height': 1080, 'width': 1920, 'format': 'video/x-raw', 'fpsmax': '30'})
-            caps.append({'value': "1640x922", 'label': "1640x922", 'height': 922, 'width': 1640, 'format': 'video/x-raw', 'fpsmax': '40'})
-            caps.append({'value': "1280x720", 'label': "1280x720", 'height': 720, 'width': 1280, 'format': 'video/x-raw', 'fpsmax': '60'})
-            caps.append({'value': "640x480", 'label': "640x480", 'height': 480, 'width': 640, 'format': 'video/x-raw', 'fpsmax': '90'})
+            if cam['Model'] == 'imx296':
+                # Raspi global shutter camera has specific modes
+                # https://www.raspberrypi.com/documentation/accessories/camera.html
+                caps.append({'value': "1456x1088", 'label': "1456x1088", 'height': 1088, 'width': 1456, 'format': 'video/x-raw', 'fpsmax': '30'})
+            else:
+                caps.append({'value': "1920x1080", 'label': "1920x1080", 'height': 1080, 'width': 1920, 'format': 'video/x-raw', 'fpsmax': '30'})
+                caps.append({'value': "1640x922", 'label': "1640x922", 'height': 922, 'width': 1640, 'format': 'video/x-raw', 'fpsmax': '40'})
+                caps.append({'value': "1280x720", 'label': "1280x720", 'height': 720, 'width': 1280, 'format': 'video/x-raw', 'fpsmax': '60'})
+                caps.append({'value': "640x480", 'label': "640x480", 'height': 480, 'width': 640, 'format': 'video/x-raw', 'fpsmax': '90'})
             name = "CSI Port Camera ({0})".format(cam['Model'])
             path = cam['Id']
-            if path.startswith("/base/soc/i2c"):
+            if path.startswith("/base/soc/i2c") or path.startswith("/base/axi/pcie"):
                 retDevices.append({'value': path, 'label': name, 'caps': caps})
     except:
         pass
@@ -62,6 +67,10 @@ for device in devices:
     path = device.get_properties().get_string("device.path")
     name = device.get_properties().get_string("v4l2.device.card")
     caps = []
+
+    # Don't show Pi5 CSI here
+    if name in ['pispbe', 'rp1-cfe']:
+        continue
 
     # If Ubuntu and Rpi camera
     if "Ubuntu" in platform.uname().version and ("mmal service" in name or name == "unicam"):

--- a/python/gstcaps.py
+++ b/python/gstcaps.py
@@ -48,7 +48,16 @@ if is_raspberry_pi():
             if cam['Model'] == 'imx296':
                 # Raspi global shutter camera has specific modes
                 # https://www.raspberrypi.com/documentation/accessories/camera.html
-                caps.append({'value': "1456x1088", 'label': "1456x1088", 'height': 1088, 'width': 1456, 'format': 'video/x-raw', 'fpsmax': '30'})
+                caps.append({'value': "1456x1088", 'label': "1456x1088", 'height': 1088, 'width': 1456, 'format': 'video/x-raw', 'fpsmax': '60'})
+                caps.append({'value': "1440x900", 'label': "1440x900", 'height': 900, 'width': 1440, 'format': 'video/x-raw', 'fpsmax': '60'})
+                caps.append({'value': "1280x720", 'label': "1280x720", 'height': 720, 'width': 1280, 'format': 'video/x-raw', 'fpsmax': '60'})
+                caps.append({'value': "640x480", 'label': "640x480", 'height': 480, 'width': 640, 'format': 'video/x-raw', 'fpsmax': '60'})
+            elif cam['Model'] == 'imx708':
+                caps.append({'value': "1920x1200", 'label': "1920x1200", 'height': 1200, 'width': 1920, 'format': 'video/x-raw', 'fpsmax': '60'})
+                caps.append({'value': "1920x1080", 'label': "1920x1080", 'height': 1080, 'width': 1920, 'format': 'video/x-raw', 'fpsmax': '60'})
+                caps.append({'value': "1640x922", 'label': "1640x922", 'height': 922, 'width': 1640, 'format': 'video/x-raw', 'fpsmax': '60'})
+                caps.append({'value': "1280x720", 'label': "1280x720", 'height': 720, 'width': 1280, 'format': 'video/x-raw', 'fpsmax': '120'})
+                caps.append({'value': "640x480", 'label': "640x480", 'height': 480, 'width': 640, 'format': 'video/x-raw', 'fpsmax': '120'})
             else:
                 caps.append({'value': "1920x1080", 'label': "1920x1080", 'height': 1080, 'width': 1920, 'format': 'video/x-raw', 'fpsmax': '30'})
                 caps.append({'value': "1640x922", 'label': "1640x922", 'height': 922, 'width': 1640, 'format': 'video/x-raw', 'fpsmax': '40'})

--- a/python/rtsp-server.py
+++ b/python/rtsp-server.py
@@ -104,7 +104,7 @@ def getPipeline(device, height, width, bitrate, format, rotation, framerate, tim
         s_h264 = "identity"
     elif device.startswith("/base/soc/i2c") or device.startswith("/base/axi/pcie"):
         # Bullseye uses the new libcamera interface ... so need a different pipeline
-        s_src = "libcamerasrc camera-name={3} ! capsfilter caps=video/x-raw,width={0},height={1},format=NV12{2}".format(
+        s_src = "libcamerasrc camera-name={3} ! capsfilter caps=video/x-raw,width={0},height={1},format=RGBx{2}".format(
             width, height, framestr, device)
     elif format == "video/x-raw":
         s_src = "v4l2src device={0} ! videorate ! {3},width={1},height={2}{4}".format(

--- a/python/rtsp-server.py
+++ b/python/rtsp-server.py
@@ -102,7 +102,7 @@ def getPipeline(device, height, width, bitrate, format, rotation, framerate, tim
         s_src = "rpicamsrc {5} bitrate={0} rotation={3} camera-number={6} preview=false ! video/x-h264,width={1},height={2}{4}".format(
             bitrate*1000, width, height, devrotation, framestr, ts, device[0])
         s_h264 = "identity"
-    elif device.startswith("/base/soc/i2c"):
+    elif device.startswith("/base/soc/i2c") or device.startswith("/base/axi/pcie"):
         # Bullseye uses the new libcamera interface ... so need a different pipeline
         s_src = "libcamerasrc camera-name={3} ! capsfilter caps=video/x-raw,width={0},height={1},format=NV12{2}".format(
             width, height, framestr, device)

--- a/server/flightController.js
+++ b/server/flightController.js
@@ -428,33 +428,33 @@ class FCDetails {
     }
     // for the Ras Pi's inbuilt UART
     if (fs.existsSync('/dev/serial0') && isPi()) {
-      this.serialDevices.push({ value: '/dev/serial0', label: '/dev/serial0', pnpId: '' })
+      this.serialDevices.push({ value: '/dev/serial0', label: '/dev/serial0', pnpId: '/dev/serial0' })
     }
     if (fs.existsSync('/dev/ttyAMA0') && isPi()) {
       //Pi5 uses a different UART name. See https://forums.raspberrypi.com/viewtopic.php?t=359132
-      this.serialDevices.push({ value: '/dev/ttyAMA0', label: '/dev/ttyAMA0', pnpId: '' })
+      this.serialDevices.push({ value: '/dev/ttyAMA0', label: '/dev/ttyAMA0', pnpId: '/dev/ttyAMA0' })
     }
     if (fs.existsSync('/dev/ttyAMA1') && isPi()) {
-      this.serialDevices.push({ value: '/dev/ttyAMA1', label: '/dev/ttyAMA1', pnpId: '' })
+      this.serialDevices.push({ value: '/dev/ttyAMA1', label: '/dev/ttyAMA1', pnpId: '/dev/ttyAMA1' })
     }
     if (fs.existsSync('/dev/ttyAMA2') && isPi()) {
-      this.serialDevices.push({ value: '/dev/ttyAMA2', label: '/dev/ttyAMA2', pnpId: '' })
+      this.serialDevices.push({ value: '/dev/ttyAMA2', label: '/dev/ttyAMA2', pnpId: '/dev/ttyAMA2' })
     }
     if (fs.existsSync('/dev/ttyAMA3') && isPi()) {
-      this.serialDevices.push({ value: '/dev/ttyAMA3', label: '/dev/ttyAMA3', pnpId: '' })
+      this.serialDevices.push({ value: '/dev/ttyAMA3', label: '/dev/ttyAMA3', pnpId: '/dev/ttyAMA3' })
     }
     if (fs.existsSync('/dev/ttyAMA4') && isPi()) {
-      this.serialDevices.push({ value: '/dev/ttyAMA4', label: '/dev/ttyAMA4', pnpId: '' })
+      this.serialDevices.push({ value: '/dev/ttyAMA4', label: '/dev/ttyAMA4', pnpId: '/dev/ttyAMA4' })
     }
     // rpi uart has different name under Ubuntu
     const data = await si.osInfo()
     if (data.distro.toString().includes('Ubuntu') && fs.existsSync('/dev/ttyS0') && isPi()) {
       // console.log("Running Ubuntu")
-      this.serialDevices.push({ value: '/dev/ttyS0', label: '/dev/ttyS0', pnpId: '' })
+      this.serialDevices.push({ value: '/dev/ttyS0', label: '/dev/ttyS0', pnpId: '/dev/ttyS0' })
     }
     // jetson serial ports
     if (fs.existsSync('/dev/ttyTHS1')) {
-      this.serialDevices.push({ value: '/dev/ttyTHS1', label: '/dev/ttyTHS1', pnpId: '' })
+      this.serialDevices.push({ value: '/dev/ttyTHS1', label: '/dev/ttyTHS1', pnpId: '/dev/ttyTHS1' })
     }
 
     // has the active device been disconnected?

--- a/server/flightController.js
+++ b/server/flightController.js
@@ -6,9 +6,29 @@ const path = require('path')
 const appRoot = require('app-root-path')
 const { spawn, spawnSync, exec } = require('child_process')
 const si = require('systeminformation')
-const isPi = require('detect-rpi')
+//const isPi = require('detect-rpi')
 
 const mavManager = require('../mavlink/mavManager.js')
+
+function isPi () {
+  let cpuInfo = ''
+  try {
+    cpuInfo = fs.readFileSync('/proc/device-tree/compatible', { encoding: 'utf8' })
+  } catch (e) {
+    // if this fails, this is probably not a pi
+    return false
+  }
+
+  const model = cpuInfo
+    .split(',')
+    .filter(line => line.length > 0)
+
+  if (!model || model.length === 0) {
+    return false
+  }
+
+  return model[0] === 'raspberrypi'
+}
 
 class FCDetails {
   constructor (settings, winston) {

--- a/server/flightController.js
+++ b/server/flightController.js
@@ -6,7 +6,6 @@ const path = require('path')
 const appRoot = require('app-root-path')
 const { spawn, spawnSync, exec } = require('child_process')
 const si = require('systeminformation')
-//const isPi = require('detect-rpi')
 
 const mavManager = require('../mavlink/mavManager.js')
 
@@ -430,6 +429,10 @@ class FCDetails {
     // for the Ras Pi's inbuilt UART
     if (fs.existsSync('/dev/serial0') && isPi()) {
       this.serialDevices.push({ value: '/dev/serial0', label: '/dev/serial0', pnpId: '' })
+    }
+    if (fs.existsSync('/dev/ttyAMA0') && isPi()) {
+      //Pi5 uses a different UART name. See https://forums.raspberrypi.com/viewtopic.php?t=359132
+      this.serialDevices.push({ value: '/dev/ttyAMA0', label: '/dev/ttyAMA0', pnpId: '' })
     }
     if (fs.existsSync('/dev/ttyAMA1') && isPi()) {
       this.serialDevices.push({ value: '/dev/ttyAMA1', label: '/dev/ttyAMA1', pnpId: '' })


### PR DESCRIPTION
Small fix for non-detected UART.

Video streaming API has changed again :(

From https://forums.raspberrypi.com/viewtopic.php?p=2167282&hilit=v4l2h264enc#p2167282, the Pi5 no longer has H264 hardware encoding, so we need to fallback to software encoding.

Video currently doesn't work - still need to work through gstreamer wierdness.