### PR TITLE
Deploy: Increase swap size for Raspberry Pi builds

### DIFF
--- a/deploy/RasPi2-3-4-5-deploy.sh
+++ b/deploy/RasPi2-3-4-5-deploy.sh
@@ -10,6 +10,18 @@ git submodule update --init --recursive
 sudo raspi-config nonint do_camera 0
 sudo raspi-config nonint do_ssh 0
 
+# Increase swap size to 1024MB if it is currently less than 1000MB
+# Allows the NPM build to complete successfully on systems with 500MB of RAM
+if [ $(stat -c%s "/var/swap") -le 1000000000 ]; then
+    echo "Swap file is less than 1000MB. Increasing to 1024MB."
+    sudo dphys-swapfile swapoff
+    sudo sed -i '/CONF_SWAPSIZE=.*/c\CONF_SWAPSIZE=1024' /etc/dphys-swapfile
+    sudo dphys-swapfile setup
+    sudo dphys-swapfile swapon
+else
+    echo "Swapfile is already >1000MB"
+fi
+
 ## Pi5 uses a different UART for the 40-pin header (/dev/ttyAMA0)
 # See https://forums.raspberrypi.com/viewtopic.php?t=359132
 if [ -e "/proc/device-tree/compatible" ]; then


### PR DESCRIPTION
Raspbian sets the swap size to 100MB by default, which causes the npm install step to hang the system on devices with 500MB of RAM. About 700MB of total memory is needed for the build/install process.

This commit adds a step to build_rpanion.sh to increase the swap size, which enables the installation to complete successfully.

Fixes issue #207

Edit: Sounds like this may also fix #208? 