### PR TITLE
Photo Mode Skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@
 # production
 /build
 
+# media storage
+/media
+
 # misc
 .DS_Store
 .env

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,7 +58,9 @@
         "npm-run-all": "^4.1.5",
         "pino-colada": "^2.2.2",
         "pino-http": "^10.3.0",
-        "should": "^13.2.3"
+        "should": "^13.2.3",
+        "sinon": "^19.0.2",
+        "sinon-chai": "^3.7.0"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -4023,6 +4025,45 @@
       "dependencies": {
         "@sinonjs/commons": "^1.7.0"
       }
+    },
+    "node_modules/@sinonjs/samsam": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-8.0.2.tgz",
+      "integrity": "sha512-v46t/fwnhejRSFTGqbpn9u+LQ9xJDse10gNnPgAcxgdoCDMXj/G2asWAC/8Qs+BAZDicX+MNZouXT1A7c83kVw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1",
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.1.0"
+      }
+    },
+    "node_modules/@sinonjs/samsam/node_modules/@sinonjs/commons": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
+      "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/samsam/node_modules/@sinonjs/commons/node_modules/type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@sinonjs/text-encoding": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.3.tgz",
+      "integrity": "sha512-DE427ROAphMQzU4ENbliGYrBSYPXF+TtLg9S8vzeA+OF4ZKzoDdzfL8sxuMUGS/lgRhM6j1URSk9ghf7Xo1tyA==",
+      "dev": true,
+      "license": "(Unlicense OR Apache-2.0)"
     },
     "node_modules/@socket.io/component-emitter": {
       "version": "3.1.2",
@@ -12856,6 +12897,13 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/just-extend": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-6.2.0.tgz",
+      "integrity": "sha512-cYofQu2Xpom82S6qD778jBDpwvvy39s1l/hrYij2u9AMdQcGRpaBu6kY4mVhuno5kJVi1DAz4aiphA2WI1/OAw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -13067,6 +13115,13 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
       "integrity": "sha512-uHaJFihxmJcEX3kT4I23ABqKKalJ/zDrDg0lsFtc1h+3uw49SIJ5beyhx5ExVRti3AvKoOJngIj7xz3oylPdWQ==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.memoize": {
@@ -13686,6 +13741,60 @@
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/nise": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-6.1.1.tgz",
+      "integrity": "sha512-aMSAzLVY7LyeM60gvBS423nBmIPP+Wy7St7hsb+8/fc1HmeoHJfLO8CKse4u3BtOZvQLJghYPI2i/1WZrEj5/g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1",
+        "@sinonjs/fake-timers": "^13.0.1",
+        "@sinonjs/text-encoding": "^0.7.3",
+        "just-extend": "^6.2.0",
+        "path-to-regexp": "^8.1.0"
+      }
+    },
+    "node_modules/nise/node_modules/@sinonjs/commons": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
+      "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "node_modules/nise/node_modules/@sinonjs/fake-timers": {
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-13.0.2.tgz",
+      "integrity": "sha512-4Bb+oqXZTSTZ1q27Izly9lv8B9dlV61CROxPiVtywwzv5SnytJqhvYe6FclHYuXml4cd1VHPo1zd5PmTeJozvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1"
+      }
+    },
+    "node_modules/nise/node_modules/path-to-regexp": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz",
+      "integrity": "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/nise/node_modules/type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/no-case": {
       "version": "3.0.4",
@@ -21771,6 +21880,76 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/sinon": {
+      "version": "19.0.2",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-19.0.2.tgz",
+      "integrity": "sha512-euuToqM+PjO4UgXeLETsfQiuoyPXlqFezr6YZDFwHR3t4qaX0fZUe1MfPMznTL5f8BWrVS89KduLdMUsxFCO6g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1",
+        "@sinonjs/fake-timers": "^13.0.2",
+        "@sinonjs/samsam": "^8.0.1",
+        "diff": "^7.0.0",
+        "nise": "^6.1.1",
+        "supports-color": "^7.2.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/sinon"
+      }
+    },
+    "node_modules/sinon-chai": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-3.7.0.tgz",
+      "integrity": "sha512-mf5NURdUaSdnatJx3uhoBOrY9dtL19fiOtAdT1Azxg3+lNJFiuN0uzaU3xX1LeAfL17kHQhTAJgpsfhbMJMY2g==",
+      "dev": true,
+      "license": "(BSD-2-Clause OR WTFPL)",
+      "peerDependencies": {
+        "chai": "^4.0.0",
+        "sinon": ">=4.0.0"
+      }
+    },
+    "node_modules/sinon/node_modules/@sinonjs/commons": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
+      "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "node_modules/sinon/node_modules/@sinonjs/fake-timers": {
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-13.0.2.tgz",
+      "integrity": "sha512-4Bb+oqXZTSTZ1q27Izly9lv8B9dlV61CROxPiVtywwzv5SnytJqhvYe6FclHYuXml4cd1VHPo1zd5PmTeJozvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1"
+      }
+    },
+    "node_modules/sinon/node_modules/diff": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-7.0.0.tgz",
+      "integrity": "sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/sinon/node_modules/type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/sisteransi": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,8 @@
         "coveralls": "bin/coveralls.js"
       },
       "devDependencies": {
+        "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
+        "@babel/plugin-transform-private-property-in-object": "^7.25.9",
         "@eslint/js": "^9.13.0",
         "body-parser": "^1.20.2",
         "chai": "^4.5.0",
@@ -89,12 +91,13 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.25.7.tgz",
-      "integrity": "sha512-0xZJFNE5XMpENsgfHYTw8FbX4kv53mFLn2i3XPoq69LyhYSCBJtitaHx9QnsVTrsogI4Z3+HtEfZ2/GFPOtf5g==",
+      "version": "7.26.2",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.26.2.tgz",
+      "integrity": "sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==",
       "license": "MIT",
       "dependencies": {
-        "@babel/highlight": "^7.25.7",
+        "@babel/helper-validator-identifier": "^7.25.9",
+        "js-tokens": "^4.0.0",
         "picocolors": "^1.0.0"
       },
       "engines": {
@@ -197,12 +200,13 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.25.7.tgz",
-      "integrity": "sha512-5Dqpl5fyV9pIAD62yK9P7fcA768uVPUyrQmqpqstHWgMma4feF1x/oFysBCVZLY5wJ2GkMUCdsNDnGZrPoR6rA==",
+      "version": "7.26.2",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.26.2.tgz",
+      "integrity": "sha512-zevQbhbau95nkoxSq3f/DC/SC+EEOUZd3DYqfSkMhY2/wfSeaHV1Ew4vk8e+x8lja31IbyuUa2uQ3JONqKbysw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.25.7",
+        "@babel/parser": "^7.26.2",
+        "@babel/types": "^7.26.0",
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.25",
         "jsesc": "^3.0.2"
@@ -212,12 +216,12 @@
       }
     },
     "node_modules/@babel/helper-annotate-as-pure": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.25.7.tgz",
-      "integrity": "sha512-4xwU8StnqnlIhhioZf1tqnVWeQ9pvH/ujS8hRfw/WOza+/a+1qv69BWNy+oY231maTCWgKWhfBU7kDpsds6zAA==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.25.9.tgz",
+      "integrity": "sha512-gv7320KBUFJz1RnylIg5WWYPRXKZ884AGkYpgpWW02TH66Dl+HaC1t1CKd0z3R4b6hdYEcmrNZHUmfCP+1u3/g==",
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.25.7"
+        "@babel/types": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -253,17 +257,17 @@
       }
     },
     "node_modules/@babel/helper-create-class-features-plugin": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.25.7.tgz",
-      "integrity": "sha512-bD4WQhbkx80mAyj/WCm4ZHcF4rDxkoLFO6ph8/5/mQ3z4vAzltQXAmbc7GvVJx5H+lk5Mi5EmbTeox5nMGCsbw==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.25.9.tgz",
+      "integrity": "sha512-UTZQMvt0d/rSz6KI+qdu7GQze5TIajwTS++GUozlw8VBJDEOAqSXwm1WvmYEZwqdqSGQshRocPDqrt4HBZB3fQ==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.25.7",
-        "@babel/helper-member-expression-to-functions": "^7.25.7",
-        "@babel/helper-optimise-call-expression": "^7.25.7",
-        "@babel/helper-replace-supers": "^7.25.7",
-        "@babel/helper-skip-transparent-expression-wrappers": "^7.25.7",
-        "@babel/traverse": "^7.25.7",
+        "@babel/helper-annotate-as-pure": "^7.25.9",
+        "@babel/helper-member-expression-to-functions": "^7.25.9",
+        "@babel/helper-optimise-call-expression": "^7.25.9",
+        "@babel/helper-replace-supers": "^7.25.9",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.25.9",
+        "@babel/traverse": "^7.25.9",
         "semver": "^6.3.1"
       },
       "engines": {
@@ -330,13 +334,13 @@
       "license": "MIT"
     },
     "node_modules/@babel/helper-member-expression-to-functions": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.25.7.tgz",
-      "integrity": "sha512-O31Ssjd5K6lPbTX9AAYpSKrZmLeagt9uwschJd+Ixo6QiRyfpvgtVQp8qrDR9UNFjZ8+DO34ZkdrN+BnPXemeA==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.25.9.tgz",
+      "integrity": "sha512-wbfdZ9w5vk0C0oyHqAJbc62+vet5prjj01jjJ8sKn3j9h3MQQlflEdXYvuqRWjHnM12coDEqiC1IRCi0U/EKwQ==",
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.25.7",
-        "@babel/types": "^7.25.7"
+        "@babel/traverse": "^7.25.9",
+        "@babel/types": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -374,21 +378,21 @@
       }
     },
     "node_modules/@babel/helper-optimise-call-expression": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.25.7.tgz",
-      "integrity": "sha512-VAwcwuYhv/AT+Vfr28c9y6SHzTan1ryqrydSTFGjU0uDJHw3uZ+PduI8plCLkRsDnqK2DMEDmwrOQRsK/Ykjng==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.25.9.tgz",
+      "integrity": "sha512-FIpuNaz5ow8VyrYcnXQTDRGvV6tTjkNtCK/RYNDXGSLlUD6cBuQTSw43CShGxjvfBTfcUA/r6UhUCbtYqkhcuQ==",
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.25.7"
+        "@babel/types": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.25.7.tgz",
-      "integrity": "sha512-eaPZai0PiqCi09pPs3pAFfl/zYgGaE6IdXtYvmf0qlcDTd3WCtO7JWCcRd64e0EQrcYgiHibEZnOGsSY4QSgaw==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.25.9.tgz",
+      "integrity": "sha512-kSMlyUVdWe25rEsRGviIgOWnoT/nfABVWlqt9N19/dIPWViAOW2s9wznP5tURbs/IDuNk4gPy3YdYRgH3uxhBw==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -412,14 +416,14 @@
       }
     },
     "node_modules/@babel/helper-replace-supers": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.25.7.tgz",
-      "integrity": "sha512-iy8JhqlUW9PtZkd4pHM96v6BdJ66Ba9yWSE4z0W4TvSZwLBPkyDsiIU3ENe4SmrzRBs76F7rQXTy1lYC49n6Lw==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.25.9.tgz",
+      "integrity": "sha512-IiDqTOTBQy0sWyeXyGSC5TBJpGFXBkRynjBeXsvbhQFKj2viwJC76Epz35YLU1fpe/Am6Vppb7W7zM4fPQzLsQ==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-member-expression-to-functions": "^7.25.7",
-        "@babel/helper-optimise-call-expression": "^7.25.7",
-        "@babel/traverse": "^7.25.7"
+        "@babel/helper-member-expression-to-functions": "^7.25.9",
+        "@babel/helper-optimise-call-expression": "^7.25.9",
+        "@babel/traverse": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -442,31 +446,31 @@
       }
     },
     "node_modules/@babel/helper-skip-transparent-expression-wrappers": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.25.7.tgz",
