### PR TITLE
Video.js isMulticastUpdateIP(): Convert to string before splitting

### DIFF
--- a/src/video.js
+++ b/src/video.js
@@ -74,7 +74,7 @@ class VideoPage extends basePage {
 
   isMulticastUpdateIP(ip) {
     // Split the IP address into its four octets
-    const octets = ip.split('.').map(Number);
+    const octets = ip.toString().split('.').map(Number);
     let udpmult = " ";
 
     // Check if the IP address has 4 octets and all are within the valid range


### PR DESCRIPTION
~~I was getting an "ip.split is not a function" runtime error in the browser when loading the Video page. This seems to fix it by forcing the IP into a string before trying to split it.~~

That definitely doesn't fix it...