-      "integrity": "sha512-pPbNbchZBkPMD50K0p3JGcFMNLVUCuU/ABybm/PGNj4JiHrpmNyqqCphBk4i19xXtNV0JhldQJJtbSW5aUvbyA==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.25.9.tgz",
+      "integrity": "sha512-K4Du3BFa3gvyhzgPcntrkDgZzQaq6uozzcpGbOO1OEJaI+EJdqWIMTLgFgQf6lrfiDFo5FU+BxKepI9RmZqahA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.25.7",
-        "@babel/types": "^7.25.7"
+        "@babel/traverse": "^7.25.9",
+        "@babel/types": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.25.7.tgz",
-      "integrity": "sha512-CbkjYdsJNHFk8uqpEkpCvRs3YRp9tY6FmFY7wLMSYuGYkrdUi7r2lc4/wqsvlHoMznX3WJ9IP8giGPq68T/Y6g==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz",
+      "integrity": "sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.7.tgz",
-      "integrity": "sha512-AM6TzwYqGChO45oiuPqwL2t20/HdMC1rTPAesnBCgPCSF1x3oN9MVUwQV2iyz4xqWrctwK5RNC8LV22kaQCNYg==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
+      "integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -508,99 +512,13 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/highlight": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.25.7.tgz",
-      "integrity": "sha512-iYyACpW3iW8Fw+ZybQK+drQre+ns/tKpXbNESfrhNnPLIklLbXr7MYJ6gPEd0iETGLOK+SxMjVvKb/ffmk+FEw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.25.7",
-        "chalk": "^2.4.2",
-        "js-tokens": "^4.0.0",
-        "picocolors": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/chalk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-      "license": "MIT"
-    },
-    "node_modules/@babel/highlight/node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/@babel/parser": {
-      "version": "7.25.8",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.25.8.tgz",
-      "integrity": "sha512-HcttkxzdPucv3nNFmfOOMfFf64KgdJVqm1KaCm25dPGMLElo9nsLvXeJECQg8UzPuBGLyTSA0ZzqCtDSzKTEoQ==",
+      "version": "7.26.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.2.tgz",
+      "integrity": "sha512-DWMCZH9WA4Maitz2q21SRKHo9QXZxkDsbNZoVD62gusNtNBBqDg9i7uOhASfTfIGNzW+O+r7+jAlM8dwphcJKQ==",
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.25.8"
+        "@babel/types": "^7.26.0"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -792,10 +710,18 @@
       }
     },
     "node_modules/@babel/plugin-proposal-private-property-in-object": {
-      "version": "7.21.0-placeholder-for-preset-env.2",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz",
-      "integrity": "sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==",
+      "version": "7.21.11",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.11.tgz",
+      "integrity": "sha512-0QZ8qP/3RLDVBwBFoWAwCtgcDZJVwA5LUJRZU8x2YFfKNuFq161wK3cuGrALu5yiPu+vzwTAg/sMWVNeWeNyaw==",
+      "deprecated": "This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-private-property-in-object instead.",
+      "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.18.6",
+        "@babel/helper-create-class-features-plugin": "^7.21.0",
+        "@babel/helper-plugin-utils": "^7.20.2",
+        "@babel/plugin-syntax-private-property-in-object": "^7.14.5"
+      },
       "engines": {
         "node": ">=6.9.0"
       },
@@ -1683,14 +1609,14 @@
       }
     },
     "node_modules/@babel/plugin-transform-private-property-in-object": {
-      "version": "7.25.8",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-property-in-object/-/plugin-transform-private-property-in-object-7.25.8.tgz",
-      "integrity": "sha512-8Uh966svuB4V8RHHg0QJOB32QK287NBksJOByoKmHMp1TAobNniNalIkI2i5IPj5+S9NYCG4VIjbEuiSN8r+ow==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-property-in-object/-/plugin-transform-private-property-in-object-7.25.9.tgz",
+      "integrity": "sha512-Evf3kcMqzXA3xfYJmZ9Pg1OvKdtqsDMSWBDzZOPLvHiTt36E75jLDQo5w1gtRU95Q4E5PDttrTf25Fw8d/uWLw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.25.7",
-        "@babel/helper-create-class-features-plugin": "^7.25.7",
-        "@babel/helper-plugin-utils": "^7.25.7"
+        "@babel/helper-annotate-as-pure": "^7.25.9",
+        "@babel/helper-create-class-features-plugin": "^7.25.9",
+        "@babel/helper-plugin-utils": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2085,6 +2011,18 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/preset-env/node_modules/@babel/plugin-proposal-private-property-in-object": {
+      "version": "7.21.0-placeholder-for-preset-env.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz",
+      "integrity": "sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
     "node_modules/@babel/preset-modules": {
       "version": "0.1.6-no-external-plugins",
       "resolved": "https://registry.npmjs.org/@babel/preset-modules/-/preset-modules-0.1.6-no-external-plugins.tgz",
@@ -2151,30 +2089,30 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.25.7.tgz",
-      "integrity": "sha512-wRwtAgI3bAS+JGU2upWNL9lSlDcRCqD05BZ1n3X2ONLH1WilFP6O1otQjeMK/1g0pvYcXC7b/qVUB1keofjtZA==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.25.9.tgz",
+      "integrity": "sha512-9DGttpmPvIxBb/2uwpVo3dqJ+O6RooAFOS+lB+xDqoE2PVCE8nfoHMdZLpfCQRLwvohzXISPZcgxt80xLfsuwg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.25.7",
-        "@babel/parser": "^7.25.7",
-        "@babel/types": "^7.25.7"
+        "@babel/code-frame": "^7.25.9",
+        "@babel/parser": "^7.25.9",
+        "@babel/types": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.25.7.tgz",
-      "integrity": "sha512-jatJPT1Zjqvh/1FyJs6qAHL+Dzb7sTb+xr7Q+gM1b+1oBsMsQQ4FkVKb6dFlJvLlVssqkRzV05Jzervt9yhnzg==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.25.9.tgz",
+      "integrity": "sha512-ZCuvfwOwlz/bawvAuvcj8rrithP2/N55Tzz342AkTvq4qaWbGfmCk/tKhNaV2cthijKrPAA8SRJV5WWe7IBMJw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.25.7",
-        "@babel/generator": "^7.25.7",
-        "@babel/parser": "^7.25.7",
-        "@babel/template": "^7.25.7",
-        "@babel/types": "^7.25.7",
+        "@babel/code-frame": "^7.25.9",
+        "@babel/generator": "^7.25.9",
+        "@babel/parser": "^7.25.9",
+        "@babel/template": "^7.25.9",
+        "@babel/types": "^7.25.9",
         "debug": "^4.3.1",
         "globals": "^11.1.0"
       },
@@ -2215,14 +2153,13 @@
       "license": "MIT"
     },
     "node_modules/@babel/types": {
-      "version": "7.25.8",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.8.tgz",
-      "integrity": "sha512-JWtuCu8VQsMladxVz/P4HzHUGCAwpuqacmowgXFs5XjxIgKuNjnLokQzuVjlTvIzODaDmpjT3oxcC48vyk9EWg==",
+      "version": "7.26.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.0.tgz",
+      "integrity": "sha512-Z/yiTPj+lDVnF7lWeKCIJzaIkI0vYO87dMpZ4bg4TDrFe4XXLFWL1TbXU27gBP3QccxV9mZICCrnjnYlJjXHOA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.25.7",
-        "@babel/helper-validator-identifier": "^7.25.7",
-        "to-fast-properties": "^2.0.0"
+        "@babel/helper-string-parser": "^7.25.9",
+        "@babel/helper-validator-identifier": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -23588,15 +23525,6 @@
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
       "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
       "license": "BSD-3-Clause"
-    },
-    "node_modules/to-fast-properties": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,9 @@
     "npm-run-all": "^4.1.5",
     "pino-colada": "^2.2.2",
     "pino-http": "^10.3.0",
-    "should": "^13.2.3"
+    "should": "^13.2.3",
+    "sinon": "^19.0.2",
+    "sinon-chai": "^3.7.0"
   },
   "nyc": {
     "all": true,

--- a/package.json
+++ b/package.json
@@ -58,6 +58,8 @@
     "not op_mini all"
   ],
   "devDependencies": {
+    "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
+    "@babel/plugin-transform-private-property-in-object": "^7.25.9",
     "@eslint/js": "^9.13.0",
     "body-parser": "^1.20.2",
     "chai": "^4.5.0",

--- a/python/photomode.py
+++ b/python/photomode.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 vi:ts=4:noexpandtab
+
+from picamera2 import Picamera2
+from picamera2.encoders import H264Encoder
+
+import argparse
+import time, signal, os
+
+from gi.repository import GLib
+
+# Reset the signal flag
+GOT_SIGNAL = False
+# Get the PID (for testing/troubleshooting)
+pid = os.getpid()
+print("PID is : ", pid)
+
+def receive_signal(signum, stack):
+    global GOT_SIGNAL
+    GOT_SIGNAL = True
+
+# Register the signal handler function to fire when signals are received
+signal.signal(signal.SIGUSR1, receive_signal)
+
+# Reset the video recording flag
+VIDEO_ACTIVE = False
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description="Camera control server using libcamera")
+    parser.add_argument("-d", "--destination", dest="mediaPath",
+                        help="Save captured image to PATH. Default: ../media/",
+                        metavar="PATH",
+                        default="../media/"
+                        )
+    parser.add_argument("-m", "--mode", choices=['photo', 'video'],
+                        dest="captureMode",
+                        help="Capture mode options: photo [default], video", metavar="MODE",
+                        default='photo'
+                        )
+    parser.add_argument("-b", "--bitrate", metavar = "N",
+                        type = int, dest="vidBitrate",
+                        help="Video bitrate in bits per second. Default: 10000000",
+                        default=10000000
+                        )
+    args = parser.parse_args()
+
+captureMode = args.captureMode
+print("Mode is: ", captureMode)
+
+mediaPath = args.mediaPath
+print("Media storage directory is:", mediaPath)
+
+if captureMode == "video":
+    vidBitrate = args.vidBitrate
+    print("Video Bitrate is: ", vidBitrate, " (", vidBitrate / 1000000, " MBps)", sep = "")
+
+
+# Initialize the camera
+if captureMode == "photo":
+    # Initialize the camera
+    picam2_still = Picamera2()
+    # By default, use the full resolution of the sensor
+    config = picam2_still.create_still_configuration(
+        main={"size": picam2_still.sensor_resolution},
+        buffer_count=2
+    )
+    picam2_still.configure(config)
+    # Keep the camera active to make responses faster
+    picam2_still.start()
+    print("Waiting 2 seconds for camera to stabilize...")
+    time.sleep(2)
+    print("Camera is ready")
+
+elif captureMode == "video":
+    picam2_vid = Picamera2()
+    video_config = picam2_vid.create_video_configuration()
+    picam2_vid.configure(video_config)
+
+    encoder = H264Encoder(bitrate = vidBitrate)
+
+def startstop_video():
+    global VIDEO_ACTIVE
+
+    if VIDEO_ACTIVE:
+        picam2_vid.stop_recording()
+        VIDEO_ACTIVE = False
+        print ("Video recording stopped.")
+    else:
+        filename = time.strftime("RPN%Y%m%d_%H%M%S.h264")
+        filepath = os.path.join(mediaPath, filename)
+        print("Recording to ", filepath)
+
+        VIDEO_ACTIVE = True
+        output_video = picam2_vid.start_recording(encoder, filepath)
+
+try:
+    # Wait for a signal to arrive
+    while True:
+        if (GOT_SIGNAL and (captureMode == "photo")):
+            GOT_SIGNAL = False
+            print("Received signal.SIGUSR1. Capturing photo.")
+            filename = time.strftime("/home/pi/Rpanion-server/media/RPN%Y%m%d_%H%M%S.jpg")
+            print(filename)
+            output_orig = picam2_still.capture_file(filename)
+        elif (GOT_SIGNAL and (captureMode == "video")):
+            GOT_SIGNAL = False
+            print("Received signal.SIGUSR1.")
+            startstop_video()
+
+        # Wait for a signal
+        signal.pause()
+        #loop.run()
+except:
+    print("Exiting Photo/Video Server")

--- a/server/videostream.js
+++ b/server/videostream.js
@@ -12,6 +12,7 @@ class videoStream {
     this.devices = null
     this.settings = settings
     this.savedDevice = null
+    this.photoSeq = 0
 
     this.winston = winston
 
@@ -34,7 +35,8 @@ class videoStream {
           this.startStopStreaming(true, this.savedDevice.device, this.savedDevice.height,
             this.savedDevice.width, this.savedDevice.format,
             this.savedDevice.rotation, this.savedDevice.bitrate, this.savedDevice.fps, this.savedDevice.useUDP,
-            this.savedDevice.useUDPIP, this.savedDevice.useUDPPort, this.savedDevice.useTimestamp, this.savedDevice.useCameraHeartbeat, this.savedDevice.mavStreamSelected,
+            this.savedDevice.useUDPIP, this.savedDevice.useUDPPort, this.savedDevice.useTimestamp, this.savedDevice.usePhotoMode,
+            this.savedDevice.useCameraHeartbeat, this.savedDevice.mavStreamSelected,
             (err) => {
               if (err) {
                 // failed setup, reset settings
@@ -42,6 +44,7 @@ class videoStream {
                 this.resetVideo()
               }
             })
+          this.winston.info('Media path is: ', this.savedDevice.mediaPath)
         } else {
           // failed setup, reset settings
           console.log('Reset video3')
@@ -65,7 +68,8 @@ class videoStream {
   // video streaming
   getVideoDevices (callback) {
     // get all video device details
-    // callback is: err, devices, active, seldevice, selRes, selRot, selbitrate, selfps, SeluseUDP, SeluseUDPIP, SeluseUDPPort, timestamp, fps, FPSMax, vidres, cameraHeartbeat, selMavURI
+    // callback is: err, devices, active, seldevice, selRes, selRot, selbitrate, selfps, SeluseUDP, SelusePhotoMode, SeluseUDPIP,
+    // SeluseUDPPort, timestamp, fps, FPSMax, vidres, cameraHeartbeat, mavControl, selMavURI, selMediaPath
     exec('python3 ./python/gstcaps.py', (error, stdout, stderr) => {
       const warnstrings = ['DeprecationWarning', 'gst_element_message_full_with_details', 'camera_manager.cpp', 'Unsupported V4L2 pixel format']
       if (stderr && !warnstrings.some(wrn => stderr.includes(wrn))) {
@@ -82,9 +86,9 @@ class videoStream {
         // and return current settings
         if (!this.active) {
           return callback(null, this.devices, this.active, this.devices[0], this.devices[0].caps[0],
-            { label: '0°', value: 0 }, 1100, fpsSelected, false, '127.0.0.1', 5400, false,
+            { label: '0°', value: 0 }, 1100, fpsSelected, false, false, '127.0.0.1', 5400, false,
             (this.devices[0].caps[0].fps !== undefined) ? this.devices[0].caps[0].fps : [],
-            this.devices[0].caps[0].fpsmax, this.devices[0].caps, false, { label: '127.0.0.1', value: 0 })
+            this.devices[0].caps[0].fpsmax, this.devices[0].caps, false, false, { label: '127.0.0.1', value: 0 }, '/home/pi/Rpanion-server/media/')
         } else {
           // format saved settings
           const seldevice = this.devices.filter(it => it.value === this.savedDevice.device)
@@ -94,9 +98,9 @@ class videoStream {
             this.winston.error('Bad video settings. Resetting ', { message: this.savedDevice })
             this.resetVideo()
             return callback(null, this.devices, this.active, this.devices[0], this.devices[0].caps[0],
-              { label: '0°', value: 0 }, 1100, fpsSelected, false, '127.0.0.1', 5400, false,
+              { label: '0°', value: 0 }, 1100, fpsSelected, false, false, '127.0.0.1', 5400, false,
               (this.devices[0].caps[0].fps !== undefined) ? this.devices[0].caps[0].fps : [],
-              this.devices[0].caps[0].fpsmax, this.devices[0].caps, false, { label: '127.0.0.1', value: 0 })
+              this.devices[0].caps[0].fpsmax, this.devices[0].caps, false, false, { label: '127.0.0.1', value: 0 }, '/home/pi/Rpanion-server/media/')
           }
           const selRes = seldevice[0].caps.filter(it => it.value === this.savedDevice.width.toString() + 'x' + this.savedDevice.height.toString() + 'x' + this.savedDevice.format.toString().split('/')[1])
           let selFPS = this.savedDevice.fps
@@ -108,18 +112,22 @@ class videoStream {
             console.log(seldevice[0])
             return callback(null, this.devices, this.active, seldevice[0], selRes[0],
               { label: this.savedDevice.rotation.toString() + '°', value: this.savedDevice.rotation },
-              this.savedDevice.bitrate, selFPS, this.savedDevice.useUDP, this.savedDevice.useUDPIP,
+              this.savedDevice.bitrate, selFPS, this.savedDevice.useUDP, this.savedDevice.usePhotoMode, this.savedDevice.useUDPIP,
               this.savedDevice.useUDPPort, this.savedDevice.useTimestamp, (selRes[0].fps !== undefined) ? selRes[0].fps : [],
-              selRes[0].fpsmax, seldevice[0].caps, this.savedDevice.useCameraHeartbeat, { label: this.savedDevice.mavStreamSelected.toString(), value: this.savedDevice.mavStreamSelected })
+              selRes[0].fpsmax, seldevice[0].caps, this.savedDevice.useCameraHeartbeat, this.savedDevice.useMavControl,
+              { label: this.savedDevice.mavStreamSelected.toString(), value: this.savedDevice.mavStreamSelected },
+              this.savedDevice.mediaPath
+            )
           } else {
             // bad settings
             console.error('Bad video settings. Resetting' + seldevice + ', ' + selRes)
             this.winston.error('Bad video settings. Resetting ', { message: JSON.stringify(this.savedDevice) })
             this.resetVideo()
             return callback(null, this.devices, this.active, this.devices[0], this.devices[0].caps[0],
-              { label: '0°', value: 0 }, 1100, fpsSelected, false, '127.0.0.1', 5400, false,
+              { label: '0°', value: 0 }, 1100, fpsSelected, false, false, '127.0.0.1', 5400, false,
               (this.devices[0].caps[0].fps !== undefined) ? this.devices[0].caps[0].fps : [],
-              this.devices[0].caps[0].fpsmax, this.devices[0].caps, false, { label: '127.0.0.1', value: 0 })
+              this.devices[0].caps[0].fpsmax, this.devices[0].caps, false, false, { label: '127.0.0.1', value: 0 },
+              '/home/pi/Rpanion-server/media/')
           }
         }
       }
@@ -164,7 +172,7 @@ class videoStream {
     return iface
   }
 
-  async startStopStreaming (active, device, height, width, format, rotation, bitrate, fps, useUDP, useUDPIP, useUDPPort, useTimestamp, useCameraHeartbeat, mavStreamSelected, callback) {
+  async startStopStreaming (active, device, height, width, format, rotation, bitrate, fps, useUDP, usePhotoMode, useUDPIP, useUDPPort, useTimestamp, useCameraHeartbeat, useMavControl, mavStreamSelected, mediaPath, callback) {
     // if current state same, don't do anything
     if (this.active === active) {
       console.log('Video current same')
@@ -201,77 +209,88 @@ class videoStream {
         fps,
         rotation,
         useUDP,
+        usePhotoMode,
         useUDPIP,
         useUDPPort,
         useTimestamp,
         useCameraHeartbeat,
-        mavStreamSelected
+        useMavControl,
+        mavStreamSelected,
+        mediaPath
       }
 
-      // note that video device URL's are the alphanumeric characters only. So /dev/video0 -> devvideo0
-      this.populateAddresses(device.replace(/\W/g, ''))
+      this.winston.info('from startStopStreamning(), media path is: ', this.savedDevice.mediaPath)
 
-      // rpi camera has different name under Ubuntu
-      if (await this.isUbuntu() && device === 'rpicam') {
-        device = '/dev/video0'
-        format = 'video/x-raw'
-      }
+      // Don't start a video stream if we are in photo mode
+      if (this.savedDevice.usePhotoMode) {
+        console.log('Started photo mode')
+      } else {
+        // note that video device URL's are the alphanumeric characters only. So /dev/video0 -> devvideo0
+        this.populateAddresses(device.replace(/\W/g, ''))
 
-      const args = ['./python/rtsp-server.py',
-        '--video=' + device,
-        '--height=' + height,
-        '--width=' + width,
-        '--format=' + format,
-        '--bitrate=' + bitrate,
-        '--rotation=' + rotation,
-        '--fps=' + fps,
-        '--udp=' + ((useUDP === false) ? '0' : useUDPIP + ':' + useUDPPort.toString())
-      ]
-
-      if (useTimestamp) {
-        args.push('--timestamp')
-      }
-
-      this.deviceStream = spawn('python3', args)
-
-      try {
-        if (this.deviceStream === null) {
-          this.settings.setValue('videostream.active', false)
-          console.log('Error spawning rtsp-server.py')
-          this.winston.info('Error spawning rtsp-server.py')
-          return callback(null, this.active, this.deviceAddresses)
+        // rpi camera has different name under Ubuntu
+        if (await this.isUbuntu() && device === 'rpicam') {
+          device = '/dev/video0'
+          format = 'video/x-raw'
         }
-        this.settings.setValue('videostream.active', this.active)
-        this.settings.setValue('videostream.savedDevice', this.savedDevice)
-      } catch (e) {
-        console.log(e)
-        this.winston.info(e)
+
+        const args = ['./python/rtsp-server.py',
+          '--video=' + device,
+          '--height=' + height,
+          '--width=' + width,
+          '--format=' + format,
+          '--bitrate=' + bitrate,
+          '--rotation=' + rotation,
+          '--fps=' + fps,
+          '--udp=' + ((useUDP === false) ? '0' : useUDPIP + ':' + useUDPPort.toString())
+        ]
+
+        if (useTimestamp) {
+          args.push('--timestamp')
+        }
+
+        this.deviceStream = spawn('python3', args)
+
+        try {
+          if (this.deviceStream === null) {
+            this.settings.setValue('videostream.active', false)
+            console.log('Error spawning rtsp-server.py')
+            this.winston.info('Error spawning rtsp-server.py')
+            return callback(null, this.active, this.deviceAddresses)
+          }
+          this.settings.setValue('videostream.active', this.active)
+          this.settings.setValue('videostream.savedDevice', this.savedDevice)
+        } catch (e) {
+          console.log(e)
+          this.winston.info(e)
+        }
+
+        this.deviceStream.stdout.on('data', (data) => {
+          this.winston.info('startStopStreaming() data ' + data)
+          console.log(`GST stdout: ${data}`)
+        })
+
+        this.deviceStream.stderr.on('data', (data) => {
+          this.winston.error('startStopStreaming() err ', { message: data })
+          console.error(`GST stderr: ${data}`)
+        })
+
+        this.deviceStream.on('close', (code) => {
+          console.log(`GST process exited with code ${code}`)
+          this.winston.info('startStopStreaming() close ' + code)
+          this.deviceStream.stdin.pause()
+          this.deviceStream.kill()
+          this.resetVideo()
+        })
+
+        console.log('Started Video Streaming of ' + device)
+        this.winston.info('Started Video Streaming of ' + device)
       }
 
-      this.deviceStream.stdout.on('data', (data) => {
-        this.winston.info('startStopStreaming() data ' + data)
-        console.log(`GST stdout: ${data}`)
-      })
-
-      this.deviceStream.stderr.on('data', (data) => {
-        this.winston.error('startStopStreaming() err ', { message: data })
-        console.error(`GST stderr: ${data}`)
-      })
-
-      this.deviceStream.on('close', (code) => {
-        console.log(`GST process exited with code ${code}`)
-        this.winston.info('startStopStreaming() close ' + code)
-        this.deviceStream.stdin.pause()
-        this.deviceStream.kill()
-        this.resetVideo()
-      })
-
+      // If enabled, start the camera heartbeat in either photo or video mode
       if (this.savedDevice.useCameraHeartbeat) {
         this.startInterval()
       }
-
-      console.log('Started Video Streaming of ' + device)
-      this.winston.info('Started Video Streaming of ' + device)
 
       return callback(null, this.active, this.deviceAddresses)
     } else {
@@ -281,9 +300,15 @@ class videoStream {
       if (this.savedDevice.useCameraHeartbeat) {
         clearInterval(this.intervalObj)
       }
-      this.deviceStream.stdin.pause()
-      this.deviceStream.kill()
-      this.resetVideo()
+
+      if (this.savedDevice.usePhotoMode) {
+        console.log('Stopped photo mode')
+        this.resetVideo()
+      } else {
+        this.deviceStream.stdin.pause()
+        this.deviceStream.kill()
+        this.resetVideo()
+      }
     }
     return callback(null, this.active, this.deviceAddresses)
   }
@@ -313,88 +338,327 @@ class videoStream {
     }, 1000)
   }
 
+  async startStopStreaming (active, device, height, width, format, rotation, bitrate, fps, useUDP, usePhotoMode, useUDPIP, useUDPPort, useTimestamp, useCameraHeartbeat, useMavControl, mavStreamSelected, mediaPath, callback) {
+    // if current state same, don't do anything
+    if (this.active === active) {
+      console.log('Video current same')
+      this.winston.info('Video current same')
+      return callback(null, this.active, this.deviceAddresses)
+      this.winston.info('From startstopstreaming, mediapath is: ', this.mediaPath)
+    }
+    // user wants to start or stop streaming
+    if (active) {
+      // check it's a valid video device
+      let found = false
+      if (this.devices !== null) {
+        for (let j = 0; j < this.devices.length; j++) {
+          if (device === this.devices[j].value) {
+            found = true
+          }
+        }
+        if (!found) {
+          console.log('No video device: ' + device)
+          this.winston.info('No video device: ' + device)
+          return callback(new Error('No video device: ' + device))
+        }
+      } else {
+        console.log('No video devices in list')
+        this.winston.info('No video devices in list')
+      }
+
+      this.active = true
+      this.savedDevice = {
+        device,
+        height,
+        width,
+        format,
+        bitrate,
+        fps,
+        rotation,
+        useUDP,
+        usePhotoMode,
+        useUDPIP,
+        useUDPPort,
+        useTimestamp,
+        useCameraHeartbeat,
+        useMavControl,
+        mavStreamSelected,
+        mediaPath
+      }
+
+      // If photo mode was selected, start the libcamera server
+      if (this.savedDevice.usePhotoMode) {
+        // note that video device URL's are the alphanumeric characters only. So /dev/video0 -> devvideo0
+        this.populateAddresses(device.replace(/\W/g, ''))
+
+        const args = ['./python/photomode.py']
+
+        this.deviceStream = spawn('python3', args)
+
+        try {
+          if (this.deviceStream === null) {
+            this.settings.setValue('videostream.active', false)
+            console.log('Error spawning photomode.py')
+            this.winston.info('Error spawning photomode.py')
+            return callback(null, this.active, this.deviceAddresses)
+          }
+          this.settings.setValue('videostream.active', this.active)
+          this.settings.setValue('videostream.savedDevice', this.savedDevice)
+        } catch (e) {
+          console.log(e)
+          this.winston.info(e)
+        }
+
+        this.deviceStream.stdout.on('data', (data) => {
+          this.winston.info('startStopStreaming() data ' + data)
+          console.log(`GST stdout: ${data}`)
+        })
+
+        this.deviceStream.stderr.on('data', (data) => {
+          this.winston.error('startStopStreaming() err ', { message: data })
+          console.error(`GST stderr: ${data}`)
+        })
+
+        this.deviceStream.on('close', (code) => {
+          console.log(`GST process exited with code ${code}`)
+          this.winston.info('startStopStreaming() close ' + code)
+          this.deviceStream.stdin.pause()
+          this.deviceStream.kill()
+          this.resetVideo()
+        })
+
+        console.log('Started Video Streaming of ' + device)
+        this.winston.info('Started Video Streaming of ' + device)
+      } else {
+        // note that video device URL's are the alphanumeric characters only. So /dev/video0 -> devvideo0
+        this.populateAddresses(device.replace(/\W/g, ''))
+
+        // rpi camera has different name under Ubuntu
+        if (await this.isUbuntu() && device === 'rpicam') {
+          device = '/dev/video0'
+          format = 'video/x-raw'
+        }
+
+        const args = ['./python/rtsp-server.py',
+          '--video=' + device,
+          '--height=' + height,
+          '--width=' + width,
+          '--format=' + format,
+          '--bitrate=' + bitrate,
+          '--rotation=' + rotation,
+          '--fps=' + fps,
+          '--udp=' + ((useUDP === false) ? '0' : useUDPIP + ':' + useUDPPort.toString())
+        ]
+
+        if (useTimestamp) {
+          args.push('--timestamp')
+        }
+
+        this.deviceStream = spawn('python3', args)
+
+        try {
+          if (this.deviceStream === null) {
+            this.settings.setValue('videostream.active', false)
+            console.log('Error spawning rtsp-server.py')
+            this.winston.info('Error spawning rtsp-server.py')
+            return callback(null, this.active, this.deviceAddresses)
+          }
+          this.settings.setValue('videostream.active', this.active)
+          this.settings.setValue('videostream.savedDevice', this.savedDevice)
+        } catch (e) {
+          console.log(e)
+          this.winston.info(e)
+        }
+
+        this.deviceStream.stdout.on('data', (data) => {
+          this.winston.info('startStopStreaming() data ' + data)
+          console.log(`GST stdout: ${data}`)
+        })
+
+        this.deviceStream.stderr.on('data', (data) => {
+          this.winston.error('startStopStreaming() err ', { message: data })
+          console.error(`GST stderr: ${data}`)
+        })
+
+        this.deviceStream.on('close', (code) => {
+          console.log(`GST process exited with code ${code}`)
+          this.winston.info('startStopStreaming() close ' + code)
+          this.deviceStream.stdin.pause()
+          this.deviceStream.kill()
+          this.resetVideo()
+        })
+        console.log('Started Video Streaming of ' + device)
+        this.winston.info('Started Video Streaming of ' + device)
+      }
+
+      // If enabled, start the camera heartbeat in either photo or video mode
+      if (this.savedDevice.useCameraHeartbeat) {
+        this.startInterval()
+      }
+
+      return callback(null, this.active, this.deviceAddresses)
+    } else {
+      // stop streaming
+      // if mavlink advertising is on, clear the interval
+
+      if (this.savedDevice.useCameraHeartbeat) {
+        clearInterval(this.intervalObj)
+      }
+
+      if (this.savedDevice.usePhotoMode) {
+        console.log('Stopped photo mode')
+        this.deviceStream.stdin.pause()
+        this.deviceStream.kill()
+        this.resetVideo()
+      } else {
+        this.deviceStream.stdin.pause()
+        this.deviceStream.kill()
+        this.resetVideo()
+      }
+    }
+    return callback(null, this.active, this.deviceAddresses)
+  }
+
+  captureStillPhoto () {
+    // Capture a single still photo
+    console.log('Received capturestillphoto event')
+    this.deviceStream.kill('SIGUSR1')
+
+    const senderSysId = this.targetSystem
+    const senderCompId = minimal.MavComponent.CAMERA
+
+    // build a CAMERA_TRIGGER packet
+    const msg = new common.CameraTrigger()
+
+    // Date.now() returns time in milliseconds
+    msg.timeUsec = BigInt(Date.now() * 1000)
+    msg.seq = this.photoSeq
+
+    this.photoSeq++
+
+    this.eventEmitter.emit('cameratrigger', msg, senderSysId, senderCompId)
+  }
+
+  sendCameraInformation (senderSysId, senderCompId, targetComponent) {
+    console.log('Responding to MAVLink request for CameraInformation')
+    this.winston.info('Responding to MAVLink request for CameraInformation')
+
+    // const senderSysId = packet.header.sysid
+    // const senderCompId = minimal.MavComponent.CAMERA
+    // const targetComponent = packet.header.compid
+
+    // build a CAMERA_INFORMATION packet
+    const msg = new common.CameraInformation()
+
+    // TODO: implement missing attributes here
+    msg.timeBootMs = 0
+    msg.vendorName = 0
+    msg.modelName = 0
+    msg.firmwareVersion = 0
+    msg.focalLength = null
+    msg.sensorSizeH = null
+    msg.sensorSizeV = null
+    msg.resolutionH = this.savedDevice.width
+    msg.resolutionV = this.savedDevice.height
+    msg.lensId = 0
+    // 256 = CAMERA_CAP_FLAGS_HAS_VIDEO_STREAM (hard-coded for now until Rpanion gains more camera capabilities)
+    if (this.savedDevice.usePhotoMode) {
+      // 2 = CAMERA_CAP_FLAGS_CAPTURE_IMAGE
+      msg.flags = 2
+    } else {
+      // 256 = CAMERA_CAP_FLAGS_HAS_VIDEO_STREAM
+      msg.flags = 256
+    }
+
+    msg.camDefinitionVersion = 0
+    msg.camDefinitionUri = ''
+    msg.gimbalDeviceId = 0
+    this.eventEmitter.emit('camerainfo', msg, senderSysId, senderCompId, targetComponent)
+  }
+
+  sendVideoStreamInformation (senderSysId, senderCompId, targetComponent) {
+    console.log('Responding to MAVLink request for VideoStreamInformation')
+    this.winston.info('Responding to MAVLink request for VideoStreamInformation')
+
+    // const senderSysId = packet.header.sysid
+    // const senderCompId = minimal.MavComponent.CAMERA
+    // const targetComponent = packet.header.compid
+
+    // build a VIDEO_STREAM_INFORMATION packet
+    const msg = new common.VideoStreamInformation()
+    // rpanion only supports a single stream, so streamId and count will always be 1
+    msg.streamId = 1
+    msg.count = 1
+
+    // msg.type and msg.uri need to be different depending on whether RTP or RTSP is selected
+    if (this.savedDevice.useUDP) {
+      // msg.type = 0 = VIDEO_STREAM_TYPE_RTSP
+      // msg.type = 1 = VIDEO_STREAM_TYPE_RTPUDP
+      msg.type = 1
+      // For RTP, just send the destination UDP port instead of a full URI
+      msg.uri = this.savedDevice.useUDPPort.toString()
+    } else {
+      msg.type = 0
+      msg.uri = `rtsp://${this.savedDevice.mavStreamSelected}:8554/${this.savedDevice.device}`
+    }
+
+    // 1 = VIDEO_STREAM_STATUS_FLAGS_RUNNING
+    // 2 = VIDEO_STREAM_STATUS_FLAGS_THERMAL
+    msg.flags = 1
+    msg.framerate = this.savedDevice.fps
+    msg.resolutionH = this.savedDevice.width
+    msg.resolutionV = this.savedDevice.height
+    msg.bitrate = this.savedDevice.bitrate
+    msg.rotation = this.savedDevice.rotation
+    // Rpanion doesn't collect field of view values, so just set to zero
+    msg.hfov = 0
+    msg.name = this.savedDevice.device
+
+    this.eventEmitter.emit('videostreaminfo', msg, senderSysId, senderCompId, targetComponent)
+  }
+
+  sendCameraSettings (senderSysId, senderCompId, targetComponent) {
+    console.log('Responding to MAVLink request for CameraSettings')
+    this.winston.info('Responding to MAVLink request for CameraSettings')
+    // const senderSysId = packet.header.sysid
+    // const senderCompId = minimal.MavComponent.CAMERA
+    // const targetComponent = packet.header.compid
+
+    // build a CAMERA_SETTINGS packet
+    const msg = new common.CameraSettings()
+
+    msg.timeBootMs = 0
+    // Camera modes: 0 = IMAGE, 1 = VIDEO, 2 = IMAGE_SURVEY
+    if (this.savedDevice.usePhotoMode) {
+      msg.modeId = 0
+    } else {
+      msg.modeId = 1
+    }
+    msg.zoomLevel = null
+    msg.focusLevel = null
+
+    this.eventEmitter.emit('camerasettings', msg, senderSysId, senderCompId, targetComponent)
+  }
+
   onMavPacket (packet, data) {
     // FC is active
     if (!this.active) {
       return
     }
 
-    if (data.targetComponent === minimal.MavComponent.CAMERA &&
-      packet.header.msgid === common.CommandLong.MSG_ID &&
-      data._param1 === common.CameraInformation.MSG_ID) {
-      console.log('Responding to MAVLink request for CameraInformation')
-      this.winston.info('Responding to MAVLink request for CameraInformation')
-
-      const senderSysId = packet.header.sysid
-      const senderCompId = minimal.MavComponent.CAMERA
-      const targetComponent = packet.header.compid
-
-      // build a CAMERA_INFORMATION packet
-      const msg = new common.CameraInformation()
-
-      // TODO: implement missing attributes here
-      msg.timeBootMs = 0
-      msg.vendorName = 0
-      msg.modelName = 0
-      msg.firmwareVersion = 0
-      msg.focalLength = null
-      msg.sensorSizeH = null
-      msg.sensorSizeV = null
-      msg.resolutionH = this.savedDevice.width
-      msg.resolutionV = this.savedDevice.height
-      msg.lensId = 0
-      // 256 = CAMERA_CAP_FLAGS_HAS_VIDEO_STREAM (hard-coded for now until Rpanion gains more camera capabilities)
-      msg.flags = 256
-      msg.camDefinitionVersion = 0
-      msg.camDefinitionUri = ''
-      msg.gimbalDeviceId = 0
-      this.eventEmitter.emit('camerainfo', msg, senderSysId, senderCompId, targetComponent)
-
-    } else if (data.targetComponent === minimal.MavComponent.CAMERA &&
-      packet.header.msgid === common.CommandLong.MSG_ID &&
-      data._param1 === common.VideoStreamInformation.MSG_ID) {
-
-      console.log('Responding to MAVLink request for VideoStreamInformation')
-      this.winston.info('Responding to MAVLink request for VideoStreamInformation')
-
-      const senderSysId = packet.header.sysid
-      const senderCompId = minimal.MavComponent.CAMERA
-      const targetComponent = packet.header.compid
-
-      // build a VIDEO_STREAM_INFORMATION packet
-      const msg = new common.VideoStreamInformation()
-
-      // rpanion only supports a single stream, so streamId and count will always be 1
-      msg.streamId = 1
-      msg.count = 1
-
-      // msg.type and msg.uri need to be different depending on whether RTP or RTSP is selected
-      if (this.savedDevice.useUDP) {
-        // msg.type = 0 = VIDEO_STREAM_TYPE_RTSP
-        // msg.type = 1 = VIDEO_STREAM_TYPE_RTPUDP
-        msg.type = 1
-        // For RTP, just send the destination UDP port instead of a full URI
-        msg.uri = this.savedDevice.useUDPPort.toString()
-      } else {
-        msg.type = 0
-        msg.uri = `rtsp://${this.savedDevice.mavStreamSelected}:8554/${this.savedDevice.device}`
+    if (data.targetComponent === minimal.MavComponent.CAMERA && packet.header.msgid === common.CommandLong.MSG_ID) {
+      if (data._param1 === common.CameraInformation.MSG_ID) {
+        this.sendCameraInformation(packet.header.sysid, minimal.MavComponent.CAMERA, packet.header.compid)
+      } else if (data._param1 === common.VideoStreamInformation.MSG_ID && !this.savedDevice.usePhotoMode) {
+        this.sendVideoStreamInformation(packet.header.sysid, minimal.MavComponent.CAMERA, packet.header.compid)
+      } else if (data._param1 === common.CameraSettings.MSG_ID) {
+        this.sendCameraSettings(packet.header.sysid, minimal.MavComponent.CAMERA, packet.header.compid)
+      // 203 = MAV_CMD_DO_DIGICAM_CONTROL
+      } else if (data.command === 203) {
+        console.log('Received DoDigicamControl command')
+        this.captureStillPhoto(packet)
       }
-
-      // 1 = VIDEO_STREAM_STATUS_FLAGS_RUNNING
-      // 2 = VIDEO_STREAM_STATUS_FLAGS_THERMAL
-      msg.flags = 1
-      msg.framerate = this.savedDevice.fps
-      msg.resolutionH = this.savedDevice.width
-      msg.resolutionV = this.savedDevice.height
-      msg.bitrate = this.savedDevice.bitrate
-      msg.rotation = this.savedDevice.rotation
-      // Rpanion doesn't collect field of view values, so just set to zero
-      msg.hfov = 0
-      msg.name = this.savedDevice.device
-
-      this.eventEmitter.emit('videostreaminfo', msg, senderSysId, senderCompId, targetComponent)
     }
   }
 }
-
 module.exports = videoStream

--- a/server/videostream.test.js
+++ b/server/videostream.test.js
@@ -3,6 +3,12 @@ const settings = require('settings-store')
 const VideoStream = require('./videostream')
 const winston = require('./winstonconfig')(module)
 
+const chai = require('chai')
+const sinon = require('sinon')
+const { expect } = chai
+chai.use(require('sinon-chai'))
+const { minimal, common } = require('node-mavlink')
+
 describe('Video Functions', function () {
   it('#videomanagerinit()', function () {
     settings.clear()
@@ -31,7 +37,9 @@ describe('Video Functions', function () {
     const vManager = new VideoStream(settings, winston)
 
     vManager.populateAddresses()
-    vManager.getVideoDevices(function (err, devices, active, seldevice, selRes, selRot, selbitrate, selfps, SeluseUDP, SeluseUDPIP, SeluseUDPPort, timestamp, fps, FPSMax, vidres, selMavURI) {
+    vManager.getVideoDevices(function (err, devices, active, seldevice, selRes, selRot, selbitrate, selfps,
+      SeluseUDP, SelusePhotoMode, SeluseUDPIP, SeluseUDPPort, timestamp, fps, FPSMax, vidres,
+      useCameraHeartbeat, useMavControl, selMavURI, selMediaPath) {
       assert.equal(err, null)
       assert.equal(active, false)
       assert.notEqual(seldevice, null)
@@ -40,13 +48,17 @@ describe('Video Functions', function () {
       assert.notEqual(selbitrate, null)
       assert.notEqual(selfps, null)
       assert.equal(SeluseUDP, false)
+      assert.equal(SelusePhotoMode, false)
       assert.equal(SeluseUDPIP, '127.0.0.1')
       assert.equal(SeluseUDPPort, 5400)
       assert.equal(timestamp, false)
       assert.notEqual(fps, null)
       assert.notEqual(FPSMax, null)
       assert.notEqual(vidres, null)
+      assert.equal(useCameraHeartbeat, false)
+      assert.equal(useMavControl, false)
       assert.notEqual(selMavURI, null)
+      assert.equal(selMediaPath, '/home/pi/Rpanion-server/media/')
       done()
     })
   }).timeout(5000)
@@ -72,6 +84,343 @@ describe('Video Functions', function () {
         assert.equal(status, false)
         done()
       })
+    })
+  })
+
+  describe('#videomanagerstartInterval()', () => {
+    let vManager
+    let setIntervalStub
+    let emitStub
+
+    beforeEach(() => {
+      vManager = new VideoStream(settings, winston)
+      setIntervalStub = sinon.stub(global, 'setInterval')
+      emitStub = sinon.stub(vManager.eventEmitter, 'emit')
+    })
+
+    afterEach(() => {
+      sinon.restore()
+    })
+
+    it('should start an interval and emit a "cameraheartbeat" event', () => {
+      const intervalId = 12345
+      setIntervalStub.returns(intervalId)
+
+      vManager.startInterval()
+
+      // Simulate the interval execution
+      const mavType = minimal.MavType.CAMERA
+      const autopilot = minimal.MavAutopilot.INVALID
+      const component = minimal.MavComponent.CAMERA
+
+      // Call the interval function manually
+      const intervalFunction = setIntervalStub.firstCall.args[0] // Get the first argument (the callback)
+      intervalFunction() // Manually invoke the callback
+
+      expect(vManager.intervalObj).to.equal(intervalId)
+      expect(emitStub).to.have.been.calledWith('cameraheartbeat', mavType, autopilot, component)
+    })
+  })
+
+  describe('#videomanagercaptureStillPhoto()', () => {
+    let vManager
+    let emitStub
+
+    beforeEach(() => {
+      vManager = new VideoStream(settings, winston)
+      // Mocking deviceStream with a kill method
+      vManager.deviceStream = {
+        kill: sinon.stub()
+      }
+      sinon.stub(Date, 'now').returns(1729137498022000) // Stub to return a fixed timestamp
+      emitStub = sinon.stub(vManager.eventEmitter, 'emit')
+    })
+
+    afterEach(() => {
+      sinon.restore()
+    })
+
+    it('should emit a "cameratrigger" event', () => {
+      // build a CAMERA_TRIGGER packet
+      const expectedMsg = new common.CameraTrigger()
+      expectedMsg.timeUsec = BigInt(Date.now() * 1000)
+      expectedMsg.seq = 0
+
+      vManager.captureStillPhoto() // Call the method under test
+
+      expect(emitStub).to.have.been.calledWith('cameratrigger', expectedMsg)
+    })
+  })
+
+  describe('#videomanagersendCameraInformation()', () => {
+    let vManager
+    let emitStub
+
+    beforeEach(() => {
+      vManager = new VideoStream(settings, winston)
+      emitStub = sinon.stub(vManager.eventEmitter, 'emit')
+
+      vManager.savedDevice = {
+        width: 1920,
+        height: 1080,
+        usePhotoMode: true
+      }
+    })
+
+    afterEach(() => {
+      sinon.restore()
+    })
+
+    it('should emit a "camerainfo" event', () => {
+      // build a CAMERA_INFORMATION packet
+      const expectedMsg = new common.CameraInformation()
+
+      expectedMsg.timeBootMs = 0
+      expectedMsg.vendorName = 0
+      expectedMsg.modelName = 0
+      expectedMsg.firmwareVersion = 0
+      expectedMsg.focalLength = null
+      expectedMsg.sensorSizeH = null
+      expectedMsg.sensorSizeV = null
+      expectedMsg.resolutionH = vManager.savedDevice.width
+      expectedMsg.resolutionV = vManager.savedDevice.height
+      expectedMsg.lensId = 0
+      // 256 = CAMERA_CAP_FLAGS_HAS_VIDEO_STREAM (hard-coded for now until Rpanion gains more camera capabilities)
+      if (vManager.savedDevice.usePhotoMode) {
+        // 2 = CAMERA_CAP_FLAGS_CAPTURE_IMAGE
+        expectedMsg.flags = 2
+      } else {
+        // 256 = CAMERA_CAP_FLAGS_HAS_VIDEO_STREAM
+        expectedMsg.flags = 256
+      }
+
+      expectedMsg.camDefinitionVersion = 0
+      expectedMsg.camDefinitionUri = ''
+      expectedMsg.gimbalDeviceId = 0
+
+      const senderSysId = 1
+      const senderCompId = minimal.MavComponent.CAMERA
+      const targetComponent = 1
+
+      vManager.sendCameraInformation(senderSysId, senderCompId, targetComponent) // Call the method under test
+      expect(emitStub).to.have.been.calledWith('camerainfo', expectedMsg, senderSysId, senderCompId, targetComponent)
+
+      // Test again with usePhotoMode = false
+      vManager.savedDevice.usePhotoMode = false
+      vManager.sendCameraInformation(senderSysId, senderCompId, targetComponent) // Call the method under test
+      expect(emitStub).to.have.been.calledWith('camerainfo', expectedMsg, senderSysId, senderCompId, targetComponent)
+    })
+  })
+
+  describe('#videomanagersendVideoStreamInformation()', () => {
+    let vManager
+    let emitStub
+
+    beforeEach(() => {
+      vManager = new VideoStream(settings, winston)
+      emitStub = sinon.stub(vManager.eventEmitter, 'emit')
+
+      vManager.savedDevice = {
+        useUDP: true,
+        useUDPPort: 9000,
+        mavStreamSelected: 'localhost',
+        device: 'camera1',
+        fps: 30,
+        width: 1920,
+        height: 1080,
+        bitrate: 6000,
+        rotation: 0
+      }
+    })
+
+    afterEach(() => {
+      sinon.restore()
+    })
+
+    it('should emit a "videostreaminfo" event', () => {
+      // build a VIDEO_STREAM_INFORMATION packet
+      const expectedMsg = new common.VideoStreamInformation()
+
+      expectedMsg.streamId = 1
+      expectedMsg.count = 1
+      // expectedMsg.type and expectedMsg.uri need to be different depending on whether RTP or RTSP is selected
+      if (vManager.savedDevice.useUDP) {
+        // expectedMsg.type = 0 = VIDEO_STREAM_TYPE_RTSP
+        // expectedMsg.type = 1 = VIDEO_STREAM_TYPE_RTPUDP
+        expectedMsg.type = 1
+        // For RTP, just send the destination UDP port instead of a full URI
+        expectedMsg.uri = vManager.savedDevice.useUDPPort.toString()
+      } else {
+        expectedMsg.type = 0
+        expect.uri = `rtsp://${vManager.savedDevice.mavStreamSelected}:8554/${vManager.savedDevice.device}`
+      }
+
+      // 1 = VIDEO_STREAM_STATUS_FLAGS_RUNNING
+      // 2 = VIDEO_STREAM_STATUS_FLAGS_THERMAL
+      expectedMsg.flags = 1
+      expectedMsg.framerate = vManager.savedDevice.fps
+      expectedMsg.resolutionH = vManager.savedDevice.width
+      expectedMsg.resolutionV = vManager.savedDevice.height
+      expectedMsg.bitrate = vManager.savedDevice.bitrate
+      expectedMsg.rotation = vManager.savedDevice.rotation
+      // Rpanion doesn't collect field of view values, so just set to zero
+      expectedMsg.hfov = 0
+      expectedMsg.name = vManager.savedDevice.device
+
+      const senderSysId = 1
+      const senderCompId = minimal.MavComponent.CAMERA
+      const targetComponent = 1
+
+      vManager.sendVideoStreamInformation(senderSysId, senderCompId, targetComponent) // Call the method under test
+      expect(emitStub).to.have.been.calledWith('videostreaminfo', expectedMsg, senderSysId, senderCompId, targetComponent)
+
+      // Test again with useUDP = false
+      vManager.savedDevice.useUDP = false
+      vManager.sendVideoStreamInformation(senderSysId, senderCompId, targetComponent) // Call the method under test
+      expect(emitStub).to.have.been.calledWith('videostreaminfo', expectedMsg, senderSysId, senderCompId, targetComponent)
+    })
+  })
+
+  describe('#videomanagersendCameraSettings()', () => {
+    let vManager
+    let emitStub
+
+    beforeEach(() => {
+      vManager = new VideoStream(settings, winston)
+      emitStub = sinon.stub(vManager.eventEmitter, 'emit')
+
+      vManager.savedDevice = {
+        usePhotoMode: true
+      }
+    })
+
+    afterEach(() => {
+      sinon.restore()
+    })
+
+    it('should emit a "camerasettings" event', () => {
+      // build a CAMERA_SETTINGS packet
+      const expectedMsg = new common.CameraSettings()
+      expectedMsg.timeBootMs = 0
+      // Camera modes: 0 = IMAGE, 1 = VIDEO, 2 = IMAGE_SURVEY
+      if (vManager.savedDevice.usePhotoMode) {
+        expectedMsg.modeId = 0
+      } else {
+        expectedMsg.modeId = 1
+      }
+      expectedMsg.zoomLevel = null
+      expectedMsg.focusLevel = null
+
+      const senderSysId = 1
+      const senderCompId = minimal.MavComponent.CAMERA
+      const targetComponent = 1
+
+      vManager.sendCameraSettings(senderSysId, senderCompId, targetComponent) // Call the method under test
+      expect(emitStub).to.have.been.calledWith('camerasettings', expectedMsg, senderSysId, senderCompId, targetComponent)
+
+      // Test again with usePhotoMode = false
+      vManager.savedDevice.usePhotoMode = false
+      vManager.sendCameraSettings(senderSysId, senderCompId, targetComponent) // Call the method under test
+      expect(emitStub).to.have.been.calledWith('camerasettings', expectedMsg, senderSysId, senderCompId, targetComponent)
+    })
+  })
+
+  describe('#videomanageronMavPacket', function () {
+    let instance
+    let packet
+    let data
+
+    beforeEach(function () {
+      instance = {
+        active: true,
+        savedDevice: {
+          usePhotoMode: false
+        },
+        sendCameraInformation: sinon.spy(),
+        sendVideoStreamInformation: sinon.spy(),
+        sendCameraSettings: sinon.spy(),
+        captureStillPhoto: sinon.spy(),
+
+        // Define the onMavPacket function within the instance
+        onMavPacket: function (packet, data) {
+          if (!this.active) {
+            return
+          }
+
+          if (data.targetComponent === minimal.MavComponent.CAMERA && packet.header.msgid === common.CommandLong.MSG_ID) {
+            if (data._param1 === common.CameraInformation.MSG_ID) {
+              this.sendCameraInformation(packet.header.sysid, minimal.MavComponent.CAMERA, packet.header.compid)
+            } else if (data._param1 === common.VideoStreamInformation.MSG_ID && !this.savedDevice.usePhotoMode) {
+              this.sendVideoStreamInformation(packet.header.sysid, minimal.MavComponent.CAMERA, packet.header.compid)
+            } else if (data._param1 === common.CameraSettings.MSG_ID) {
+              this.sendCameraSettings(packet.header.sysid, minimal.MavComponent.CAMERA, packet.header.compid)
+            } else if (data.command === 203) {
+              console.log('Received DoDigicamControl command')
+              this.captureStillPhoto(packet)
+            }
+          }
+        }
+      }
+
+      packet = {
+        header: {
+          sysid: 1,
+          compid: 1,
+          msgid: 76 // example msgid for CommandLong
+        }
+      }
+
+      data = {
+        targetComponent: 100,
+        _param1: 0,
+        command: null
+      }
+    })
+
+    it('should not process if inactive', function () {
+      instance.active = false
+      instance.onMavPacket(packet, data)
+      expect(instance.sendCameraInformation.called).to.be.false
+      expect(instance.sendVideoStreamInformation.called).to.be.false
+      expect(instance.sendCameraSettings.called).to.be.false
+      expect(instance.captureStillPhoto.called).to.be.false
+    })
+
+    it('should send camera information when _param1 matches CameraInformation MSG_ID', function () {
+      data.targetComponent = minimal.MavComponent.CAMERA
+      data._param1 = common.CameraInformation.MSG_ID
+      instance.onMavPacket(packet, data)
+      expect(instance.sendCameraInformation.calledWith(packet.header.sysid, minimal.MavComponent.CAMERA, packet.header.compid)).to.be.true
+    })
+
+    it('should send video stream information when _param1 matches VideoStreamInformation MSG_ID and usePhotoMode is false', function () {
+      data.targetComponent = minimal.MavComponent.CAMERA
+      data._param1 = common.VideoStreamInformation.MSG_ID
+      instance.onMavPacket(packet, data)
+      expect(instance.sendVideoStreamInformation.calledWith(packet.header.sysid, minimal.MavComponent.CAMERA, packet.header.compid)).to.be.true
+    })
+
+    it('should send camera settings when _param1 matches CameraSettings MSG_ID', function () {
+      data.targetComponent = minimal.MavComponent.CAMERA
+      data._param1 = common.CameraSettings.MSG_ID
+      instance.onMavPacket(packet, data)
+      expect(instance.sendCameraSettings.calledWith(packet.header.sysid, minimal.MavComponent.CAMERA, packet.header.compid)).to.be.true
+    })
+
+    it('should capture still photo when command equals 203 (MAV_CMD_DO_DIGICAM_CONTROL)', function () {
+      data.targetComponent = minimal.MavComponent.CAMERA
+      data.command = 203
+      instance.onMavPacket(packet, data)
+      expect(instance.captureStillPhoto.calledWith(packet)).to.be.true
+    })
+
+    it('should not process when targetComponent is not CAMERA', function () {
+      data.targetComponent = 200 // not the CAMERA component
+      instance.onMavPacket(packet, data)
+      expect(instance.sendCameraInformation.called).to.be.false
+      expect(instance.sendVideoStreamInformation.called).to.be.false
+      expect(instance.sendCameraSettings.called).to.be.false
+      expect(instance.captureStillPhoto.called).to.be.false
     })
   })
 })

--- a/server/videostream.test.js
+++ b/server/videostream.test.js
@@ -87,22 +87,22 @@ describe('Video Functions', function () {
     })
   })
 
-  describe('#videomanagerstartInterval()', () => {
+  describe('#videomanagerstartInterval()', function () {
     let vManager
     let setIntervalStub
     let emitStub
 
-    beforeEach(() => {
+    beforeEach( function () {
       vManager = new VideoStream(settings, winston)
       setIntervalStub = sinon.stub(global, 'setInterval')
       emitStub = sinon.stub(vManager.eventEmitter, 'emit')
     })
 
-    afterEach(() => {
+    afterEach( function () {
       sinon.restore()
     })
 
-    it('should start an interval and emit a "cameraheartbeat" event', () => {
+    it('should start an interval and emit a "cameraheartbeat" event',  function () {
       const intervalId = 12345
       setIntervalStub.returns(intervalId)
 
@@ -122,11 +122,11 @@ describe('Video Functions', function () {
     })
   })
 
-  describe('#videomanagercaptureStillPhoto()', () => {
+  describe('#videomanagercaptureStillPhoto()',  function () {
     let vManager
     let emitStub
 
-    beforeEach(() => {
+    beforeEach( function () {
       vManager = new VideoStream(settings, winston)
       // Mocking deviceStream with a kill method
       vManager.deviceStream = {
@@ -136,11 +136,11 @@ describe('Video Functions', function () {
       emitStub = sinon.stub(vManager.eventEmitter, 'emit')
     })
 
-    afterEach(() => {
+    afterEach( function () {
       sinon.restore()
     })
 
-    it('should emit a "cameratrigger" event', () => {
+    it('should emit a "cameratrigger" event',  function () {
       // build a CAMERA_TRIGGER packet
       const expectedMsg = new common.CameraTrigger()
       expectedMsg.timeUsec = BigInt(Date.now() * 1000)
@@ -152,11 +152,11 @@ describe('Video Functions', function () {
     })
   })
 
-  describe('#videomanagersendCameraInformation()', () => {
+  describe('#videomanagersendCameraInformation()',  function () {
     let vManager
     let emitStub
 
-    beforeEach(() => {
+    beforeEach( function () {
       vManager = new VideoStream(settings, winston)
       emitStub = sinon.stub(vManager.eventEmitter, 'emit')
 
@@ -167,11 +167,11 @@ describe('Video Functions', function () {
       }
     })
 
-    afterEach(() => {
+    afterEach( function () {
       sinon.restore()
     })
 
-    it('should emit a "camerainfo" event', () => {
+    it('should emit a "camerainfo" event',  function () {
       // build a CAMERA_INFORMATION packet
       const expectedMsg = new common.CameraInformation()
 
@@ -212,11 +212,11 @@ describe('Video Functions', function () {
     })
   })
 
-  describe('#videomanagersendVideoStreamInformation()', () => {
+  describe('#videomanagersendVideoStreamInformation()',  function () {
     let vManager
     let emitStub
 
-    beforeEach(() => {
+    beforeEach( function () {
       vManager = new VideoStream(settings, winston)
       emitStub = sinon.stub(vManager.eventEmitter, 'emit')
 
@@ -233,11 +233,11 @@ describe('Video Functions', function () {
       }
     })
 
-    afterEach(() => {
+    afterEach( function () {
       sinon.restore()
     })
 
-    it('should emit a "videostreaminfo" event', () => {
+    it('should emit a "videostreaminfo" event',  function () {
       // build a VIDEO_STREAM_INFORMATION packet
       const expectedMsg = new common.VideoStreamInformation()
 
@@ -281,11 +281,11 @@ describe('Video Functions', function () {
     })
   })
 
-  describe('#videomanagersendCameraSettings()', () => {
+  describe('#videomanagersendCameraSettings()',  function () {
     let vManager
     let emitStub
 
-    beforeEach(() => {
+    beforeEach( function () {
       vManager = new VideoStream(settings, winston)
       emitStub = sinon.stub(vManager.eventEmitter, 'emit')
 
@@ -294,11 +294,11 @@ describe('Video Functions', function () {
       }
     })
 
-    afterEach(() => {
+    afterEach( function () {
       sinon.restore()
     })
 
-    it('should emit a "camerasettings" event', () => {
+    it('should emit a "camerasettings" event',  function () {
       // build a CAMERA_SETTINGS packet
       const expectedMsg = new common.CameraSettings()
       expectedMsg.timeBootMs = 0

--- a/src/AppRouter.js
+++ b/src/AppRouter.js
@@ -25,7 +25,7 @@ function AppRouter () {
           <Link className='list-group-item list-group-item-action bg-light' to="/network">Network Config</Link>
           <Link className='list-group-item list-group-item-action bg-light' to="/adhoc">Adhoc Wifi Config</Link>
           <Link className='list-group-item list-group-item-action bg-light' to="/apclients">Access Point Clients</Link>
-          <Link className='list-group-item list-group-item-action bg-light' to="/video">Video Streaming</Link>
+          <Link className='list-group-item list-group-item-action bg-light' to="/video">Video and Photo</Link>
           <Link className='list-group-item list-group-item-action bg-light' to="/cloud">Cloud Upload</Link>
           <Link className='list-group-item list-group-item-action bg-light' to="/vpn">VPN Config</Link>
           <Link className='list-group-item list-group-item-action bg-light' to="/about">About</Link>

--- a/src/video.js
+++ b/src/video.js
@@ -12,6 +12,7 @@ class VideoPage extends basePage {
     super(props);
     this.state = {
       ifaces: [],
+      photoMode: false,
       dev: [],
       vidDeviceSelected: this.props.vidDeviceSelected,
       vidres: [],
@@ -33,12 +34,21 @@ class VideoPage extends basePage {
       timestamp: false,
       enableCameraHeartbeat: false,
       mavStreamSelected: this.props.mavStreamSelected,
-      multicastString: " "
+      multicastString: " ",
+      mediaPath: "/home/pi/Rpanion-server/media/"
     }
   }
 
   componentDidMount() {
     fetch(`/api/videodevices`).then(response => response.json()).then(state => { this.setState(state); this.isMulticastUpdateIP(state.useUDPIP); this.loadDone() });
+  }
+
+  handleUsePhotoModeChange = (event) => {
+    this.setState({ photoMode: event.target.value==="photo" });
+  }
+
+  handleUsePhotoModeChange = (event) => {
+    this.setState({ photoMode: event.target.value==="photo" });
   }
 
   handleVideoChange = (value) => {
@@ -121,10 +131,44 @@ class VideoPage extends basePage {
     this.setState({ enableCameraHeartbeat: !this.state.enableCameraHeartbeat });
   }
 
+  handleMavControlChange = (event) => {
+    // Allow MAVLink-connected devices to control the camera
+    this.setState({ enableMavControl: !this.state.enableMavControl });
+  }
+
   handleMavStreamChange = (value) => {
     //new value for selected stream IP
     this.setState({ mavStreamSelected: value });
   }
+
+  handleMediaPathChange = (event) => {
+    this.setState({ mediaPath: event.target.value});
+  }
+
+  handleCaptureStill = (event) => {
+    fetch('/api/capturestillphoto', {
+      method: 'POST',
+      headers: {
+        'Accept': 'application/json',
+        'Content-Type': 'application/json',
+      }
+    });
+  }
+
+  handleMediaPathChange = (event) => {
+    this.setState({ mediaPath: event.target.value});
+  }
+
+  handleCaptureStill = (event) => {
+    fetch('/api/capturestillphoto', {
+      method: 'POST',
+      headers: {
+        'Accept': 'application/json',
+        'Content-Type': 'application/json',
+      }
+    });
+  }
+
 
   handleStreaming = () => {
     //user clicked start/stop streaming
@@ -137,6 +181,7 @@ class VideoPage extends basePage {
         },
         body: JSON.stringify({
           active: !this.state.streamingStatus,
+          usePhotoMode: this.state.photoMode,
           device: this.state.vidDeviceSelected.value,
           height: this.state.vidResSelected.height,
           width: this.state.vidResSelected.width,
@@ -150,7 +195,9 @@ class VideoPage extends basePage {
           useUDPPort: this.state.useUDPPort,
           useTimestamp: this.state.timestamp,
           useCameraHeartbeat: this.state.enableCameraHeartbeat,
+          useMavControl: this.state.enableMavControl,
           mavStreamSelected: this.state.mavStreamSelected.value,
+          mediaPath: this.state.mediaPath
         })
       }).then(response => response.json()).then(state => { this.setState(state); this.setState({ waiting: false }) });
     });
@@ -165,76 +212,107 @@ class VideoPage extends basePage {
       <Form style={{ width: 600 }}>
         <p><i>Stream live video from any connected camera devices. Only 1 camera can be streamed at a time. Multicast IP addresses are supported in RTP mode.</i></p>
         <h2>Configuration</h2>
-        <div className="form-group row" style={{ marginBottom: '5px' }}>
-              <label className="col-sm-4 col-form-label">Streaming Mode</label>
-              <div className="col-sm-8">
-                <div className="form-check">
-                  <input className="form-check-input" type="radio" name="streamtype" value="rtp" disabled={this.state.streamingStatus} onChange={this.handleUseUDPChange} checked={this.state.UDPChecked} />
-                  <label className="form-check-label">RTP (stream to single client)</label>
-                </div>
-                <div className="form-check">
-                  <input className="form-check-input" type="radio" name="streamtype" value="rtsp" disabled={this.state.streamingStatus} onChange={this.handleUseUDPChange} checked={!this.state.UDPChecked} />
-                  <label className="form-check-label">RTSP (multiple clients can connect to stream)</label>
-                </div>
-              </div>
-            </div>
 
         <div className="form-group row" style={{ marginBottom: '5px' }}>
-          <label className="col-sm-4 col-form-label">Device</label>
-          <div className="col-sm-8">
-            <Select isDisabled={this.state.streamingStatus} onChange={this.handleVideoChange} options={this.state.dev} value={this.state.vidDeviceSelected} />
-          </div>
+              <label className="col-sm-4 col-form-label">Camera Mode</label>
+              <div className="col-sm-8">
+                <div className="form-check">
+                  <input className="form-check-input" type="radio" name="cameramode" value="streaming" disabled={this.state.streamingStatus} onChange={this.handleUsePhotoModeChange} checked={!this.state.photoMode} />
+                  <label className="form-check-label">Streaming Video (Default) </label>
+                </div>
+                <div className="form-check">
+                  <input className="form-check-input" type="radio" name="cameramode" value="photo" disabled={this.state.streamingStatus} onChange={this.handleUsePhotoModeChange} checked={this.state.photoMode} />
+                  <label className="form-check-label">Still Photo Capture</label>
+                </div>
+              </div>
         </div>
-        <div className="form-group row" style={{ marginBottom: '5px' }}>
-          <label className="col-sm-4 col-form-label">Resolution</label>
-          <div className="col-sm-8">
-            <Select isDisabled={this.state.streamingStatus} options={this.state.vidres} onChange={this.handleResChange} value={this.state.vidResSelected} />
-          </div>
-        </div>
-        <div style={{ display: (typeof this.state.vidResSelected !== 'undefined' && this.state.vidResSelected.format !== "video/x-h264") ? "block" : "none" }}>
+        <div className = "videostreaming" style = {{display: !this.state.photoMode ? "block" : "none"}}>
           <div className="form-group row" style={{ marginBottom: '5px' }}>
-            <label className="col-sm-4 col-form-label">Rotation</label>
+                <label className="col-sm-4 col-form-label">Streaming Mode</label>
+                <div className="col-sm-8">
+                  <div className="form-check">
+                    <input className="form-check-input" type="radio" name="streamtype" value="rtp" disabled={this.state.streamingStatus} onChange={this.handleUseUDPChange} checked={this.state.UDPChecked} />
+                    <label className="form-check-label">RTP (stream to single client)</label>
+                  </div>
+                  <div className="form-check">
+                    <input className="form-check-input" type="radio" name="streamtype" value="rtsp" disabled={this.state.streamingStatus} onChange={this.handleUseUDPChange} checked={!this.state.UDPChecked} />
+                    <label className="form-check-label">RTSP (multiple clients can connect to stream)</label>
+                  </div>
+                </div>
+              </div>
+
+          <div className="form-group row" style={{ marginBottom: '5px' }}>
+            <label className="col-sm-4 col-form-label">Device</label>
             <div className="col-sm-8">
-              <Select isDisabled={this.state.streamingStatus} options={this.state.rotations} onChange={this.handleRotChange} value={this.state.rotSelected} />
+              <Select isDisabled={this.state.streamingStatus} onChange={this.handleVideoChange} options={this.state.dev} value={this.state.vidDeviceSelected} />
             </div>
           </div>
           <div className="form-group row" style={{ marginBottom: '5px' }}>
-            <label className="col-sm-4 col-form-label">Maximum Bitrate</label>
+            <label className="col-sm-4 col-form-label">Resolution</label>
             <div className="col-sm-8">
-              <input disabled={this.state.streamingStatus} type="number" name="bitrate" min="50" max="50000" step="10" onChange={this.handleBitrateChange} value={this.state.bitrate} />kbps
+              <Select isDisabled={this.state.streamingStatus} options={this.state.vidres} onChange={this.handleResChange} value={this.state.vidResSelected} />
+            </div>
+          </div>
+          <div style={{ display: (typeof this.state.vidResSelected !== 'undefined' && this.state.vidResSelected.format !== "video/x-h264") ? "block" : "none" }}>
+            <div className="form-group row" style={{ marginBottom: '5px' }}>
+              <label className="col-sm-4 col-form-label">Rotation</label>
+              <div className="col-sm-8">
+                <Select isDisabled={this.state.streamingStatus} options={this.state.rotations} onChange={this.handleRotChange} value={this.state.rotSelected} />
+              </div>
+            </div>
+            <div className="form-group row" style={{ marginBottom: '5px' }}>
+              <label className="col-sm-4 col-form-label">Maximum Bitrate</label>
+              <div className="col-sm-8">
+                <input disabled={this.state.streamingStatus} type="number" name="bitrate" min="50" max="50000" step="10" onChange={this.handleBitrateChange} value={this.state.bitrate} />kbps
+              </div>
+            </div>
+            <div className="form-group row" style={{ marginBottom: '5px' }}>
+            <label className="col-sm-4 col-form-label">Timestamp Overlay</label>
+            <div className="col-sm-8">
+              <input type="checkbox" disabled={this.state.streamingStatus} onChange={this.handleTimestampChange} checked={this.state.timestamp} />
+            </div>
             </div>
           </div>
           <div className="form-group row" style={{ marginBottom: '5px' }}>
-          <label className="col-sm-4 col-form-label">Timestamp Overlay</label>
-          <div className="col-sm-8">
-            <input type="checkbox" disabled={this.state.streamingStatus} onChange={this.handleTimestampChange} checked={this.state.timestamp} />
-          </div>
-          </div>
-        </div>
-        <div className="form-group row" style={{ marginBottom: '5px' }}>
-          <label className="col-sm-4 col-form-label">Framerate</label>
-          <div className="col-sm-8" style={{ display: (this.state.FPSMax === 0) ? "block" : "none" }}>
-            <Select isDisabled={this.state.streamingStatus} options={this.state.fps} value={this.state.fpsSelected} onChange={this.handleFPSChangeSelect} />
-          </div>
-          <div className="col-sm-8" style={{ display: (this.state.FPSMax !== 0) ? "block" : "none" }}>
-            <input disabled={this.state.streamingStatus} type="number" name="fps" min="1" max={this.state.FPSMax} step="1" onChange={this.handleFPSChange} value={this.state.fpsSelected} />fps (max: {this.state.FPSMax})
-          </div>
-        </div>
-        <div style={{ display: (this.state.UDPChecked) ? "block" : "none" }}>
-          <div className="form-group row" style={{ marginBottom: '5px' }}>
-            <label className="col-sm-4 col-form-label ">Destination IP</label>
-            <div className="col-sm-8">
-              <input type="text" name="ipaddress" disabled={!this.state.UDPChecked || this.state.streamingStatus} value={this.state.useUDPIP} onChange={this.handleUDPIPChange} />
+            <label className="col-sm-4 col-form-label">Framerate</label>
+            <div className="col-sm-8" style={{ display: (this.state.FPSMax === 0) ? "block" : "none" }}>
+              <Select isDisabled={this.state.streamingStatus} options={this.state.fps} value={this.state.fpsSelected} onChange={this.handleFPSChangeSelect} />
+            </div>
+            <div className="col-sm-8" style={{ display: (this.state.FPSMax !== 0) ? "block" : "none" }}>
+              <input disabled={this.state.streamingStatus} type="number" name="fps" min="1" max={this.state.FPSMax} step="1" onChange={this.handleFPSChange} value={this.state.fpsSelected} />fps (max: {this.state.FPSMax})
             </div>
           </div>
-          <div className="form-group row" style={{ marginBottom: '5px' }}>
-            <label className="col-sm-4 col-form-label">Destination Port</label>
-            <div className="col-sm-8">
-              <input type="text" name="port" disabled={!this.state.UDPChecked || this.state.streamingStatus} value={this.state.useUDPPort} onChange={this.handleUDPPortChange} />
+          <div style={{ display: (this.state.UDPChecked) ? "block" : "none" }}>
+            <div className="form-group row" style={{ marginBottom: '5px' }}>
+              <label className="col-sm-4 col-form-label ">Destination IP</label>
+              <div className="col-sm-8">
+                <input type="text" name="ipaddress" disabled={!this.state.UDPChecked || this.state.streamingStatus} value={this.state.useUDPIP} onChange={this.handleUDPIPChange} />
+              </div>
+            </div>
+            <div className="form-group row" style={{ marginBottom: '5px' }}>
+              <label className="col-sm-4 col-form-label">Destination Port</label>
+              <div className="col-sm-8">
+                <input type="text" name="port" disabled={!this.state.UDPChecked || this.state.streamingStatus} value={this.state.useUDPPort} onChange={this.handleUDPPortChange} />
+              </div>
             </div>
           </div>
         </div>
-        <br/>
+
+        <div className = "photomode" style = {{display: (this.state.photoMode ? "block" : "none")}}>
+          <div className="form-group row" style={{ marginBottom: '5px' }}>
+          <label className="col-sm-4 col-form-label ">Media Storage Path</label>
+              <div className="col-sm-8">
+                <input type="text" size="35" name="mediastoragepath" disabled={this.state.streamingStatus} value={this.state.mediaPath} onChange={this.handleMediaPathChange} />
+                <br/>
+                <br/>
+              </div>
+            <div className="col-sm-8" style={{ display: (this.state.streamingStatus) ? "block" : "none" }}>
+              <Button onClick={this.handleCaptureStill} className="btn btn-primary" >Take Photo Now</Button>
+            </div>
+          </div>
+          <br/>
+        </div>
+
         <h3>MAVLink Video Streaming Service</h3>
         <p><i>Configuration for advertising the camera and associated video stream via MAVLink. See <a href='https://mavlink.io/en/services/camera.html#video_streaming'>here</a> for details.</i></p>
         <div className="form-group row" style={{ marginBottom: '5px' }}>
@@ -242,8 +320,12 @@ class VideoPage extends basePage {
           <div className="col-sm-7">
           <input type="checkbox" disabled={this.state.streamingStatus} checked={this.state.enableCameraHeartbeat} onChange={this.handleUseCameraHeartbeatChange} />
           </div>
+          <label className="col-sm-4 col-form-label">Allow connected MAVLink devices to control the camera</label>
+          <div className="col-sm-7">
+          <input type="checkbox" disabled={this.state.streamingStatus} checked={this.state.enableMavControl} onChange={this.handleMavControlChange} />
+          </div>
         </div>
-        <div style={{ display: (this.state.enableCameraHeartbeat && (!this.state.UDPChecked)) ? "block" : "none" }}>
+        <div style={{ display: (this.state.enableCameraHeartbeat && (!this.state.UDPChecked) && (!this.state.photoMode)) ? "block" : "none" }}>
           <div className="form-group row" style={{ marginBottom: '5px' } }>
               <label className="col-sm-4 col-form-label">Video source IP Address</label>
               <div className="col-sm-8">
@@ -253,16 +335,25 @@ class VideoPage extends basePage {
         </div>
         <br/>
 
-        <div className="form-group row" style={{ marginBottom: '5px' }}>
-          <div className="col-sm-8">
-            <Button onClick={this.handleStreaming} className="btn btn-primary">{this.state.streamingStatus ? "Stop Streaming" : "Start Streaming"}</Button>
+        <div className = "videostreaming" style = {{display: !this.state.photoMode ? "block" : "none"}}>
+          <div className="form-group row" style={{ marginBottom: '5px' }}>
+            <div className="col-sm-8">
+              <Button onClick={this.handleStreaming} className="btn btn-primary">{this.state.streamingStatus ? "Stop Streaming" : "Start Streaming"}</Button>
+            </div>
+            <br/>
           </div>
-          <br/>
         </div>
-
+        <div className = "mavlink" style = {{display: this.state.photoMode ? "block" : "none"}}>
+          <div className="form-group row" style={{ marginBottom: '5px' }}>
+            <div className="col-sm-8">
+              <Button onClick={this.handleStreaming} className="btn btn-primary">{this.state.streamingStatus ? "Stop MAVLink Camera Interface" : "Start MAVLink Camera Interface"}</Button>
+            </div>
+            <br/>
+          </div>
+        </div>
         <br />
-        <h3 style={{ display: (this.state.streamingStatus) ? "block" : "none" }}>Connection strings for video stream</h3>
-        <Accordion defaultActiveKey="0" style={{ display: (this.state.streamingStatus && !this.state.UDPChecked) ? "block" : "none" }}>
+        <h3 style={{ display: (this.state.streamingStatus && !this.state.photoMode) ? "block" : "none" }}>Connection strings for video stream</h3>
+        <Accordion defaultActiveKey="0" style={{ display: (this.state.streamingStatus && !this.state.UDPChecked && !this.state.photoMode) ? "block" : "none" }}>
           <Accordion.Item eventKey="0">
             <Accordion.Header>
               + RTSP Streaming Addresses (for VLC, etc)

--- a/src/video.js
+++ b/src/video.js
@@ -185,7 +185,7 @@ class VideoPage extends basePage {
   }
 
   renderTitle() {
-    return "Video Streaming";
+    return "Video and Photo";
   }
 
   renderContent() {

--- a/src/video.js
+++ b/src/video.js
@@ -47,10 +47,6 @@ class VideoPage extends basePage {
     this.setState({ photoMode: event.target.value==="photo" });
   }
 
-  handleUsePhotoModeChange = (event) => {
-    this.setState({ photoMode: event.target.value==="photo" });
-  }
-
   handleVideoChange = (value) => {
     //new video device
     this.setState({ vidDeviceSelected: value, vidres: value.caps });
@@ -131,7 +127,7 @@ class VideoPage extends basePage {
     this.setState({ enableCameraHeartbeat: !this.state.enableCameraHeartbeat });
   }
 
-  handleMavControlChange = (event) => {
+  handleMavControlChange = () => {
     // Allow MAVLink-connected devices to control the camera
     this.setState({ enableMavControl: !this.state.enableMavControl });
   }
@@ -145,7 +141,7 @@ class VideoPage extends basePage {
     this.setState({ mediaPath: event.target.value});
   }
 
-  handleCaptureStill = (event) => {
+  handleCaptureStill = () => {
     fetch('/api/capturestillphoto', {
       method: 'POST',
       headers: {
@@ -154,21 +150,6 @@ class VideoPage extends basePage {
       }
     });
   }
-
-  handleMediaPathChange = (event) => {
-    this.setState({ mediaPath: event.target.value});
-  }
-
-  handleCaptureStill = (event) => {
-    fetch('/api/capturestillphoto', {
-      method: 'POST',
-      headers: {
-        'Accept': 'application/json',
-        'Content-Type': 'application/json',
-      }
-    });
-  }
-
 
   handleStreaming = () => {
     //user clicked start/stop streaming


### PR DESCRIPTION
The start of a Photo mode that allows full-resolution still images to be captured locally on the device running Rpanion. As requested in #167 

This is currently very much a _work in progress_ (expect broken things, for now), but I'm adding it as a draft PR in case anyone wants to comment on its early stages or contribute.

The basic idea is to have a radio button on the Video page to select between Streaming (the current state) and Photo mode. Photo mode would:

- Start capture_still.py, which configures the camera using Picamera2 and then goes to sleep waiting for a SIGUSR1
- Accept and process MAVLink camera commands. If a DO_DIGICAM_CONTROL shoot command is received, send a SIGUSR1 to capture_still.py
- Stop capture_still.py by sending a SIGKILL when user clicks "Stop" 
- (Optional): Allow configuration of camera settings (exposure, focus, zoom, etc.) which would be passed to capture_still.py as arguments (probably ties in to #228)
- (Optional): Allow the user to select where images will be stored
- (Eventual goal): Accept MAVLink gimbal control commands
- (Pie in the sky goal): Provide a live preview from the camera, either in the browser window or via an RTP/RTSP stream
- (Pie in the sky goal): Accept MAVLink commands to change camera settings, start/stop, and switch back and forth between Photo and Streaming modes