### PR TITLE
Video: Add local still image and video recording

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,5 @@ settingsTest.json
 /rpanion-server_*
 
 /python/.venv
+
+/media

--- a/deploy/RasPi3-4-5-deploy.sh
+++ b/deploy/RasPi3-4-5-deploy.sh
@@ -34,6 +34,7 @@ fi
 source /etc/os-release
 if [[ "$ID" == "debian" || "$ID" == "raspbian" ]] && [ "$VERSION_CODENAME" == "bookworm" ]; then
     sudo apt install -y  gstreamer1.0-libcamera
+fi
 
 ## Only install picamera2 on RaspiOS
 sudo apt -y install python3-picamera2 python3-libcamera python3-kms++

--- a/deploy/install_common_libraries.sh
+++ b/deploy/install_common_libraries.sh
@@ -9,6 +9,9 @@ sudo apt upgrade -y
 sudo apt install -y gstreamer1.0-plugins-good libgstrtspserver-1.0-0 gir1.2-gst-rtsp-server-1.0 gstreamer1.0-plugins-base-apps gstreamer1.0-plugins-ugly gstreamer1.0-plugins-bad
 sudo apt install -y network-manager python3 python3-gst-1.0 python3-pip dnsmasq git jq wireless-tools iw python3-dev gstreamer1.0-x ppp python3-venv
 
+## Install OpenCV for camera management
+sudo apt install -y python3-opencv
+
 ## Pymavlink
 sudo apt install -y python3-lxml python3-numpy
 

--- a/python/get_camera_caps.py
+++ b/python/get_camera_caps.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 vi:ts=4:noexpandtab -*-
+
+import subprocess
+import re
+import sys
+import json
+import os
+
+def check_if_v4l2_ctl_avail():
+    try:
+        subprocess.run(['v4l2-ctl', '--help'], check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        print("Could not load v4l2-ctl or v4l2-ctl is not installed. Exiting.")
+        sys.exit(1)
+
+def get_subdev_paths():
+    base_path = '/dev'
+    return sorted([os.path.join(base_path, dev) for dev in os.listdir(base_path) if dev.startswith('v4l-subdev')])
+
+def get_video_device_paths():
+    base_path = '/dev'
+    return sorted([os.path.join(base_path, dev) for dev in os.listdir(base_path) if dev.startswith('video')])
+
+def get_mbus_codes(dev_path):
+    command = f"v4l2-ctl -d {dev_path} --list-subdev-mbus-codes 0"
+    result = subprocess.run(command, shell=True, text=True, capture_output=True)
+    if result.returncode != 0:
+        return []
+    pattern = r"0x([0-9a-fA-F]+):\s+([A-Za-z0-9_]+)"
+    return re.findall(pattern, result.stdout)
+
+def get_resolutions(dev_path, mbus_code):
+    command = f"v4l2-ctl -d {dev_path} --list-subdev-framesizes pad=0,code=0x{mbus_code}"
+    result = subprocess.run(command, shell=True, text=True, capture_output=True)
+    if result.returncode != 0:
+        return []
+    pattern = r"Size Range: (\d+)x(\d+)"
+    matches = re.findall(pattern, result.stdout)
+    return [{'width': int(w), 'height': int(h)} for w, h in matches]
+
+def get_formats_and_resolutions(dev_path):
+    command = f"v4l2-ctl -d {dev_path} --list-formats-ext"
+    result = subprocess.run(command, shell=True, text=True, capture_output=True)
+    if result.returncode != 0:
+        return []
+
+    devices = []
+    fmt_pattern = r"^\s*\[\d+\]: '(\w+)' \(.*?\)"
+    size_pattern = r"\s+Size: Discrete (\d+)x(\d+)"
+    current_fmt = None
+
+    for line in result.stdout.splitlines():
+        fmt_match = re.match(fmt_pattern, line)
+        if fmt_match:
+            current_fmt = fmt_match.group(1)
+            continue
+
+        size_match = re.match(size_pattern, line)
+        if size_match and current_fmt:
+            width, height = map(int, size_match.groups())
+            devices.append({
+                'format': current_fmt,
+                'width': width,
+                'height': height,
+                'label': f"{width}x{height}_{current_fmt}",
+                'value': f"{current_fmt}_{width}x{height}"
+            })
+
+    return devices
+
+def get_card_name(dev_path):
+    command = f"v4l2-ctl -d {dev_path} --all"
+    result = subprocess.run(command, shell=True, text=True, capture_output=True)
+    if result.returncode != 0:
+        return None
+
+    match = re.search(r"Card type\s+:\s+(.+)", result.stdout)
+    if match:
+        return match.group(1).strip()
+
+    return None
+
+def get_libcamera_models():
+    """Get CSI camera model names from libcamera"""
+    try:
+        from picamera2 import Picamera2
+        models = {}
+        camera_info = Picamera2.global_camera_info()
+        
+        for idx, info in enumerate(camera_info):
+            model = info.get('Model', None)
+            if model and "usb@" not in info.get('Id', ''):
+                models[idx] = model
+        
+        return list(models.values())
+    except:
+        return []
+
+def get_capabilities():
+    """Check for availability of required libraries for photo/video modes"""
+    capabilities = {
+        'cv2': False,
+        'picamera2': False
+    }
+    
+    try:
+        import cv2
+        capabilities['cv2'] = True
+    except ImportError:
+        pass
+    
+    try:
+        from picamera2 import Picamera2
+        capabilities['picamera2'] = True
+    except (ImportError, OSError):
+        pass
+    
+    return capabilities
+
+check_if_v4l2_ctl_avail()
+
+devices = []
+
+# Get libcamera model names first
+libcamera_models = get_libcamera_models()
+model_idx = 0
+
+# Process CSI cameras
+for dev_path in get_subdev_paths():
+    mbus_codes = get_mbus_codes(dev_path)
+    if not mbus_codes:
+        continue
+    
+    # Use libcamera model name if available, otherwise fall back to the v4l2 name
+    if model_idx < len(libcamera_models):
+        card_name = libcamera_models[model_idx]
+        model_idx += 1
+    else:
+        card_name = get_card_name(dev_path) or "Unnamed CSI Camera"
+
+    device_caps = {
+        # Don't specify a device path for CSI cameras,
+        # but generate a unique ID for them.
+        'id': f"CSI-{re.sub(r'[^a-zA-Z0-9]', '_', card_name)}",
+        'device': None,
+        'type': 'CSI',
+        'card_name': card_name,
+        'caps': []
+    }
+
+    for mbus_code, pixel_format in mbus_codes:
+        resolutions = get_resolutions(dev_path, mbus_code)
+
+        for res in resolutions:
+            fmt = pixel_format.split("MEDIA_BUS_FMT_")[1] if "MEDIA_BUS_FMT_" in pixel_format else pixel_format
+            cap_info = {
+                'format': fmt,
+                'width': res['width'],
+                'height': res['height'],
+                'label': f"{res['width']}x{res['height']}_{fmt}",
+                'value': f"{mbus_code}_{fmt}_{res['width']}x{res['height']}"
+            }
+            device_caps['caps'].append(cap_info)
+
+    if device_caps['caps']:
+        devices.append(device_caps)
+
+# Process UVC cameras
+for dev_path in get_video_device_paths():
+    caps = get_formats_and_resolutions(dev_path)
+    if caps:
+        devices.append({
+            'id': dev_path, # use the device path as the unique ID for UVC cameras
+            'device': dev_path,
+            'type': 'UVC',
+            'card_name': get_card_name(dev_path) or "Unnamed UVC Camera",
+            'caps': caps
+        })
+
+# Get library capabilities and output as a single JSON object
+capabilities = get_capabilities()
+
+output = {
+    'devices': devices,
+    'capabilities': capabilities
+}
+
+print(json.dumps(output, indent=4))

--- a/python/gstcaps.py
+++ b/python/gstcaps.py
@@ -213,10 +213,18 @@ for device in devices:
                     fps = []
                     if framerates:
                         for i in range(framerates.n_values):
-                            fp = str(framerates.get_nth(i)).split('/')
-                            if int(fp[1]) == 1:
-                                fps.append({'value': str(int(fp[0])/int(fp[1])), 'label': (str(int(fp[0])/int(fp[1])) + " fps")})
-                            #print(' - framerate = ', framerates.get_nth(i))
+                            try:
+                                frac = framerates.get_nth(i)
+                                numerator = int(frac.numerator)
+                                denominator = int(frac.denominator)
+                                if denominator == 1:
+                                    fps.append({'value': str(int(numerator/denominator)), 'label': (str(int(numerator/denominator)) + " fps")})
+                                else:
+                                    fps_val = numerator / denominator
+                                    fps.append({'value': str(fps_val), 'label': (str(fps_val) + " fps")})
+                            except (AttributeError, TypeError, ValueError, ZeroDivisionError):
+                                # Skip framerates that can't be parsed
+                                pass
                     else:
                         fps.append({'value': "-1", 'label': "N/A"})
 

--- a/python/photovideo.py
+++ b/python/photovideo.py
@@ -1,0 +1,372 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 vi:ts=4:noexpandtab
+
+import argparse
+import time, signal, os, sys, shutil, traceback
+import json
+
+# Parse command line arguments
+home_dir = os.path.expanduser("~")
+
+parser = argparse.ArgumentParser(description="Camera control server")
+parser.add_argument("-d", "--destination", dest="mediaPath",
+                    help="Save captured image to PATH. Default: ~/Rpanion-server/media/",
+                    metavar="PATH",
+                    default=f"{home_dir}/Rpanion-server/media/"
+                    )
+parser.add_argument("-m", "--mode", choices=['photo', 'video'],
+                    dest="captureMode",
+                    help="Capture mode options: photo [default], video", metavar="MODE",
+                    default='photo'
+                    )
+parser.add_argument("--device", dest="captureDeviceId",
+                    help="Unique device ID. If it starts with 'CSI', Picamera2 is used. Otherwise, it's treated as a V4L2 device path.",
+                    default=None
+                    )
+parser.add_argument("--width", metavar="W", type=int, dest="vidWidth",
+                    help="Image width", default=1920
+                    )
+parser.add_argument("--height", metavar="H", type=int, dest="vidHeight",
+                    help="Image height", default=1080
+                    )
+parser.add_argument("--fps", metavar="FPS", type=int, dest="vidFps",
+                    help="Video framerate", default=30
+                    )
+parser.add_argument("--format", dest="vidFormat",
+                    help="Video format (e.g., YUV420, MJPEG, RGB888). Default: YUV420",
+                    default="YUV420"
+                    )
+parser.add_argument("--rotation", metavar="DEG", type=int, choices=[0, 90, 180, 270],
+                    dest="imageRotation", help="Image rotation", default=0)
+parser.add_argument("-b", "--bitrate", metavar = "N",
+                    type = int, dest="vidBitrate",
+                    help="Video bitrate in bits per second. Default: 10000000",
+                    default=10000000
+                    )
+parser.add_argument("-f", "--min-disk-space", metavar = "N",
+                type = int, dest="minFreeSpace",
+                help="Minimum free disk space (in MB) required to save files. Default: 1000 MB",
+                default=1000
+                )
+args = parser.parse_args()
+
+mediaPath = args.mediaPath
+captureMode = args.captureMode
+minFreeSpace = args.minFreeSpace * 10**6
+
+# Try importing piexif for geotagging, if photo mode was requested
+if captureMode == "photo":
+    try:
+        import piexif
+        HAS_PIEXIF = True
+    except ImportError:
+        HAS_PIEXIF = False
+        print("Warning: 'piexif' module not found. Geotagging will be disabled. Install with: pip3 install piexif", flush=True)
+
+# Set up signals before importing heavy libraries (cv2, picamera2)
+# to prevent the process from being killed if a signal arrives during import.
+
+GOT_SIGUSR1 = False
+GOT_SIGTERM = False
+VIDEO_ACTIVE = False
+
+def handle_sigusr1(signum, stack):
+    global GOT_SIGUSR1
+    GOT_SIGUSR1 = True
+
+def handle_sigterm(signum, stack):
+    global GOT_SIGTERM
+    GOT_SIGTERM = True
+
+# Register the signal handler functions with the actual signals
+signal.signal(signal.SIGTERM, handle_sigterm)
+signal.signal(signal.SIGUSR1, handle_sigusr1)
+
+# Notify Node.js immediately that we are alive (prevents timeout)
+print(f"PID is : {os.getpid()}", flush=True)
+
+# Load the heavy libraries
+HAS_PICAMERA = False
+
+# Attempt to load Picamera2
+print("Loading camera libraries. This may take a while.", flush=True)
+try:
+    from picamera2 import Picamera2
+    print("Loaded Picamera2", flush=True)
+    # Only try importing H264Encoder if video mode was requested
+    if captureMode == "video":
+        from picamera2.encoders import H264Encoder
+        print("Loaded the H264 Encoder", flush=True)
+    from libcamera import Transform
+    
+    HAS_PICAMERA = True
+
+except (ImportError, OSError):
+    HAS_PICAMERA = False
+    print("Picamera2 not found. Will attempt to fall back to V4L2.", flush=True)
+
+try:
+    import cv2
+    print("Loaded OpenCV-Python", flush=True)
+    print("Finished loading camera libraries.", flush=True)
+except ImportError:
+    print("Critical Error: OpenCV-Python (cv2) not found. Exiting.", file=sys.stderr)
+    sys.exit(1)
+
+# --- Helper Functions for EXIF ---
+def to_deg(value, loc):
+    """Converts decimal coordinates to EXIF-ready rational (deg, min, sec)"""
+    if value < 0:
+        loc_value = loc[1] # S or W
+    else:
+        loc_value = loc[0] # N or E
+    abs_value = abs(value)
+    deg = int(abs_value)
+    t1 = (deg, 1)
+    min = int((abs_value - deg) * 60)
+    t2 = (min, 1)
+    sec = round((abs_value - deg - min / 60) * 3600 * 100)
+    t3 = (sec, 100)
+    return (t1, t2, t3), loc_value
+
+def geotag_image(filepath):
+    if not HAS_PIEXIF:
+        print("EXIF library not available. Skipping geotag.", flush=True)
+        return
+
+    gps_file = '/tmp/rpanion_gps.json'
+    if not os.path.exists(gps_file):
+        return
+
+    try:
+        with open(gps_file, 'r') as f:
+            data = json.load(f)
+        
+        # Check if data is valid (non-zero)
+        if data['lat'] == 0 and data['lon'] == 0:
+            print("Warning: GPS Lat/Lon are 0.0 (No Fix). Skipping geotag.", flush=True)
+            return
+
+        lat_deg, lat_ref = to_deg(data['lat'], ["N", "S"])
+        lon_deg, lon_ref = to_deg(data['lon'], ["E", "W"])
+        
+        # Altitude (MSL)
+        alt = data.get('alt', 0)
+        alt_ref = 0 if alt >= 0 else 1
+        alt_rational = (int(abs(alt) * 100), 100)
+
+        exif_dict = piexif.load(filepath)
+        
+        gps_ifd = {
+            piexif.GPSIFD.GPSLatitudeRef: lat_ref,
+            piexif.GPSIFD.GPSLatitude: lat_deg,
+            piexif.GPSIFD.GPSLongitudeRef: lon_ref,
+            piexif.GPSIFD.GPSLongitude: lon_deg,
+            piexif.GPSIFD.GPSAltitudeRef: alt_ref,
+            piexif.GPSIFD.GPSAltitude: alt_rational,
+        }
+
+        exif_dict["GPS"] = gps_ifd
+        exif_bytes = piexif.dump(exif_dict)
+        piexif.insert(exif_bytes, filepath)
+        print(f"Geotagged image with Lat: {data['lat']}, Lon: {data['lon']}", flush=True)
+        
+        # Cleanup
+        os.remove(gps_file)
+
+    except Exception as e:
+        print(f"Error Geotagging: {e}", file=sys.stderr)
+
+# Main script setup
+picam2_still = None
+picam2_vid = None
+v4l2_cam = None
+v4l2_writer = None
+encoder = None
+use_picamera = False
+
+# Create media directory if it doesn't exist
+try:
+    os.makedirs(mediaPath, exist_ok=True)
+    print(f"Media storage directory '{mediaPath}' is ready.")
+except Exception as e:
+    sys.exit(f"An error occurred creating directory: {e}")
+
+# Determine which backend to use
+# If the device path starts with '/dev/video', it is a USB/V4L2 camera.
+# Everything else (None, 'CSI', '/base/soc/...') is treated as a Libcamera/Picamera2 device.
+
+is_explicit_v4l2 = args.captureDeviceId is not None and args.captureDeviceId.startswith('/dev/video')
+
+if not is_explicit_v4l2 and HAS_PICAMERA:
+    print(f"Device {args.captureDeviceId} specified (or None). Defaulting to Picamera2 backend.", flush=True)
+    use_picamera = True
+    try:
+        if not Picamera2.global_camera_info():
+             sys.exit("Picamera2 backend selected, but no libcamera cameras found.")
+    except Exception as e:
+        sys.exit(f"Could not query for Picamera2 cameras: {e}")
+else:
+    print(f"Device {args.captureDeviceId} specified. Using V4L2/OpenCV backend.", flush=True)
+    use_picamera = False
+
+    # If no device ID was provided, default to /dev/video0
+    if args.captureDeviceId is None:
+        args.captureDevicePath = "/dev/video0"
+        print("No device ID provided. Defaulting to /dev/video0")
+    else:
+        args.captureDevicePath = args.captureDeviceId
+
+if captureMode == "photo":
+    if use_picamera:
+        picam2_still = Picamera2()
+        config = picam2_still.create_still_configuration({"size":(args.vidWidth, args.vidHeight)}, transform=Transform(rotation=args.imageRotation))
+        picam2_still.configure(config)
+        picam2_still.start()
+        time.sleep(2)
+        print(f"Camera is ready in Picamera2 photo mode. Capturing {args.vidWidth}x{args.vidHeight}, {args.imageRotation}° rotation")
+    else:
+        v4l2_cam = cv2.VideoCapture(args.captureDevicePath, cv2.CAP_V4L2)
+        v4l2_cam.set(cv2.CAP_PROP_FRAME_WIDTH, args.vidWidth)
+        v4l2_cam.set(cv2.CAP_PROP_FRAME_HEIGHT, args.vidHeight)
+        if not v4l2_cam.isOpened():
+            sys.exit(f"V4L2 camera at {args.captureDevicePath} failed to open.")
+        time.sleep(2)
+        print(f"Camera is ready in V4L2 photo mode. Capturing {args.vidWidth}x{args.vidHeight}")
+
+elif captureMode == "video":
+    if use_picamera:
+
+        # Sanitize the format codes: Convert GStreamer MIME types (from frontend) to Picamera2 pixel formats
+        # Picamera2 generally needs 'YUV420' as the main stream format to feed the H264 encoder.
+        if args.vidFormat and (args.vidFormat.startswith("video/") or "h264" in args.vidFormat):
+            print(f"Mapping format '{args.vidFormat}' to 'YUV420' for Picamera2", flush=True)
+            args.vidFormat = "YUV420"
+            
+        picam2_vid = Picamera2()
+        video_config = picam2_vid.create_video_configuration(
+            main={
+                "size": (args.vidWidth, args.vidHeight),
+                "format": args.vidFormat},
+                controls={"FrameRate": args.vidFps},
+                transform=Transform(rotation=args.imageRotation)
+            )
+        picam2_vid.configure(video_config)
+        encoder = H264Encoder(bitrate=args.vidBitrate)
+        picam2_vid.start()
+        print(f"Camera is ready in Picamera2 video mode. Capturing {args.vidWidth}x{args.vidHeight} {args.vidFormat} @ {args.vidFps} fps, {args.imageRotation}° rotation")
+    else:
+        v4l2_cam = cv2.VideoCapture(args.captureDevicePath, cv2.CAP_V4L2)
+        if not v4l2_cam.isOpened():
+            sys.exit(f"V4L2 camera at {args.captureDevicePath} failed to open.")
+
+        v4l2_cam.set(cv2.CAP_PROP_FRAME_WIDTH, args.vidWidth)
+        v4l2_cam.set(cv2.CAP_PROP_FRAME_HEIGHT, args.vidHeight)
+        v4l2_cam.set(cv2.CAP_PROP_FPS, args.vidFps)
+
+        # Check if the actual width, height, and FPS were written correctly
+        actual_v4l2_width = int(v4l2_cam.get(cv2.CAP_PROP_FRAME_WIDTH))
+        actual_v4l2_height = int(v4l2_cam.get(cv2.CAP_PROP_FRAME_HEIGHT))
+        actual_v4l2_fps = int(v4l2_cam.get(cv2.CAP_PROP_FPS))
+
+        print(f"Camera is ready in V4L2 video mode. Capturing {actual_v4l2_width}x{actual_v4l2_height} {args.vidFormat} @ {actual_v4l2_fps} fps")
+
+def graceful_exit():
+    global VIDEO_ACTIVE
+    print("Gracefully exiting...")
+    if VIDEO_ACTIVE:
+        startstop_video()
+        time.sleep(0.2)
+    if use_picamera:
+        if picam2_still: picam2_still.stop()
+        if picam2_vid: picam2_vid.stop()
+    elif v4l2_cam:
+        v4l2_cam.release()
+    sys.exit(0)
+
+def startstop_video():
+    global VIDEO_ACTIVE, v4l2_writer
+    if use_picamera:
+        if VIDEO_ACTIVE:
+            picam2_vid.stop_recording()
+            VIDEO_ACTIVE = False
+            print("Picamera2 recording stopped.")
+        else:
+            filepath = os.path.join(mediaPath, time.strftime("RPN%Y%m%d_%H%M%S.h264"))
+            picam2_vid.start_recording(encoder, filepath)
+            VIDEO_ACTIVE = True
+            print(f"Picamera2 recording started to {filepath}")
+    else: # V4L2
+        if VIDEO_ACTIVE:
+            VIDEO_ACTIVE = False
+            if v4l2_writer:
+                v4l2_writer.release()
+                v4l2_writer = None
+                print("V4L2 recording stopped.")
+        else:
+            for _ in range(5): v4l2_cam.read() # Flush buffer
+            filepath = os.path.join(mediaPath, time.strftime("RPN%Y%m%d_%H%M%S.avi"))
+            fourcc = cv2.VideoWriter_fourcc(*'MJPG')
+            v4l2_writer = cv2.VideoWriter(filepath, fourcc, actual_v4l2_fps, (actual_v4l2_width, actual_v4l2_height))
+            if v4l2_writer.isOpened():
+                VIDEO_ACTIVE = True
+                print(f"V4L2 recording started to {filepath}")
+            else:
+                print(f"Error: Could not open VideoWriter for {filepath}", file=sys.stderr)
+
+if __name__ == '__main__':
+    try:
+        while True:
+            if GOT_SIGTERM:
+                GOT_SIGTERM = False
+                graceful_exit()
+
+            if GOT_SIGUSR1:
+                GOT_SIGUSR1 = False
+
+                freeDiskSpace = shutil.disk_usage(mediaPath).free
+                if freeDiskSpace < minFreeSpace and (captureMode == 'photo' or (captureMode == 'video' and not VIDEO_ACTIVE)):
+                    print(f"Free disk space is {(int)(freeDiskSpace / 10**6)} MB, which is less than the minimum of {(int)(minFreeSpace / 10**6)} MB. Action aborted.", flush=True)
+                else:
+                    if captureMode == 'photo':
+                        filepath = os.path.join(mediaPath, time.strftime("RPN%Y%m%d_%H%M%S.jpg"))
+                        print(f"Capturing photo to {filepath}")
+                        if use_picamera:
+                            picam2_still.capture_file(filepath)
+                            print("Photo captured.")
+                            # Geotag the captured photo
+                            geotag_image(filepath)
+                        else:
+                            for _ in range(5): v4l2_cam.read()
+                            ret, frame = v4l2_cam.read()
+                            if ret:
+                                cv2.imwrite(filepath, frame)
+                                print("Photo captured.")
+                                # Geotag the captured photo
+                                geotag_image(filepath)
+                            else:
+                                print("Failed to capture frame from V4L2 camera.", file=sys.stderr)
+                    elif captureMode == 'video':
+                        print("Toggling video recording.")
+                        startstop_video()
+
+            # Main loop with two states: paused and waiting for a signal, or actively recording V4L2 video
+            if use_picamera or not VIDEO_ACTIVE:
+                #print("... Paused, waiting for signal ...", file=sys.stderr)
+                time.sleep(0.1)
+            else:
+                if v4l2_cam and v4l2_writer:
+                    ret, frame = v4l2_cam.read()
+                    if ret:
+                        v4l2_writer.write(frame)
+                    else:
+                        print("V4L2 frame read failed during recording. Stopping.", file=sys.stderr)
+                        startstop_video()
+                time.sleep(0.1)
+
+    except KeyboardInterrupt:
+        graceful_exit()
+    except Exception as e:
+        print(f"!!! PYTHON ERROR: Unhandled exception: {e}", file=sys.stderr)
+        traceback.print_exc(file=sys.stderr)
+        graceful_exit()

--- a/python/setup-venv.sh
+++ b/python/setup-venv.sh
@@ -27,3 +27,6 @@ pip install --upgrade pip
 echo -e "Installing pymavlink..."
 DISABLE_MAVNATIVE=True pip install pymavlink
 
+# Install piexif library for writing image metadata
+echo -e "Installing piexif..."
+pip install piexif

--- a/server/flightController.js
+++ b/server/flightController.js
@@ -3,6 +3,7 @@ const events = require('events')
 const path = require('path')
 const { spawn, spawnSync } = require('child_process')
 
+const { common } = require('node-mavlink')
 const mavManager = require('../mavlink/mavManager.js')
 const logpaths = require('./paths.js')
 const { detectSerialDevices, isModemManagerInstalled, isPi, getSerialPathFromValue } = require('./serialDetection.js')
@@ -76,6 +77,15 @@ class FCDetails {
 
     // mavlink-routerd path
     this.mavlinkRouterPath = null
+    
+    // Store vehicle position received via mavlink
+    this.vehiclePosition = {
+            lat: 0,
+            lon: 0,
+            alt: 0,       // MSL in meters
+            relAlt: 0,    // Relative to home/ground in meters
+            hdg: 0        // Heading in degrees
+    }
 
     // load settings
     this.settings = settings
@@ -249,7 +259,9 @@ class FCDetails {
         conStatus: this.m.conStatusStr(),
         statusText: this.m.statusText,
         byteRate: this.m.statusBytesPerSec.avgBytesSec,
-        fcVersion: this.m.fcVersion
+        fcVersion: this.m.fcVersion,
+        vehiclePosition: this.vehiclePosition
+
       }
     } else {
       return {
@@ -259,7 +271,8 @@ class FCDetails {
         conStatus: 'Not connected',
         statusText: '',
         byteRate: 0,
-        fcVersion: ''
+        fcVersion: '',
+        vehiclePosition: { lat: 0, lon: 0, alt: 0, relAlt: 0, hdg: 0 }
       }
     }
   }
@@ -424,6 +437,16 @@ class FCDetails {
       this.m.eventEmitter.on('gotMessage', (packet, data) => {
         // got valid message - send on to attached classes
         this.previousConnection = true
+        if (packet.header.msgid === common.GlobalPositionInt.MSG_ID) {
+            // MAVLink sends lat/lon as int * 1E7, alt as mm, heading as cdeg
+            if (this.vehiclePosition) {
+                this.vehiclePosition.lat = data.lat / 10000000
+                this.vehiclePosition.lon = data.lon / 10000000
+                this.vehiclePosition.alt = data.alt / 1000
+                this.vehiclePosition.relAlt = data.relativeAlt / 1000
+                this.vehiclePosition.hdg = data.hdg / 100
+            }
+        }
         this.eventEmitter.emit('gotMessage', packet, data)
       })
     }

--- a/server/flightLogger.js
+++ b/server/flightLogger.js
@@ -13,66 +13,113 @@ class flightLogger {
     // this.tlogfolder = path.join(this.topfolder, 'tlogs')
     // this.binlogfolder = path.join(this.topfolder, 'binlogs')
     this.kmzlogfolder = logpaths.kmzDir
+    this.mediafolder = logpaths.mediaDir
     // this.activeLogging = true
     // this.settings = settings
 
     // get settings
     // this.activeLogging = this.settings.value('flightLogger.activeLogging', true)
 
-    // mkdir the log folders (both of them)
+    // mkdir the log and media folders
     fs.mkdirSync(this.topfolder, { recursive: true })
     // fs.mkdirSync(this.binlogfolder, { recursive: true })
     fs.mkdirSync(this.kmzlogfolder, { recursive: true })
+    // and the media folder
+    fs.mkdirSync(this.mediafolder, { recursive: true })
   }
 
   // Delete all logs - tlog or binlog or kmz files
   clearlogs (logtype, curBinLog) {
-    if (logtype === 'tlog') {
-      const files = fs.readdirSync(this.topfolder)
-      files.forEach((file) => {
-        const filePath = path.join(this.topfolder, file)
-        if (filePath.endsWith('.tlog')) {
-          fs.unlinkSync(filePath)
+    function deleteRecursively (targetPath) {
+      const targetStat = fs.lstatSync(targetPath)
+      if (targetStat.isDirectory()) {
+        const entries = fs.readdirSync(targetPath)
+        entries.forEach((entry) => {
+          deleteRecursively(path.join(targetPath, entry))
+        })
+        fs.rmdirSync(targetPath)
+      } else {
+        fs.unlinkSync(targetPath)
+      }
+    }
+
+    function deleteMatchingFiles (dir, matcher) {
+      const entries = fs.readdirSync(dir)
+      entries.forEach((entry) => {
+        const entryPath = path.join(dir, entry)
+        const entryStat = fs.lstatSync(entryPath)
+        if (entryStat.isDirectory()) {
+          deleteMatchingFiles(entryPath, matcher)
+        } else if (matcher(entryPath)) {
+          fs.unlinkSync(entryPath)
         }
       })
+    }
+
+    function removeEmptySubDirs (dir) {
+      const entries = fs.readdirSync(dir)
+      entries.forEach((entry) => {
+        const entryPath = path.join(dir, entry)
+        const stat = fs.lstatSync(entryPath)
+        if (stat.isDirectory()) {
+          removeEmptySubDirs(entryPath)
+          try {
+            fs.rmdirSync(entryPath)
+          } catch (e) {
+            // Directory not empty, skip
+          }
+        }
+      })
+    }
+
+    if (logtype === 'tlog') {
+      deleteMatchingFiles(this.topfolder, (filePath) => filePath.endsWith('.tlog'))
+      removeEmptySubDirs(this.topfolder)
       console.log('Deleted tlogs')
     } else if (logtype === 'binlog') {
-      const files = fs.readdirSync(this.topfolder)
-      files.forEach((file) => {
-        const filePath = path.join(this.topfolder, file)
-        // don't remove the actively logging file
-        if (curBinLog !== filePath && filePath.endsWith('.bin')) {
-          fs.unlinkSync(filePath)
-        }
-      })
+      // Don't delete the actively logging file
+      deleteMatchingFiles(this.topfolder, (filePath) => filePath.endsWith('.bin') && filePath !== curBinLog)
+      removeEmptySubDirs(this.topfolder)
       console.log('Deleted binlogs')
     } else if (logtype === 'kmzlog') {
-      const files = fs.readdirSync(this.kmzlogfolder)
-      files.forEach((file) => {
-        const filePath = path.join(this.kmzlogfolder, file)
-        fs.unlinkSync(filePath)
+      fs.readdirSync(this.kmzlogfolder).forEach((entry) => {
+        deleteRecursively(path.join(this.kmzlogfolder, entry))
       })
       console.log('Deleted kmzlogs')
+    } else if (logtype === 'media') {
+      fs.readdirSync(this.mediafolder).forEach((entry) => {
+        deleteRecursively(path.join(this.mediafolder, entry))
+      })
+      console.log('Deleted all media files and subfolders')
     }
   }
 
-  // find all files in dir
+  // find all files in dir (recursively)
   findInDir (dir, extfilter) {
-    const files = fs.readdirSync(dir)
     const fileList = []
+    const extensions = Array.isArray(extfilter) ? extfilter : [extfilter]
+    const topFolder = this.topfolder
 
-    files.forEach((file) => {
-      const filePath = path.join(dir, file)
-      const fileStat = fs.lstatSync(filePath)
-      const filemTime = new Date(fileStat.mtimeMs)
+    function scanDirectory(currentDir) {
+      const files = fs.readdirSync(currentDir)
 
-      if (!fileStat.isDirectory() && filePath.endsWith(extfilter)) {
-        const relpath = path.relative(this.topfolder, filePath)
-        const mTime = moment(filemTime).format('LLL')
-        fileList.push({ key: relpath, name: path.basename(filePath), modified: mTime, size: Math.round(fileStat.size / 1024) })
-      }
-    })
+      files.forEach((file) => {
+        const filePath = path.join(currentDir, file)
+        const fileStat = fs.lstatSync(filePath)
+        const filemTime = new Date(fileStat.mtimeMs)
 
+        if (fileStat.isDirectory()) {
+          // Recursively scan subdirectories
+          scanDirectory(filePath)
+        } else if (extensions.some(ext => filePath.toLowerCase().endsWith(ext.toLowerCase()))) {
+          const relpath = path.relative(topFolder, filePath)
+          const mTime = moment(filemTime).format('LLL')
+          fileList.push({ key: relpath, name: path.basename(filePath), modified: mTime, size: Math.round(fileStat.size / 1024) })
+        }
+      })
+    }
+
+    scanDirectory(dir)
     return fileList
   }
 
@@ -82,8 +129,9 @@ class flightLogger {
     const newfilestlog = this.findInDir(this.topfolder, '.tlog')
     const newfilesbinlog = this.findInDir(this.topfolder, '.bin')
     const newfileskmzlog = this.findInDir(this.kmzlogfolder, '.kmz')
+    const newfilesmedia = this.findInDir(this.mediafolder, ['.jpg', '.png', '.gif', '.avi', '.mp4', '.h264', '.h265'])
 
-    return callback(false, newfilestlog, newfilesbinlog, newfileskmzlog)
+    return callback(false, newfilestlog, newfilesbinlog, newfileskmzlog, newfilesmedia)
   };
 }
 

--- a/server/flightLogger.test.js
+++ b/server/flightLogger.test.js
@@ -1,29 +1,33 @@
+process.env.NODE_ENV = 'development'
+
 const assert = require('assert')
 const Path = require('path')
 const fs = require('fs')
-const appRoot = require('app-root-path')
-const Logger = require('./flightLogger')
+const os = require('os')
 const logpaths = require('./paths.js')
+
+const testRoot = fs.mkdtempSync(Path.join(os.tmpdir(), 'flightlogger-test-'))
+logpaths.flightsLogsDir = Path.join(testRoot, 'flightlogs')
+logpaths.kmzDir = Path.join(testRoot, 'flightlogs', 'kmzlogs')
+logpaths.mediaDir = Path.join(testRoot, 'media')
+
+const Logger = require('./flightLogger')
 
 describe('Logging Functions', function () {
   beforeEach('Ensure cleared log folder', function () {
-    deleteFolderRecursive(logpaths.flightsLogsDir, '.tlog')
+    if (fs.existsSync(logpaths.flightsLogsDir)) {
+      fs.rmSync(logpaths.flightsLogsDir, { recursive: true, force: true })
+    }
+    if (fs.existsSync(logpaths.mediaDir)) {
+      fs.rmSync(logpaths.mediaDir, { recursive: true, force: true })
+    }
   })
 
-  // Recursively delete folder and files
-  const deleteFolderRecursive = function (path, ext) {
-    if (fs.existsSync(path)) {
-      fs.readdirSync(path).forEach((file) => {
-        const curPath = Path.join(path, file)
-        if (fs.lstatSync(curPath).isDirectory()) { // recurse
-          deleteFolderRecursive(curPath)
-        } else if (curPath.endsWith(ext)) { // delete file
-          fs.unlinkSync(curPath)
-        }
-      })
-      // fs.rmdirSync(path)
+  after(function () {
+    if (fs.existsSync(testRoot)) {
+      fs.rmSync(testRoot, { recursive: true, force: true })
     }
-  }
+  })
 
   it('#loggerinit()', function () {
     const Lgr = new Logger()
@@ -39,6 +43,11 @@ describe('Logging Functions', function () {
     fs.writeFileSync(Path.join(logpaths.flightsLogsDir, 'flight.tlog'), Buffer.from('tést'))
 
     Lgr.clearlogs('tlog', null)
+
+    // ensure kmz log folder exists before clearing kmz logs
+    fs.mkdirSync(logpaths.kmzDir, { recursive: true })
+    fs.writeFileSync(Path.join(logpaths.kmzDir, 'flight.kmz'), Buffer.from('dummy'))
+
     Lgr.clearlogs('binlog', null)
     Lgr.clearlogs('kmzlog', null)
 
@@ -50,13 +59,19 @@ describe('Logging Functions', function () {
   it('#getlogs()', function (done) {
     const Lgr = new Logger()
 
+    // Ensure media directory exists before testing
+    if (!fs.existsSync(logpaths.mediaDir)) {
+      fs.mkdirSync(logpaths.mediaDir, { recursive: true })
+    }
+
     // create a fake log
     fs.writeFileSync(Path.join(logpaths.flightsLogsDir, 'flight.tlog'), Buffer.from('tést'))
 
-    Lgr.getLogs(function (err, tlogs, binlogs, kmzlogs) {
+    Lgr.getLogs(function (err, tlogs, binlogs, kmzlogs, mediafiles) {
       assert.equal(tlogs.length, 1)
       assert.equal(binlogs.length, 0)
       assert.equal(kmzlogs.length, 0)
+      assert.equal(mediafiles.length, 0)
       done()
     })
   })

--- a/server/index.js
+++ b/server/index.js
@@ -25,6 +25,13 @@ const settings = require('settings-store')
 const app = express()
 const http = require('http').Server(app)
 const path = require('path')
+const os = require('os')
+const appRoot = require('app-root-path')  // for resolving relative paths
+
+// MEDIA_ROOT is the default storage area used by the Python helpers.
+// For security, user-provided paths are required to live within it.
+const MEDIA_ROOT = logpaths.mediaDir; // absolute path to rpanion-server/media
+
 
 const io = require('socket.io')(http, { cookie: false })
 const { check, validationResult } = require('express-validator')
@@ -61,7 +68,7 @@ settings.init({
 const vManager = new videoStream(settings)
 const fcManager = new fcManagerClass(settings)
 const logManager = new flightLogger()
-const ntripClient = new ntrip(settings, )
+const ntripClient = new ntrip(settings)
 const cloud = new cloudManager(settings)
 const logConversion = new logConversionManager(settings)
 const adhocManager = new Adhoc(settings)
@@ -120,6 +127,13 @@ async function gracefulShutdown(signal, exitCode = 0) {
     
     // Stop all managed services
     console.log('Stopping managed services...')
+
+    // Stop camera processes cleanly
+    if (vManager) {
+      vManager.stopCamera();
+      console.log('Camera processes stopped');
+    }
+
     pppConnectionManager.quitting()
     cloud.quitting()
     logConversion.quitting()
@@ -177,6 +191,56 @@ ntripClient.eventEmitter.on('rtcmpacket', (msg, seq) => {
   }
 })
 
+
+// Capture a single still photo when in photo mode
+// This code responds to the button on the web interface
+app.post('/api/capturestillphoto', authenticateToken, function (req, res) {
+  if (vManager.active && vManager.cameraMode === 'photo') {
+    console.log("[API /api/capturestillphoto] Conditions met. Calling vManager.captureStillPhoto()");
+    const currentPosition = fcManager.getSystemStatus().vehiclePosition;
+    
+    // Call without MAVLink sender/target info as it's a UI trigger
+    vManager.captureStillPhoto(null, null, null, currentPosition);
+    res.status(200).send({ message: 'Capture signal sent.' });
+  } else {
+    console.log("[API /api/capturestillphoto] Conditions NOT met. Sending 400.");
+    res.status(400).send({ error: 'Camera not active or not in photo mode.' });
+  }
+})
+
+// Toggle local video recording on/off
+// This code responds to the button on the web interface
+app.post('/api/togglevideorecording', authenticateToken, function (req, res) {
+  console.log(`[API /togglevideorecording] Received request. Server state: vManager.active=${vManager.active}, vManager.cameraMode=${vManager.cameraMode}`);
+
+  // Check if active and in the correct mode
+  if (vManager.active && vManager.cameraMode === 'video') {
+    try {
+      vManager.toggleVideoRecording(); // Use the new method name
+      console.log('Toggled video recording via API.');
+      res.status(200).send({ success: true, message: 'Toggle signal sent.' });
+    } catch (err) {
+      console.log('Error toggling video recording:', err);
+      res.status(500).send({ error: 'Failed to send toggle signal.' });
+    }
+  } else {
+    console.log(`[API /togglevideorecording] Condition NOT met (active=${vManager.active}, mode=${vManager.cameraMode}). Sending 400.`);
+    res.status(400).send({ error: 'Camera is not active in video recording mode.' });
+  }
+})
+
+// This function responds to a MAVLink command to capture a photo.
+vManager.eventEmitter.on('digicamcontrol', (senderSysId, senderCompId, targetComponent) => {
+  try {
+    if (fcManager.m) {
+      // Acknowledge the MAV_CMD_DO_DIGICAM_CONTROL command
+      fcManager.m.sendCommandAck(203, 0, senderSysId, senderCompId, targetComponent)
+    }
+  } catch (err) {
+    console.log('Error acknowledging DoDigicamControl:', err);
+  }
+})
+
 // Got a camera heartbeat event, send to flight controller
 vManager.eventEmitter.on('cameraheartbeat', (mavType, autopilot, component) => {
   try {
@@ -184,7 +248,7 @@ vManager.eventEmitter.on('cameraheartbeat', (mavType, autopilot, component) => {
       fcManager.m.sendHeartbeat(mavType, autopilot, component)
     }
   } catch (err) {
-    console.log(err)
+    console.log('Error sending camera heartbeat:', err);
   }
 })
 
@@ -192,11 +256,12 @@ vManager.eventEmitter.on('cameraheartbeat', (mavType, autopilot, component) => {
 vManager.eventEmitter.on('camerainfo', (msg, senderSysId, senderCompId, targetComponent) => {
   try {
     if (fcManager.m) {
+      // Acknowledge the CAMERA_INFORMATION request
       fcManager.m.sendCommandAck(common.CameraInformation.MSG_ID, 0, senderSysId, senderCompId, targetComponent)
       fcManager.m.sendData(msg, senderCompId)
     }
   } catch (err) {
-    console.log(err)
+    console.log('Error sending CameraInformation:', err);
   }
 })
 
@@ -204,13 +269,49 @@ vManager.eventEmitter.on('camerainfo', (msg, senderSysId, senderCompId, targetCo
 vManager.eventEmitter.on('videostreaminfo', (msg, senderSysId, senderCompId, targetComponent) => {
   try {
     if (fcManager.m) {
+      // Acknowledge the VIDEO_STREAM_INFORMATION request
       fcManager.m.sendCommandAck(common.VideoStreamInformation.MSG_ID, 0, senderSysId, senderCompId, targetComponent)
       fcManager.m.sendData(msg, senderCompId)
     }
   } catch (err) {
-    console.log(err)
+    console.log('Error sending VideoStreamInformation:', err);
   }
 })
+
+// Got a CAMERA_SETTINGS event, send to flight controller
+vManager.eventEmitter.on('camerasettings', (msg, senderSysId, senderCompId, targetComponent) => {
+  try {
+    if (fcManager.m) {
+      // Acknowledge the CAMERA_SETTINGS request
+      fcManager.m.sendCommandAck(common.CameraSettings.MSG_ID, 0, senderSysId, senderCompId, targetComponent)
+      fcManager.m.sendData(msg, senderCompId)
+    }
+  } catch (err) {
+    console.log('Error sending CameraSettings:', err);
+    // console.log(err)
+  }
+})
+
+// Got a CAMERA_TRIGGER event, send to flight controller
+vManager.eventEmitter.on('cameratrigger', (msg, senderCompId) => {
+  try {
+    if (fcManager.m) {
+      // Send the CAMERA_TRIGGER message to the flight controller
+      fcManager.m.sendData(msg, senderCompId)
+    }
+  } catch (err) {
+    console.log('Error sending CameraTrigger:', err);
+  }
+})
+
+vManager.eventEmitter.on('filesaved', (filepath) => {
+  try {
+    io.sockets.emit('camera:filesaved', { filename: filepath });
+    console.log('Pushed filesaved to clients:', filepath);
+  } catch (e) {
+    console.error('Failed to emit filesaved:', e);
+  }
+});
 
 // Connecting the flight controller datastream to the logger
 // and ntrip and video
@@ -219,7 +320,7 @@ fcManager.eventEmitter.on('gotMessage', (packet, data) => {
     ntripClient.onMavPacket(packet, data)
     vManager.onMavPacket(packet, data)
   } catch (err) {
-    console.log(err)
+    console.log('Error processing MAVLink message in listener:', err);
   }
 })
 
@@ -731,15 +832,17 @@ app.get('/api/networkclients', authenticateToken, (req, res) => {
 
 // Serve the logfiles
 app.use('/logdownload', express.static(logpaths.flightsLogsDir))
+// Serve the media files
+app.use('/media', express.static(MEDIA_ROOT))
 
 app.get('/api/logfiles', authenticateToken, (req, res) => {
-  logManager.getLogs((err, tlogs, binlogs, kmzlogs) => {
+  logManager.getLogs((err, tlogs, binlogs, kmzlogs, media) => {
     res.setHeader('Content-Type', 'application/json')
-    res.send(JSON.stringify({ TlogFiles: tlogs, BinlogFiles: binlogs, KMZlogFiles: kmzlogs, url: req.protocol + '://' + req.headers.host }))
+    res.send(JSON.stringify({ TlogFiles: tlogs, BinlogFiles: binlogs, KMZlogFiles: kmzlogs, MediaFiles: media, url: req.protocol + '://' + req.headers.host }))
   })
 })
 
-app.post('/api/deletelogfiles', authenticateToken, [check('logtype').isIn(['tlog', 'binlog', 'kmzlog'])], (req, res) => {
+app.post('/api/deletelogfiles', authenticateToken, [check('logtype').isIn(['tlog', 'binlog', 'kmzlog', 'media'])], (req, res) => {
   const errors = validationResult(req)
   if (!errors.isEmpty()) {
     console.log('Bad POST vars in /api/deletelogfiles', { message: JSON.stringify(errors.array()) })
@@ -749,6 +852,11 @@ app.post('/api/deletelogfiles', authenticateToken, [check('logtype').isIn(['tlog
   logManager.clearlogs(req.body.logtype, fcManager.binlog)
   res.setHeader('Content-Type', 'application/json')
   res.send(JSON.stringify({}))
+})
+
+app.get('/api/approot', authenticateToken, (req, res) => {
+  res.setHeader('Content-Type', 'application/json')
+  res.send(JSON.stringify({ appRoot: appRoot.toString() }))
 })
 
 app.get('/api/softwareinfo', authenticateToken, (req, res) => {
@@ -766,42 +874,44 @@ app.get('/api/softwareinfo', authenticateToken, (req, res) => {
 })
 
 app.get('/api/videodevices', authenticateToken, (req, res) => {
-  vManager.getVideoDevices((err, devices, active, seldevice, selRes, selRot, selbitrate,
-                            selfps, SeluseUDPIP, SeluseUDPPort, timestamp,
-                            fps, FPSMax, vidres, useCameraHeartbeat, selMavURI, compression, Seltransport, transportOptions, customRTSPSource) => {
-    if (!err) {
-      res.setHeader('Content-Type', 'application/json')
-      res.send(JSON.stringify({
-        ifaces: vManager.ifaces,
-        dev: devices,
-        vidDeviceSelected: seldevice,
-        vidres: vidres,
-        vidResSelected: selRes,
-        streamingStatus: active,
-        streamAddresses: vManager.deviceAddresses,
-        rotSelected: selRot,
-        bitrate: selbitrate,
-        fpsSelected: selfps,
-        transportSelected: Seltransport,
-        transportOptions: transportOptions,
-        useUDPIP: SeluseUDPIP,
-        useUDPPort: SeluseUDPPort,
-        timestamp,
-        error: null,
-        fps: fps,
-        FPSMax: FPSMax,
-        enableCameraHeartbeat: useCameraHeartbeat,
-        mavStreamSelected: selMavURI,
-        compression: compression,
-        customRTSPSource: customRTSPSource
-      }))
-    } else {
-      res.setHeader('Content-Type', 'application/json')
-      res.send(JSON.stringify({ error: err }))
-      console.log('Error in /api/videodevices ', { message: err })
+
+  vManager.getVideoDevices((err, responseData) => {
+    res.setHeader('Content-Type', 'application/json');
+    if (err) {
+      console.error('Error getting video devices /api/videodevices:', err);
+      // Determine appropriate status code and send minimal fallback data
+      const status = (err === 'No video devices found') ? 404 : 500;
+      return res.status(status).json({
+        error: `Failed to get video devices: ${err}`,
+        active: vManager.active,
+        cameraMode: vManager.cameraMode,
+        networkInterfaces: vManager.scanInterfaces()
+      });
     }
-  })
-})
+    // Send the whole responseData object directly
+    res.send(JSON.stringify(responseData));
+  });
+});
+
+// GET Still Camera Device information
+app.get('/api/camera/still_devices', authenticateToken, (req, res) => {
+  vManager.getStillDevices((err, stillData) => {
+    res.setHeader('Content-Type', 'application/json');
+    if (err) {
+      console.error('Error getting still devices:', err);
+      return res.status(500).json({
+        error: `Failed to get still camera devices: ${err}`,
+        devices: []
+      });
+    }
+
+    // stillData contains { devices, selectedDevice, selectedCap }
+    res.send(JSON.stringify({
+      ...stillData,
+      error: null
+    }));
+  });
+});
 
 app.get('/api/hardwareinfo', authenticateToken, (req, res) => {
   aboutPage.getHardwareInfo((RAM, CPU, hatData, sysData, err) => {
@@ -1075,49 +1185,144 @@ app.get('/api/networkconnections', authenticateToken, (req, res) => {
   })
 })
 
-app.post('/api/startstopvideo', authenticateToken, [check('active').isBoolean(),
-  check('device').if(check('active').isIn([true])).isLength({ min: 2 }),
-  check('height').if(check('active').isIn([true])).isInt({ min: 1 }),
-  check('width').if(check('active').isIn([true])).isInt({ min: 1 }),
-  check('transport').if(check('active').isIn([true])).isIn(['RTP', 'RTSP']),
-  check('useTimestamp').if(check('active').isIn([true])).isBoolean(),
-  check('useCameraHeartbeat').if(check('active').isIn([true])).isBoolean(),
-  check('useUDPPort').if(check('active').isIn([true])).isPort(),
-  check('useUDPIP').if(check('active').isIn([true])).isIP(),
-  check('bitrate').if(check('active').isIn([true])).isInt({ min: 50, max: 50000 }),
-  check('format').if(check('active').isIn([true])).isIn(['video/x-raw', 'video/x-h264', 'video/x-h265', 'image/jpeg']),
-  check('fps').if(check('active').isIn([true])).isInt({ min: -1, max: 100 }),
-  check('rotation').if(check('active').isIn([true])).isInt().isIn([0, 90, 180, 270])],
-  check('compression').if(check('active').isIn([true])).isIn(['H264', 'H265']),
-  check('customRTSPSource').if(check('active').isIn([true])).custom((value) => {
-    if (value === '' || value === null || value === undefined) {
+// POST to START a specific camera mode (streaming, photo, video)
+app.post('/api/camera/start', authenticateToken, [
+  check('cameraMode').isIn(['streaming', 'photo', 'video']),
+  check('useCameraHeartbeat').isBoolean(),
+  // Validation for modes that use a video pipeline ('streaming' or 'video')
+  check('videoDevice').if(check('cameraMode').isIn(['streaming', 'video'])).isString().notEmpty(),
+  check('height').if(check('cameraMode').isIn(['streaming', 'video'])).isInt({ min: 1 }),
+  check('width').if(check('cameraMode').isIn(['streaming', 'video'])).isInt({ min: 1 }),
+  check('bitrate').if(check('cameraMode').isIn(['streaming', 'video'])).isInt({ min: 50, max: 50000 }),
+  check('fps').if(check('cameraMode').isIn(['streaming', 'video'])).isInt({ min: 0, max: 120 }),
+  check('rotation').if(check('cameraMode').isIn(['streaming', 'video'])).isInt().isIn([0, 90, 180, 270]),
+  // Validation ONLY for 'photo' mode
+  check('stillDevice').if(check('cameraMode').equals('photo')).isString().notEmpty(),
+  check('stillWidth').if(check('cameraMode').equals('photo')).isInt({ min: 1 }),
+  check('stillHeight').if(check('cameraMode').equals('photo')).isInt({ min: 1 }),
+  // Media destination for photo and video modes (optional, but validate if provided)
+  check('mediaDestination')
+    .if(check('cameraMode').isIn(['photo', 'video']))
+    .optional({ checkFalsy: true }) // Allow blank inputs (to save to MEDIA_ROOT without a subdir)
+    .isString()
+    .trim()
+    .customSanitizer(dest => {
+      // For ease of use:
+      // If the user pasted the full absolute media path, strip it down to just the folder name
+      if (dest.startsWith(MEDIA_ROOT)) {
+        dest = dest.slice(MEDIA_ROOT.length);
+      }
+      // Also for ease of use:
+      // Strip leading slashes so that if an absolute path is entered
+      // by mistake, it's converted to a relative path instead of being rejected
+      return dest.replace(/^[\/\\]+/, '');
+    })
+      // Check for path traversal attemptsa and null characters
+    .custom(dest => {
+      if (dest.includes('\0')) {
+        throw new Error('Media Destination contains invalid characters');
+      }
+      if (dest.includes('..')) {
+        throw new Error('Directory traversal is not allowed');
+      }
+      // Final check that an absolute path didn't make it through the sanitizer
+      if (path.isAbsolute(dest)) {
+        throw new Error('Media Destination must be a relativefolder name, not an absolute path');
+      }
       return true;
-    }
-    return check('customRTSPSource').isURL().run({ body: { customRTSPSource: value } });
-  }), (req, res) => {
-  const errors = validationResult(req)
+    })
+], (req, res) => {
+  console.log("--- Received /api/camera/start request ---");
+  const errors = validationResult(req);
+
   if (!errors.isEmpty()) {
-    console.log('Bad POST vars in /api/startstopvideo ', { message: errors.array() })
-    const ret = { streamingStatus: false, streamAddresses: [], error: ['Error ' + JSON.stringify(errors.array())] }
-    return res.status(422).json(ret)
+ console.error('Validation failed for /api/camera/start:', errors.array());
+    return res.status(422).json({ error: 'Invalid media destination', details: errors.array() });
   }
-  // user wants to start/stop video streaming
-  vManager.startStopStreaming(req.body.active, req.body.device, req.body.height, req.body.width, req.body.format, req.body.rotation,
-                              req.body.bitrate, req.body.fps, req.body.transport, req.body.useUDPIP, req.body.useUDPPort,
-                              req.body.useTimestamp, req.body.useCameraHeartbeat, req.body.mavStreamSelected, req.body.compression,
-                              req.body.customRTSPSource, (err, status, addresses) => {
-    if (!err) {
-      res.setHeader('Content-Type', 'application/json')
-      const ret = { streamingStatus: status, streamAddresses: addresses }
-      res.send(JSON.stringify(ret))
-    } else {
-      res.setHeader('Content-Type', 'application/json')
-      const ret = { streamingStatus: false, streamAddresses: ['Error ' + err] }
-      res.send(JSON.stringify(ret))
-      console.log('Error in /api/startstopvideo ', { message: err })
+
+  const mode = req.body.cameraMode;
+  vManager.cameraMode = mode;
+  vManager.useCameraHeartbeat = req.body.useCameraHeartbeat;
+
+// Sanitize the user-provided media destination
+  let safeMediaDestination = null;
+    if (req.body.mediaDestination) {
+
+      // Force the input into a string format
+      const userInput = String(req.body.mediaDestination);
+
+      // Explicitly check for traversal strings inline
+      if (userInput.includes('..') || userInput.includes('\0')) {
+        return res.status(403).json({ error: 'Path traversal characters detected' });
+      }
+
+      const targetPath = path.join(MEDIA_ROOT, userInput);
+
+      const relative = path.relative(MEDIA_ROOT, targetPath);
+      // Double-check strict path boundaries to prevent any evasion
+      if (relative.startsWith('..') || path.isAbsolute(relative)) {
+        return res.status(403).json({ error: 'Invalid media destination path boundaries' });
+      }
+
+      // Store only the path relative to the media directory
+      safeMediaDestination = relative === '.' ? '' : relative;
+      
     }
-  })
-})
+
+  // Map incoming request to the internal settings objects used by videostream.js
+  if (mode === 'streaming' || mode === 'video') {
+    vManager.videoSettings = {
+      device: req.body.videoDevice,
+      isRecording: req.body.isRecording === false || req.body.isRecording === 'false',
+      height: parseInt(req.body.height, 10),
+      width: parseInt(req.body.width, 10),
+      format: req.body.format,
+      bitrate: parseInt(req.body.bitrate, 10),
+      fps: parseInt(req.body.fps, 10),
+      rotation: parseInt(req.body.rotation, 10),
+      useUDP: req.body.useUDP === true || req.body.useUDP === 'true',
+      useUDPIP: req.body.useUDPIP,
+      useUDPPort: parseInt(req.body.useUDPPort, 10),
+      useTimestamp: req.body.useTimestamp === true || req.body.useTimestamp === 'true',
+      mavStreamSelected: req.body.mavStreamSelected,
+      compression: req.body.compression,
+      mediaDestination: safeMediaDestination
+    };
+  } else if (mode === 'photo') {
+    vManager.stillSettings = {
+      device: req.body.stillDevice,
+      width: parseInt(req.body.stillWidth, 10),
+      height: parseInt(req.body.stillHeight, 10),
+      format: req.body.stillFormat,
+      mediaDestination: safeMediaDestination
+    };
+  }
+
+  // Persist the selected media destination and mode settings immediately.
+  vManager.saveSettings();
+
+  vManager.startCamera((err, result) => {
+    res.setHeader('Content-Type', 'application/json');
+    if (err) {
+      // Use %s for the mode variable so it is treated as data, not a format string
+      console.error(`Error starting camera in %s mode:`, mode, err);
+      return res.status(500).json({ error: err.message || err });
+    }
+    res.send(JSON.stringify({ ...result, error: null }));
+  });
+});
+
+// POST to STOP the currently active camera mode
+app.post('/api/camera/stop', authenticateToken, (req, res) => {
+  vManager.stopCamera((err, active) => {
+    res.setHeader('Content-Type', 'application/json');
+    if (err) {
+      console.error('Error stopping camera:', err);
+      return res.status(500).json({ error: 'Failed to stop camera cleanly' });
+    }
+    res.send(JSON.stringify({ active: active, error: null }));
+  });
+});
 
 // Get details of a network connection by connection ID
 app.post('/api/networkIP', authenticateToken, [check('conName').isUUID()], (req, res) => {

--- a/server/paths.js
+++ b/server/paths.js
@@ -29,5 +29,6 @@ module.exports = {
     settingsFile: path.join(baseDir, 'config', 'settings.json'),
     flightsLogsDir: path.join(baseDir, 'flightlogs'),
     kmzDir: path.join(baseDir, 'flightlogs', 'kmzlogs'),
+    mediaDir: path.join(baseDir, 'media'),
     getPythonPath: getPythonPath,
 };

--- a/server/videostream.js
+++ b/server/videostream.js
@@ -1,63 +1,107 @@
 const { exec, execSync, spawn } = require('child_process')
 const os = require('os')
+const path = require('path')
 const si = require('systeminformation')
 const events = require('events')
 const { minimal, common } = require('node-mavlink')
 const logpaths = require('./paths.js')
+const fs = require('fs')
 
 class videoStream {
   constructor (settings) {
+    this.settings = settings
+
+    // Properties used in all modes
     this.active = false
     this.deviceStream = null
     this.deviceAddresses = []
-    this.devices = null
-    this.settings = settings
-    this.savedDevice = null
-
-    // For sending events outside of object
-    this.eventEmitter = new events.EventEmitter()
+    this.cameraMode = null; // 'streaming', 'photo', or 'video'
+    this.photoSeq = 0;
 
     // Interval to send camera heartbeat events
-    this.intervalObj = null
+    this.intervalObj = null;
+    this.eventEmitter = new events.EventEmitter()
 
-    // load settings. savedDevice is a json object storing all settings
-    this.active = this.settings.value('videostream.active', false)
-    this.savedDevice = this.settings.value('videostream.savedDevice', null)
+    // Mode-specific hardware lists/settings
+    this.devices = null;      // Video devices
+    this.stillDevices = null; // Still devices
+    this.videoSettings = null;
+    this.stillSettings = null;
+
+    // Load saved settings from the 'camera' namespace
+    this.active = this.settings.value('camera.active', false);
+    this.cameraMode = this.settings.value('camera.mode', 'streaming');
+    this.useCameraHeartbeat = this.settings.value('camera.useHeartbeat', false);
+
+    // Load specific settings based on mode
+    this.videoSettings = this.settings.value('camera.videoSettings', null);
+    this.stillSettings = this.settings.value('camera.stillSettings', null);
 
     // if it's an active device, stop then start it up
     // need to scan for video devices first though
     if (this.active) {
       this.active = false
-      this.initializeVideo()
+      this.initialize()
     }
   }
 
-  async initializeVideo() {
-    // Initialize video streaming on startup using promises to avoid race conditions
+  // Convert destination to relative path form for storage and UI display.
+  // Any absolute path or empty value is converted to a relative path under mediaDir.
+  //
+  // e.g., 'subdir' stays as 'subdir'
+  // and '/abs/path' is stored as a relative path under mediaDir
+  toRelativePath(dest) {
+    if (!dest || dest === '.') return '';
+    if (path.isAbsolute(dest)) {
+      dest = path.relative(logpaths.mediaDir, dest);
+      if (dest === '.') return '';
+    }
+    return dest;
+  }
+
+  // Convert relative path to absolute before it is passed to Python.
+  // Returns the media root directory if no destination is provided.
+  toAbsolutePath(dest) {
+    dest = this.toRelativePath(dest);
+    return dest ? path.join(logpaths.mediaDir, dest) : logpaths.mediaDir;
+  }
+
+  async initialize() {
     try {
-      await this.getVideoDevicesPromise()
-      await this.startStopStreamingPromise(
-        true,
-        this.savedDevice.device,
-        this.savedDevice.height,
-        this.savedDevice.width,
-        this.savedDevice.format,
-        this.savedDevice.rotation,
-        this.savedDevice.bitrate,
-        this.savedDevice.fps,
-        this.savedDevice.transport,
-        this.savedDevice.useUDPIP,
-        this.savedDevice.useUDPPort,
-        this.savedDevice.useTimestamp,
-        this.savedDevice.useCameraHeartbeat,
-        this.savedDevice.mavStreamSelected,
-        this.savedDevice.compression,
-        this.savedDevice.customRTSPSource
-      )
+      // Discover Video Hardware and wait for data
+      await new Promise((resolve, reject) => {
+        this.getVideoDevices((err, data) => {  // Get the data
+          if (err) {
+            reject(err);
+          } else {
+            // this.devices is now populated inside getVideoDevices callback
+            resolve();
+          }
+        });
+      });
+
+      // 2. Discover Still Photo Hardware (We will add this function in Step 2)
+      // For now, we wrap it in a try/catch so it doesn't crash if the helper isn't there yet
+      try {
+        await new Promise((resolve, reject) => {
+          this.getStillDevices((err) => err ? reject(err) : resolve());
+        });
+      } catch (e) {
+        console.log("Still hardware discovery skipped or failed.");
+      }
+
+      // 3. Start the camera in the last saved mode
+      this.startCamera((err) => {
+        if (err) {
+          console.error('Camera start error during init:', err);
+          this.resetCamera();
+        } else {
+          this.active = true;
+        }
+      });
     } catch (error) {
-      // failed setup, reset settings
-      console.log('Reset video - initialization failed:', error)
-      this.resetVideo()
+      console.log('Resetting camera - initialization failed:', error);
+      this.resetCamera();
     }
   }
 
@@ -74,24 +118,31 @@ class videoStream {
     })
   }
 
-  startStopStreamingPromise(active, device, height, width, format, rotation, bitrate, fps, transport, useUDPIP, useUDPPort, useTimestamp, useCameraHeartbeat, mavStreamSelected, compression, customRTSPSource) {
-    // Promise wrapper for startStopStreaming
+  startCameraPromise() {
     return new Promise((resolve, reject) => {
-      this.startStopStreaming(active, device, height, width, format, rotation, bitrate, fps, transport, useUDPIP, useUDPPort, useTimestamp, useCameraHeartbeat, mavStreamSelected, compression, customRTSPSource, (err, active, addresses) => {
+      this.startCamera((err, result) => {
         if (err) {
           reject(err)
         } else {
-          resolve({ active, addresses })
+          resolve(result)
         }
       })
     })
   }
+
 
   // Format and store all the possible rtsp addresses
   populateAddresses (factory) {
     // set up the avail addresses
     this.ifaces = this.scanInterfaces()
     this.deviceAddresses = []
+
+    // Remove leading slash if it exists to prevent double slashes
+    let mountPoint = factory.toString();
+    if (mountPoint.startsWith('/')) {
+      mountPoint = mountPoint.substring(1);
+    }
+
     for (let j = 0; j < this.ifaces.length; j++) {
       if (factory.includes('rtsp://')) {
         // remove any rtsp username or passwords, format rtsp://admin:admin@192.168.1.217:554/11
@@ -148,128 +199,193 @@ class videoStream {
   getVideoDevices (callback) {
     // get all video device details
     //dont update if streaming is running, as some camera won't be detected if in use
+    const networkInterfaces = this.scanInterfaces();
+
+    // Don't re-scan hardware if a stream is already running
     if (this.deviceStream !== null) {
-      return callback(null, this.devices, this.active, this.savedDevice.device, this.savedDevice.width.toString() + 'x' + this.savedDevice.height.toString() + 'x' + this.savedDevice.format.toString().split('/')[1],
-        this.savedDevice.rotation,
-        this.savedDevice.bitrate,
-        this.savedDevice.fps,
-        this.savedDevice.useUDPIP,
-        this.savedDevice.useUDPPort,
-        this.savedDevice.useTimestamp,
-        (this.devices.filter(it => it.value === this.savedDevice.device)[0].caps.filter(it => it.value === this.savedDevice.width.toString() + 'x' + this.savedDevice.height.toString() + 'x' + this.savedDevice.format.toString().split('/')[1])[0].fps !== undefined) ? this.devices.filter(it => it.value === this.savedDevice.device)[0].caps.filter(it => it.value === this.savedDevice.width.toString() + 'x' + this.savedDevice.height.toString() + 'x' + this.savedDevice.format.toString().split('/')[1])[0].fps : [],
-        this.devices.filter(it => it.value === this.savedDevice.device)[0].caps.filter(it => it.value === this.savedDevice.width.toString() + 'x' + this.savedDevice.height.toString() + 'x' + this.savedDevice.format.toString().split('/')[1])[0].fpsmax,
-        this.devices.filter(it => it.value === this.savedDevice.device)[0].caps,
-        this.savedDevice.useCameraHeartbeat,
-        { label: this.savedDevice.mavStreamSelected.toString(), value: this.savedDevice.mavStreamSelected },
-        this.savedDevice.compression,
-        this.savedDevice.transport,
-        this.getTransportOptions(),
-        this.savedDevice.customRTSPSource)
-    }
-    // callback is: err, devices, active, seldevice, selRes, selRot, selbitrate, selfps, SeluseUDPIP, SeluseUDPPort, timestamp, fps, FPSMax, vidres, cameraHeartbeat, selMavURI, compression, transport, transportOptions, customRTSPSource
-    const pythonPath = logpaths.getPythonPath()
-    exec(`${pythonPath} ./python/gstcaps.py`, (error, stdout, stderr) => {
-      const warnstrings = ['DeprecationWarning', 'gst_element_message_full_with_details', 'camera_manager.cpp', 'Unsupported V4L2 pixel format']
-      if (stderr && !warnstrings.some(wrn => stderr.includes(wrn))) {
-        console.error(`exec error: ${error}`)
-        return callback(stderr)
-      } else {
-        console.log(stdout)
-        this.devices = JSON.parse(stdout)
-        // add rtsp source
-        this.devices.push({ label: 'RTSP Source (H.264)', value: 'rtspsourceh264', caps: [
-          {
-            label: 'Custom RTSP Source', value: '1x1xx-h264', width: 1, height: 1, format: 'video/x-h264',
-            fps: [{ label: 'N/A', value: 1 }], fpsmax: 0
-          }
-        ]
-        })
-        this.devices.push({ label: 'RTSP Source (H.265)', value: 'rtspsourceh265', caps: [
-          {
-            label: 'Custom RTSP Source', value: '1x1xx-h265', width: 1, height: 1, format: 'video/x-h265',
-            fps: [{ label: 'N/A', value: 1 }], fpsmax: 0
-          }
-        ]
-        })
-        //console.log(this.devices)
-        const fpsSelected = ((this.devices.length > 0) ? (this.devices[0].caps[0].fpsmax === 0 ? this.devices[0].caps[0].fps[0] : this.devices[0].caps[0].fpsmax) : 1)
-        // and return current settings
-        if (!this.active) {
-          return callback(null, this.devices, this.active, this.devices[0].value, this.devices[0].caps[0].value,
-            0, 1100, fpsSelected, '127.0.0.1', 5400, false,
-            (this.devices[0].caps[0].fps !== undefined) ? this.devices[0].caps[0].fps : [],
-            this.devices[0].caps[0].fpsmax, this.devices[0].caps, false, '127.0.0.1',
-            'H264', 'RTSP', this.getTransportOptions(), "")
-        } else {
-          // format saved settings
-          const seldevice = this.devices.filter(it => it.value === this.savedDevice.device)
-          if (seldevice.length !== 1) {
-            // bad settings
-            console.error('Bad video settings1 Resetting')
-            // if video is active but bad settings, reset
-            if (this.active) {
-              //stop streaming
-              this.startStopStreaming(false, '', 0, 0, '', 0, 0, 0, '', '', 0, false, false, '', '', '', () => {
-                console.log('Stopped streaming due to bad settings')
-              })
-            }
-            this.resetVideo()
-            return callback(null, this.devices, this.active, this.devices[0].value, this.devices[0].caps[0].value,
-              0, 1100, fpsSelected, '127.0.0.1', 5400, false,
-              (this.devices[0].caps[0].fps !== undefined) ? this.devices[0].caps[0].fps : [],
-              this.devices[0].caps[0].fpsmax, this.devices[0].caps, false, '127.0.0.1',
-              'H264', 'RTSP', this.getTransportOptions(), "")
-          }
-          const selRes = seldevice[0].caps.filter(it => it.value === this.savedDevice.width.toString() + 'x' + this.savedDevice.height.toString() + 'x' + this.savedDevice.format.toString().split('/')[1])
-          let selFPS = this.savedDevice.fps
-          if (selRes.length === 1 && selRes[0].fpsmax !== undefined && selRes[0].fpsmax === 0) {
-            selFPS = selRes[0].fps.filter(it => parseInt(it.value) === this.savedDevice.fps)[0]
-          }
-          if (seldevice.length === 1 && selRes.length === 1) {
-            if (seldevice[0].value === 'rtspsourceh264' || seldevice[0].value === 'rtspsourceh265') {
-              // for rtsp source, override format to match
-              console.log('Populate RTSP Source addresses: ' + this.savedDevice.customRTSPSource)
-              this.populateAddresses(this.savedDevice.customRTSPSource)
-            } else {
-              this.populateAddresses(seldevice[0].value.toString())
-            }
-            //console.log(seldevice[0])
-            return callback(null, this.devices, this.active, seldevice[0].value, selRes[0].value,
-              this.savedDevice.rotation,
-              this.savedDevice.bitrate, selFPS, this.savedDevice.useUDPIP,
-              this.savedDevice.useUDPPort, this.savedDevice.useTimestamp, (selRes[0].fps !== undefined) ? selRes[0].fps : [],
-              selRes[0].fpsmax, seldevice[0].caps, this.savedDevice.useCameraHeartbeat,
-              { label: this.savedDevice.mavStreamSelected.toString(), value: this.savedDevice.mavStreamSelected },
-              this.savedDevice.compression, this.savedDevice.transport, this.getTransportOptions(), this.savedDevice.customRTSPSource)
-          } else {
-            // bad settings
-            console.error('Bad video settings. Resetting ' + JSON.stringify(seldevice) + ', ' + selRes.toString())
-            this.resetVideo()
-            return callback(null, this.devices, this.active, this.devices[0].value, this.devices[0].caps[0].value,
-              0, 1100, fpsSelected, '127.0.0.1', 5400, false,
-              (this.devices[0].caps[0].fps !== undefined) ? this.devices[0].caps[0].fps : [],
-              this.devices[0].caps[0].fpsmax, this.devices[0].caps, false, '127.0.0.1',
-              'H264', 'RTSP', this.getTransportOptions(), "")
-          }
+      console.log("Camera active; returning cached hardware details.");
+
+      const responseData = {
+        devices: this.devices || [],
+        networkInterfaces: networkInterfaces,
+        active: this.active,
+        cameraMode: this.cameraMode,
+        streamAddresses: this.deviceAddresses,
+        selectedDevice: null,
+        selectedCap: null,
+        resolutionCaps: [],
+        fpsOptions: [],
+        fpsMax: 0
+      };
+
+      // 1. Find the device and capability currently being used
+      if (this.videoSettings && this.devices) {
+        responseData.selectedDevice = this.devices.find(d => d.value === this.videoSettings.device);
+        if (responseData.selectedDevice) {
+          // Safeguard the format string against missing slashes for V4L2 raw modes
+          const formatStr = this.videoSettings.format || "";
+          const formatShort = formatStr.includes('/') ? formatStr.split('/')[1] : formatStr;
+          const capVal = `${this.videoSettings.width}x${this.videoSettings.height}x${formatShort}`;
+
+          responseData.selectedCap = responseData.selectedDevice.caps.find(cap => cap.value === capVal);
+          responseData.resolutionCaps = responseData.selectedDevice.caps;
+          responseData.fpsMax = responseData.selectedCap?.fpsmax || 0;
+          responseData.fpsOptions = responseData.selectedCap?.fps || [];
         }
+
+        // 2. Map raw numbers back to the UI's Object format
+        responseData.selectedRotation = {
+          label: (this.videoSettings.rotation || 0) + '°',
+          value: (this.videoSettings.rotation || 0)
+        };
+        responseData.selectedMavStreamURI = {
+          label: this.videoSettings.mavStreamSelected?.toString() || '127.0.0.1',
+          value: this.videoSettings.mavStreamSelected || '127.0.0.1'
+        };
+
+        // 3. Map simple values
+        responseData.selectedisRecording = this.videoSettings.isRecording || false;
+        responseData.selectedBitrate = this.videoSettings.bitrate || 1100;
+        responseData.selectedFps = this.videoSettings.fps || 30;
+        responseData.selectedUseUDP = this.videoSettings.useUDP || false;
+        responseData.selectedUseUDPIP = this.videoSettings.useUDPIP || '127.0.0.1';
+        responseData.selectedUseUDPPort = this.videoSettings.useUDPPort || 5600;
+        responseData.selectedUseTimestamp = this.videoSettings.useTimestamp || false;
+        responseData.selectedUseCameraHeartbeat = this.useCameraHeartbeat || false;
+
+        // Return an empty string if no media destination is given.
+        responseData.videoMediaDestination = this.toRelativePath(this.videoSettings?.mediaDestination || '');
       }
-    })
-  }
 
-  // reset and save the video settings
-  resetVideo () {
-    this.active = false
-    this.savedDevice = null
-    try {
-      this.settings.setValue('videostream.active', this.active)
-      this.settings.setValue('videostream.savedDevice', this.savedDevice)
-    } catch (e) {
-      console.log(e)
+      return callback(null, responseData);
     }
-    console.log('Reset Video Settings')
+
+    // If not streaming, proceed with hardware discovery
+    const pythonPath = logpaths.getPythonPath();
+    exec(`${pythonPath} ./python/gstcaps.py`, (error, stdout, stderr) => {
+      const responseData = {
+        devices: [],
+        networkInterfaces: networkInterfaces,
+        active: false,
+        cameraMode: this.cameraMode,
+        streamAddresses: [],
+        selectedDevice: null,
+        selectedCap: null,
+        selectedRotation: { label: '0°', value: 0 },
+        selectedBitrate: 1100,
+        selectedFps: null,
+        selectedUseUDP: false,
+        selectedUseUDPIP: '127.0.0.1',
+        selectedUseUDPPort: 5400,
+        selectedIsRecording: false,
+        selectedUseTimestamp: false,
+        fpsOptions: [],
+        fpsMax: 0,
+        resolutionCaps: [],
+        selectedUseCameraHeartbeat: this.useCameraHeartbeat,
+        selectedMavStreamURI: { label: '127.0.0.1', value: '127.0.0.1' },
+        videoMediaDestination: this.toRelativePath(this.videoSettings?.mediaDestination || '')
+      };
+
+      const warnstrings = ['DeprecationWarning', 'gst_element_message_full_with_details', 'camera_manager.cpp', 'Unsupported V4L2 pixel format'];
+      if (stderr && !warnstrings.some(wrn => stderr.includes(wrn))) {
+        return callback(stderr, responseData);
+      }
+
+      try {
+        const devices = JSON.parse(stdout);
+        // Add RTSP mocks
+        devices.push({ label: 'RTSP Source (H.264)', value: 'rtspsourceh264', caps: [{ label: 'Custom RTSP Source', value: '1x1xx-h264', width: 1, height: 1, format: 'video/x-h264', fps: [{ label: 'N/A', value: 1 }], fpsmax: 0 }] });
+        devices.push({ label: 'RTSP Source (H.265)', value: 'rtspsourceh265', caps: [{ label: 'Custom RTSP Source', value: '1x1xx-h265', width: 1, height: 1, format: 'video/x-h265', fps: [{ label: 'N/A', value: 1 }], fpsmax: 0 }] });
+
+        this.devices = devices;
+        responseData.devices = devices;
+
+        // Populate defaults or saved settings as before...
+        let selectedDevice = devices[0];
+        let selectedCap = selectedDevice?.caps[0];
+
+        responseData.selectedDevice = selectedDevice;
+        responseData.selectedCap = selectedCap;
+        responseData.resolutionCaps = selectedDevice?.caps || [];
+        responseData.fpsOptions = selectedCap?.fps || [];
+        responseData.fpsMax = selectedCap?.fpsmax || 0;
+        responseData.selectedFps = responseData.fpsMax > 0 ? responseData.fpsMax : (responseData.fpsOptions[0]?.value ?? 30);
+
+        return callback(null, responseData);
+      } catch (e) {
+        return callback('Failed to process video devices', responseData);
+      }
+    });
   }
 
-  scanInterfaces () {
+  getStillDevices(callback) {
+    const defaultResponse = {
+      devices: [],
+      capabilities: { cv2: false, picamera2: false },
+      selectedDevice: undefined,
+      selectedCap: undefined,
+      stillMediaDestination: ''
+    };
+
+    const pythonPath = logpaths.getPythonPath();
+    exec(`${pythonPath} ./python/get_camera_caps.py`, (error, stdout, stderr) => {
+      if (error) return callback(stderr || error.message, defaultResponse);
+
+      try {
+        const output = JSON.parse(stdout);
+        const cameraDevices = output.devices || [];
+        const capabilities = output.capabilities || { cv2: false, picamera2: false };
+        
+        this.stillDevices = cameraDevices;
+
+        const defaultDevice = cameraDevices.find(dev => dev.caps && dev.caps.length > 0);
+        const defaultCap = defaultDevice?.caps[0];
+        const stillMediaDestination = this.toRelativePath(this.stillSettings?.mediaDestination || '');
+
+        return callback(null, {
+          devices: cameraDevices,
+          capabilities: capabilities,
+          selectedDevice: defaultDevice,
+          selectedCap: defaultCap,
+          stillMediaDestination
+        });
+      } catch (e) {
+        return callback('Invalid JSON from get_camera_caps.py', defaultResponse);
+      }
+    });
+  }
+
+
+  saveSettings() {
+    try {
+      this.settings.setValue('camera.active', this.active);
+      this.settings.setValue('camera.mode', this.cameraMode);
+      this.settings.setValue('camera.useHeartbeat', this.useCameraHeartbeat);
+      this.settings.setValue('camera.videoSettings', this.videoSettings);
+      this.settings.setValue('camera.stillSettings', this.stillSettings);
+    } catch (e) {
+      console.error('Error saving camera settings:', e);
+    }
+  }
+
+  resetCamera() {
+    this.active = false;
+    this.videoSettings = null;
+    this.stillSettings = null;
+    try {
+      this.settings.setValue('camera.active', false);
+      this.settings.setValue('camera.mode', 'streaming');
+      this.settings.setValue('camera.videoSettings', null);
+      this.settings.setValue('camera.stillSettings', null);
+      this.settings.setValue('camera.useHeartbeat', false);
+    } catch (e) {
+      console.log('Error saving reset settings:', e);
+    }
+    console.log('Camera System Reset');
+  }
+
+  scanInterfaces() {
     // scan for available IP (v4 only) interfaces
     const iface = []
     const ifaces = os.networkInterfaces()
@@ -292,138 +408,280 @@ class videoStream {
     return iface
   }
 
-  async startStopStreaming (active, device, height, width, format, rotation, bitrate, fps, transport, useUDPIP, useUDPPort, useTimestamp, useCameraHeartbeat, mavStreamSelected, compression, customRTSPSource, callback) {
-    // if current state same, don't do anything
-    if (this.active === active) {
-      console.log('Video current same')
-      return callback(null, this.active, this.deviceAddresses)
+  startCamera(callback) {
+    console.log(`Attempting to start camera in mode: ${this.cameraMode}`);
+    try {
+      if (this.cameraMode === 'streaming') {
+        // startVideoStreaming is async, so we must catch rejections
+        this.startVideoStreaming(callback).catch(err => {
+          console.error("Async Start Error:", err);
+          callback(err);
+        });
+      } else if (this.cameraMode === 'photo') {
+        this.startPhotoMode(callback);
+      } else if (this.cameraMode === 'video') {
+        this.startVideoMode(callback);
+      } else {
+        callback(new Error(`Unsupported camera mode: ${this.cameraMode}`));
+      }
+    } catch (syncErr) {
+      console.error("Sync Start Error:", syncErr);
+      callback(syncErr);
     }
-    // user wants to start or stop streaming
-    if (active) {
-      // check it's a valid video device
-      let found = false
-      if (this.devices !== null) {
-        for (let j = 0; j < this.devices.length; j++) {
-          if (device === this.devices[j].value) {
-            found = true
+  }
+
+  async startVideoStreaming(callback) {
+    if (!this.videoSettings) return callback(new Error('No video settings provided'));
+
+    let device = this.videoSettings.device;
+    let format = this.videoSettings.format;
+
+    // Ubuntu RPI camera mapping
+    if (await this.isUbuntu() && device === 'rpicam') {
+      device = '/dev/video0';
+      format = 'video/x-raw';
+    }
+
+    this.populateAddresses(this.videoSettings.device);
+
+    const args = [
+      '-u', // force the stdout and stderr streams to be unbuffered
+      './python/video-server.py',
+      '--video=' + device,
+      '--height=' + this.videoSettings.height,
+      '--width=' + this.videoSettings.width,
+      '--format=' + format,
+      '--bitrate=' + this.videoSettings.bitrate,
+      '--rotation=' + this.videoSettings.rotation,
+      '--fps=' + this.videoSettings.fps,
+      '--udp=' + (this.videoSettings.useUDP ? `${this.videoSettings.useUDPIP}:${this.videoSettings.useUDPPort}` : '0'),
+      '--compression=' + this.videoSettings.compression
+    ];
+
+    if (this.videoSettings.useTimestamp) args.push('--timestamp');
+
+    const pythonPath = logpaths.getPythonPath()
+    this.deviceStream = spawn(pythonPath, args)
+    this.setupStreamEvents('Streaming', callback);
+
+    // Start MAVLink heartbeats if enabled
+    if (this.useCameraHeartbeat) {
+      this.startHeartbeatInterval();
+      this.sendVideoStreamInformation(null, minimal.MavComponent.CAMERA, null);
+    }
+  }
+
+  startPhotoMode(callback) {
+    if (!this.stillSettings) return callback(new Error('No still settings provided'));
+
+    const dest = this.toAbsolutePath(this.stillSettings.mediaDestination);
+
+    const args = [
+      '-u', // force the stdout and stderr streams to be unbuffered
+      './python/photovideo.py',
+      '--mode=photo'
+    ];
+    if (this.stillSettings.device) args.push('--device=' + this.stillSettings.device);
+    if (this.stillSettings.width) args.push('--width=' + this.stillSettings.width);
+    if (this.stillSettings.height) args.push('--height=' + this.stillSettings.height);
+    if (dest) {
+      try {
+        fs.mkdirSync(dest, { recursive: true });
+        console.log('Ensured media directory exists:', dest);
+      } catch (e) {
+        console.error('Failed to create media directory:', dest, e);
+      }
+      args.push('--destination=' + dest);
+    }
+
+    const pythonPath = logpaths.getPythonPath()
+    this.deviceStream = spawn(pythonPath, args)
+    this.setupStreamEvents('Photo Mode', callback);
+
+    // Start MAVLink heartbeats if enabled
+    if (this.useCameraHeartbeat) {
+      this.startHeartbeatInterval();
+      this.sendCameraInformation(null, minimal.MavComponent.CAMERA, null);
+    }
+  }
+
+  startVideoMode(callback) {
+    if (!this.videoSettings) return callback(new Error('No video settings provided'));
+
+    const dest = this.toAbsolutePath(this.videoSettings.mediaDestination);
+
+    // Convert bitrate from kbps to bps Picamera2
+    const bitrateBps = this.videoSettings.bitrate * 1000;
+
+    const args = [
+      '-u', // force the stdout and stderr streams to be unbuffered
+      './python/photovideo.py',
+      '--mode=video',
+      '--device=' + this.videoSettings.device,
+      '--width=' + this.videoSettings.width,
+      '--height=' + this.videoSettings.height,
+      '--fps=' + this.videoSettings.fps,
+      '--bitrate=' + bitrateBps,
+      '--rotation=' + this.videoSettings.rotation,
+      '--format=' + this.videoSettings.format
+    ];
+
+    if (dest) {
+      try {
+        fs.mkdirSync(dest, { recursive: true });
+        console.log('Ensured media directory exists:', dest);
+      } catch (e) {
+        console.error('Failed to create media directory:', dest, e);
+      }
+      args.push('--destination=' + dest);
+    }
+
+    const pythonPath = logpaths.getPythonPath()
+    this.deviceStream = spawn(pythonPath, args)
+    this.setupStreamEvents('Video Mode', callback);
+
+    // Start MAVLink heartbeats if enabled
+    if (this.useCameraHeartbeat) {
+      this.startHeartbeatInterval();
+      this.sendCameraInformation(null, minimal.MavComponent.CAMERA, null);
+    }
+  }
+
+  setupStreamEvents(modeName, callback) {
+    let callbackCalled = false;
+    let stdoutBuffer = ''; // Buffer for accumulating data chunks
+
+    // Importing cv2 and Picamera2 on a Pi can take a minute or more
+    // Safety Timeout: If nothing happens in 90 seconds, unblock the UI
+    const timeout = setTimeout(() => {
+
+      if (!callbackCalled) {
+        callbackCalled = true;
+        console.log(`${modeName}: No response from script after 60s, assuming start.`);
+        this.active = true;
+        this.saveSettings();
+        callback(null, { active: true, addresses: this.deviceAddresses });
+      }
+    }, 90000);
+
+    this.deviceStream.on('error', (err) => {
+      clearTimeout(timeout);
+      console.error(`Failed to spawn ${modeName}:`, err);
+      if (!callbackCalled) {
+        callbackCalled = true;
+        callback(err);
+      }
+    });
+
+    // Listen continuously until we hear "Camera is ready"
+    // or in streaming mode
+    this.deviceStream.stdout.on('data', (data) => {
+
+      const chunk = data.toString();
+      stdoutBuffer += chunk;
+
+      // Detect the video recording start/stop messages from photovideo.py and update the recording flag
+      const lower = chunk.toLowerCase();
+      // start patterns printed by photovideo.py:
+      // "Picamera2 recording started to <path>"
+      // "V4L2 recording started to <path>"
+      // also generic "recording started"
+      if (lower.includes('recording started') || lower.includes('recording started to')) {
+        this.setRecordingFlag(true);
+        this.saveSettings();
+        console.log('Detected recorder START; isRecording=true');
+      }
+      // stop patterns printed by photovideo.py:
+      // "Picamera2 recording stopped."
+      // "V4L2 recording stopped."
+      // also generic "recording stopped"
+      if (lower.includes('recording stopped')) {
+        this.setRecordingFlag(false);
+        this.saveSettings();
+        console.log('Detected recorder STOP; isRecording=false');
+      }
+
+      // find file paths printed by photovideo.py
+      const re = /to\s+(\S+\.(?:jpg|jpeg|png|h264|mp4|avi))/ig;
+      let m;
+      while ((m = re.exec(chunk)) !== null) {
+        const filepath = m[1];
+        this.lastSavedFile = filepath;             // store for API read-after-post fallback
+        this.eventEmitter.emit('filesaved', filepath); // internal event
+        console.log('Detected saved file:', filepath);
+      }
+
+      // Print chunk for debugging immediately
+      const chunkTrimmed = chunk.trim();
+      if (chunkTrimmed) console.log(`${modeName} chunk: ${chunkTrimmed}`);
+
+      if (!callbackCalled) {
+        // For Photo/Video mode (photovideo.py): Wait for "Camera is ready"
+        // For Streaming (video-server.py): Wait for any data (assumed ready)
+
+        let isReady = false;
+
+        if (modeName === 'Streaming') {
+          isReady = true; // Assuming first output from Gstreamer script means it's running
+        } else {
+          // photovideo.py prints "Camera is ready in..."
+          if (stdoutBuffer.includes("Camera is ready")) {
+            isReady = true;
           }
         }
-        if (!found) {
-          console.log('No video device: ' + device)
-          return callback(new Error('No video device: ' + device))
+
+        if (isReady) {
+          clearTimeout(timeout);
+          console.log(`${modeName} process is fully initialized.`);
+          this.active = true;
+          this.saveSettings();
+          callbackCalled = true;
+          callback(null, { active: true, addresses: this.deviceAddresses });
         }
-      } else {
-        console.log('No video devices in list')
       }
+    });
 
-      this.active = true
-      this.savedDevice = {
-        device,
-        height,
-        width,
-        format,
-        bitrate,
-        fps,
-        rotation,
-        transport,
-        useUDPIP,
-        useUDPPort,
-        useTimestamp,
-        useCameraHeartbeat,
-        mavStreamSelected,
-        compression,
-        customRTSPSource
+    this.deviceStream.stderr.on('data', (data) => {
+      const msg = data.toString().trim();
+      if (msg) console.error(`${modeName} error: ${msg}`);
+    });
+
+    this.deviceStream.on('close', (code) => {
+      clearTimeout(timeout);
+      console.log(`${modeName} exited with code ${code}`);
+      this.active = false;
+      // Clear the video recording flag
+      if (this.videoSettings) {
+        this.setRecordingFlag(false);
+        this.saveSettings();
       }
-
-      //format rtsp source differently
-      if (device === 'rtspsourceh264' || device === 'rtspsourceh265') {
-        device = customRTSPSource
+      if (!callbackCalled) {
+        callbackCalled = true;
+        callback(new Error(`${modeName} exited immediately (Code: ${code})`));
       }
+    });
+  }
 
-      // note that video device URL's are the alphanumeric characters only. So /dev/video0 -> devvideo0
-      this.populateAddresses(device.toString())
-
-      // rpi camera has different name under Ubuntu
-      if (await this.isUbuntu() && device === 'rpicam') {
-        device = '/dev/video0'
-        format = 'video/x-raw'
-      }
-
-      const args = ['./python/video-server.py',
-        '--video=' + device,
-        '--height=' + height,
-        '--width=' + width,
-        '--format=' + format,
-        '--bitrate=' + bitrate,
-        '--rotation=' + rotation,
-        '--fps=' + fps,
-        '--transport=' + transport,
-        '--udp=' + useUDPIP + ':' + useUDPPort.toString(),
-        '--compression=' + compression
-      ]
-
-      if (useTimestamp) {
-        args.push('--timestamp')
-      }
-
-      console.log('Starting video with args: ' + args.toString())
-
-      const pythonPath = logpaths.getPythonPath()
-      this.deviceStream = spawn(pythonPath, args)
-
-      try {
-        if (this.deviceStream === null) {
-          this.settings.setValue('videostream.active', false)
-          console.log('Error spawning video-server.py')
-          return callback(null, this.active, this.deviceAddresses)
-        }
-        this.settings.setValue('videostream.active', this.active)
-        this.settings.setValue('videostream.savedDevice', this.savedDevice)
-      } catch (e) {
-        console.log(e)
-      }
-
-      this.deviceStream.stdout.on('data', (data) => {
-        console.log(`GST stdout: ${data}`)
-      })
-
-      this.deviceStream.stderr.on('data', (data) => {
-        if (!data.toString().includes('FIXME')) {
-          console.error(`GST stderr: ${data}`)
-        }
-      })
-
-      this.deviceStream.on('close', (code) => {
-        console.log(`GST process exited with code ${code}`)
-        this.deviceStream.stdin.pause()
-        this.deviceStream.kill()
-        this.resetVideo()
-      })
-
-      if (this.savedDevice.useCameraHeartbeat) {
-        this.startInterval()
-      }
-
-      console.log('Started Video Streaming of ' + device)
-
-      return callback(null, this.active, this.deviceAddresses)
-    } else {
-      // stop streaming
-      // if mavlink advertising is on, clear the interval
-
-      // Remove all listeners before killing
-      this.deviceStream.stdout.removeAllListeners()
-      this.deviceStream.stderr.removeAllListeners()
-      this.deviceStream.removeAllListeners()
-
-      if (this.savedDevice.useCameraHeartbeat) {
-        clearInterval(this.intervalObj)
-      }
-      this.deviceStream.stdin.pause()
-      this.deviceStream.kill()
-      this.resetVideo()
+  stopCamera(callback) {
+    if (this.intervalObj) {
+      clearInterval(this.intervalObj);
+      this.intervalObj = null;
     }
-    return callback(null, this.active, this.deviceAddresses)
+
+    if (this.deviceStream) {
+      this.deviceStream.kill('SIGTERM'); // Clean kill
+      this.deviceStream = null;
+    }
+
+    this.active = false;
+    this.settings.setValue('camera.active', false);
+    // Clear the video recording flag and persist the current mode's settings.
+    if (this.videoSettings) {
+      this.setRecordingFlag(false);
+    }
+    this.saveSettings();
+
+    if (callback) callback(null, false);
   }
 
   async isUbuntu () {
@@ -442,13 +700,21 @@ class videoStream {
   getStreamingStatus () {
     // return the current streaming status
     if (this.active) {
-      return 'Active - Streaming video'
+      if (this.cameraMode === 'streaming') {
+        return 'Camera is streaming video'
+      } else if (this.cameraMode === 'photo') {
+        return 'Camera is active in photo mode'
+      } else if (this.cameraMode === 'video' && this.videoSettings.isRecording) {
+        return 'Camera is currently recording a video'
+      } else if (this.cameraMode === 'video' && !this.videoSettings.isRecording) {
+        return 'Camera is active in video mode'
+      }
     } else {
-      return 'Not streaming'
+      return 'Camera is inactive'
     }
   }
 
-  startInterval () {
+  startHeartbeatInterval () {
     // start the 1-sec loop to send heartbeat events
     this.intervalObj = setInterval(() => {
       const mavType = minimal.MavType.CAMERA
@@ -459,85 +725,223 @@ class videoStream {
     }, 1000)
   }
 
-  onMavPacket (packet, data) {
-    // FC is active
-    if (!this.active) {
+  captureStillPhoto(senderSysId, senderCompId, targetComponent, positionData = null) {
+    console.log('Attempting captureStillPhoto. Internal state: active=', this.active, 'mode=', this.cameraMode, 'deviceStream exists=', !!this.deviceStream);
+
+    // Capture a single still photo
+    console.log('Capturing still photo')
+
+    if (!this.active || !this.deviceStream) {
+      console.log('Cannot capture photo - camera not active')
+      console.log('Internal check failed: Cannot capture photo - camera not active or no deviceStream.');
       return
     }
 
-    if (packet.header.msgid === common.CommandLong.MSG_ID &&
-      data._param1 === common.CameraInformation.MSG_ID && 
-      data.targetComponent === minimal.MavComponent.CAMERA) {
-      console.log('Responding to MAVLink request for CameraInformation')
-
-      const senderSysId = packet.header.sysid
-      const senderCompId = minimal.MavComponent.CAMERA
-      const targetComponent = packet.header.compid
-
-      // build a CAMERA_INFORMATION packet
-      const msg = new common.CameraInformation()
-
-      // TODO: implement missing attributes here
-      msg.timeBootMs = 0
-      msg.vendorName = 0
-      msg.modelName = 0
-      msg.firmwareVersion = 0
-      msg.focalLength = null
-      msg.sensorSizeH = null
-      msg.sensorSizeV = null
-      msg.resolutionH = this.savedDevice.width
-      msg.resolutionV = this.savedDevice.height
-      msg.lensId = 0
-      // 256 = CAMERA_CAP_FLAGS_HAS_VIDEO_STREAM (hard-coded for now until Rpanion gains more camera capabilities)
-      msg.flags = 256
-      msg.camDefinitionVersion = 0
-      msg.camDefinitionUri = ''
-      msg.gimbalDeviceId = 0
-      this.eventEmitter.emit('camerainfo', msg, senderSysId, senderCompId, targetComponent)
-
-    } else if (packet.header.msgid === common.CommandLong.MSG_ID &&
-      data.targetComponent === minimal.MavComponent.CAMERA &&
-      data._param1 === common.VideoStreamInformation.MSG_ID) {
-
-      console.log('Responding to MAVLink request for VideoStreamInformation')
-
-      const senderSysId = packet.header.sysid
-      const senderCompId = minimal.MavComponent.CAMERA
-      const targetComponent = packet.header.compid
-
-      // build a VIDEO_STREAM_INFORMATION packet
-      const msg = new common.VideoStreamInformation()
-
-      // rpanion only supports a single stream, so streamId and count will always be 1
-      msg.streamId = 1
-      msg.count = 1
-
-      // msg.type and msg.uri need to be different depending on whether RTP or RTSP is selected
-      if (this.savedDevice.transport == 'RTP') {
-        // msg.type = 0 = VIDEO_STREAM_TYPE_RTSP
-        // msg.type = 1 = VIDEO_STREAM_TYPE_RTPUDP
-        msg.type = 1
-        // For RTP, just send the destination UDP port instead of a full URI
-        msg.uri = this.savedDevice.useUDPPort.toString()
-      } else {
-        msg.type = 0
-        msg.encoding = this.savedDevice.compression.value === 'H264' ? 1 : (this.savedDevice.compression.value === 'H265' ? 2 : 0)
-        msg.uri = `rtsp://${this.savedDevice.mavStreamSelected}:8554/${this.savedDevice.device}`
+    // Write GPS data to a temporary file for Python to read
+    if (positionData) {
+      try {
+        const gpsPayload = JSON.stringify(positionData);
+        fs.writeFileSync('/tmp/rpanion_gps.json', gpsPayload);
+        console.log('Wrote GPS data for geotagging:', gpsPayload);
+      } catch (e) {
+        console.error('Failed to write GPS temp file:', e);
       }
+    } else {
+      // Clean up old file to prevent stale tags
+      if (fs.existsSync('/tmp/rpanion_gps.json')) {
+        fs.unlinkSync('/tmp/rpanion_gps.json');
+      }
+    }
 
-      // 1 = VIDEO_STREAM_STATUS_FLAGS_RUNNING
-      // 2 = VIDEO_STREAM_STATUS_FLAGS_THERMAL
-      msg.flags = 1
-      msg.framerate = this.savedDevice.fps
-      msg.resolutionH = this.savedDevice.width
-      msg.resolutionV = this.savedDevice.height
-      msg.bitrate = this.savedDevice.bitrate
-      msg.rotation = this.savedDevice.rotation
-      // Rpanion doesn't collect field of view values, so just set to zero
-      msg.hfov = 0
-      msg.name = this.savedDevice.device
+    // Signal the Python process to capture a photo
+    this.deviceStream.kill('SIGUSR1')
 
-      this.eventEmitter.emit('videostreaminfo', msg, senderSysId, senderCompId, targetComponent)
+    // Build MAVLink CAMERA_TRIGGER packet for geotagging/logging
+    const msg = new common.CameraTrigger()
+    // Date.now() returns time in milliseconds
+    msg.timeUsec = BigInt(Date.now() * 1000)
+    // Increment the photo counter
+    msg.seq = this.photoSeq++
+
+    this.eventEmitter.emit('digicamcontrol', senderSysId, senderCompId, targetComponent)
+    this.eventEmitter.emit('cameratrigger', msg, senderCompId)
+  }
+
+  toggleVideoRecording() {
+    if (!this.active || !this.deviceStream) {
+      console.log('Cannot toggle video - camera not active');
+      return;
+    }
+
+    console.log('Toggling local video recording via SIGUSR1');
+    // Signal the Python process to start or stop the file write
+    this.deviceStream.kill('SIGUSR1');
+  }
+
+  // Helper to set the isRecording flag by replacing the object
+  // instead of mutating the property
+  setRecordingFlag(val) {
+    if (!this.videoSettings) return;
+    this.videoSettings = { ...this.videoSettings, isRecording: val };
+    this.saveSettings();
+  }
+
+  // Helper to convert JS strings to the Array<string> format node-mavlink expects for char[]
+  toMavChars(str, length) {
+    const buf = new Uint8Array(length);
+    if (!str) return buf;
+
+    const encoded = new TextEncoder().encode(str);
+    buf.set(encoded.slice(0, length));
+    return buf;
+  }
+
+  sendCameraInformation(senderSysId, senderCompId, targetComponent) {
+    console.log('Sending MAVLink CameraInformation packet')
+
+    const msg = new common.CameraInformation();
+
+    // Get the camera model name, and handle cases where settings might be null
+    let devicePath = "Unknown";
+    if (this.cameraMode === 'photo' && this.stillSettings && this.stillSettings.device) {
+      devicePath = this.stillSettings.device;
+    } else if (this.videoSettings && this.videoSettings.device) {
+      devicePath = this.videoSettings.device;
+    }
+
+    let extractedModel = "Unknown";
+    if (devicePath !== "Unknown") {
+      if (devicePath.includes('rtspsource')) {
+        extractedModel = "RTSP Source";
+      } else if (devicePath.includes('/')) {
+        // e.g. /base/soc/i2c0mux/i2c@1/imx219@10 -> imx219
+        const parts = devicePath.split('/');
+        const leaf = parts[parts.length - 1];
+        extractedModel = leaf.split('@')[0];
+      } else {
+        extractedModel = devicePath;
+      }
+    }
+
+    msg.vendorName = this.toMavChars("Rpanion", 32);
+    msg.modelName = this.toMavChars(extractedModel, 32);
+    msg.firmwareVersion = 0;
+    msg.focalLength = 0;
+    msg.sensorSizeH = 0;
+    msg.sensorSizeV = 0;
+    msg.lensId = 0;
+    msg.camDefinitionVersion = 0;
+    msg.camDefinitionUri = ""; // send zero-length string if not known
+    msg.gimbalDeviceId = 0;
+
+    // Mode-specific Configuration
+    if (this.cameraMode === 'photo') {
+      msg.resolutionH = this.stillSettings?.width || 0;
+      msg.resolutionV = this.stillSettings?.height || 0;
+      msg.flags = 2; // CAMERA_CAP_FLAGS_CAPTURE_IMAGE
+    }
+    else if (this.cameraMode === 'video') {
+      msg.resolutionH = this.videoSettings?.width || 0;
+      msg.resolutionV = this.videoSettings?.height || 0;
+      msg.flags = 4; // CAMERA_CAP_FLAGS_CAPTURE_VIDEO
+    }
+    else {
+      // Default: streaming
+      msg.resolutionH = this.videoSettings?.width || 0;
+      msg.resolutionV = this.videoSettings?.height || 0;
+      msg.flags = 256; // CAMERA_CAP_FLAGS_HAS_VIDEO_STREAM
+    }
+
+    this.eventEmitter.emit('camerainfo', msg, senderSysId, senderCompId, targetComponent);
+  }
+
+  sendCameraSettings(senderSysId, senderCompId, targetComponent) {
+    console.log('Sending MAVLink CameraSettings packet')
+
+    // build a CAMERA_SETTINGS packet
+    const msg = new common.CameraSettings()
+
+    msg.timeBootMs = 0
+
+    // Camera modes: 0 = IMAGE, 1 = VIDEO, 2 = IMAGE_SURVEY
+    if (this.cameraMode === 'photo') {
+      msg.modeId = 0
+    } else {
+      msg.modeId = 1
+    }
+
+    msg.zoomLevel = null
+    msg.focusLevel = null
+
+    this.eventEmitter.emit('camerasettings', msg, senderSysId, senderCompId, targetComponent)
+  }
+
+  sendVideoStreamInformation(senderSysId, senderCompId, targetComponent) {
+    console.log('Responding to MAVLink request for VideoStreamInformation')
+
+    // build a VIDEO_STREAM_INFORMATION packet
+    const msg = new common.VideoStreamInformation()
+
+    // rpanion only supports a single stream, so streamId and count will always be 1
+    msg.streamId = 1
+    msg.count = 1
+
+    // msg.type and msg.uri need to be different depending on whether RTP or RTSP is selected
+    if (this.videoSettings && this.videoSettings.useUDP) {
+      // msg.type = 0 = VIDEO_STREAM_TYPE_RTSP
+      // msg.type = 1 = VIDEO_STREAM_TYPE_RTPUDP
+      msg.type = 1
+      // For RTP, just send the destination UDP port instead of a full URI
+      msg.uri = this.videoSettings.useUDPPort.toString();
+    } else {
+      msg.type = 0
+      msg.encoding = this.videoSettings.compression === 'H264' ? 1 : (this.videoSettings.compression === 'H265' ? 2 : 0);
+
+      // Find the address in the list that matches the selected MAVLink interface IP
+      // This uses the array populated in populateAddresses() to ensure 1:1 consistency with Web UI
+      const matchedAddress = this.deviceAddresses.find(addr =>
+        addr.includes(this.videoSettings.mavStreamSelected)
+      );
+
+      msg.uri = matchedAddress || "";
+
+    }
+
+    // 1 = VIDEO_STREAM_STATUS_FLAGS_RUNNING
+    msg.flags = 1;
+    msg.framerate = this.videoSettings.fps;
+    msg.resolutionH = this.videoSettings.width;
+    msg.resolutionV = this.videoSettings.height;
+    msg.bitrate = this.videoSettings.bitrate;
+    msg.rotation = this.videoSettings.rotation;
+    // Rpanion doesn't collect field of view values, so set to zero
+    msg.hfov = 0;
+    // Set the stream name (usually the device path)
+    msg.name = this.videoSettings.device;
+
+    this.eventEmitter.emit('videostreaminfo', msg, senderSysId, senderCompId, targetComponent)
+  }
+
+  onMavPacket(packet, data) {
+    if (packet.header.msgid === common.CommandLong.MSG_ID &&
+      data.targetComponent === minimal.MavComponent.CAMERA) {
+      if (data._param1 === common.CameraInformation.MSG_ID) {
+        console.log('Responding to MAVLink request for CameraInformation')
+        this.sendCameraInformation(packet.header.sysid, minimal.MavComponent.CAMERA, packet.header.compid);
+      }
+      else if (data._param1 === common.VideoStreamInformation.MSG_ID && this.cameraMode === "streaming") {
+        console.log('Responding to MAVLink request for VideoStreamInformation')
+        this.sendVideoStreamInformation(packet.header.sysid, minimal.MavComponent.CAMERA, packet.header.compid);
+      }
+      else if (data._param1 === common.CameraSettings.MSG_ID) {
+        console.log('Responding to MAVLink request for CameraSettings')
+        this.sendCameraSettings(packet.header.sysid, minimal.MavComponent.CAMERA, packet.header.compid)
+      }
+      // 203 = MAV_CMD_DO_DIGICAM_CONTROL
+      else if (data.command === 203) {
+        console.log('Received DoDigicamControl command')
+        this.captureStillPhoto(packet.header.sysid, minimal.MavComponent.CAMERA, packet.header.compid)
+      }
     }
   }
 }

--- a/server/videostream.test.js
+++ b/server/videostream.test.js
@@ -1,5 +1,7 @@
 const assert = require('assert')
+const path = require('path')
 const settings = require('settings-store')
+const logpaths = require('./paths')
 const VideoStream = require('./videostream')
 
 describe('Video Functions', function () {
@@ -29,27 +31,38 @@ describe('Video Functions', function () {
     settings.clear()
     const vManager = new VideoStream(settings)
 
-    // err, devices, active, seldevice, selRes, selRot, selbitrate, selfps, SeluseUDPIP, SeluseUDPPort, timestamp, fps, FPSMax, vidres, cameraHeartbeat, selMavURI, compression, transport, transportOptions
-    vManager.getVideoDevices(function (err, devices, active, seldevice, selRes, selRot, selbitrate, selfps, SeluseUDPIP,
-                                       SeluseUDPPort, timestamp, fps, FPSMax, vidres, cameraHeartbeat, selMavURI,
-                                       compression, transport, transportOptions) {
-      assert.equal(err, null)
-      assert.equal(active, false)
-      assert.notEqual(seldevice, null)
-      assert.notEqual(selRes, null)
-      assert.notEqual(selRot, null)
-      assert.notEqual(selbitrate, null)
-      assert.notEqual(selfps, null)
-      assert.equal(SeluseUDPIP, '127.0.0.1')
-      assert.equal(SeluseUDPPort, 5400)
-      assert.equal(timestamp, false)
-      assert.notEqual(fps, null)
-      assert.notEqual(FPSMax, null)
-      assert.notEqual(vidres, null)
-      assert.notEqual(selMavURI, null)
-      assert.deepEqual(compression, 'H264' )
-      assert.deepEqual(transport, 'RTSP' )
-      assert.deepEqual(transportOptions, [{ label: 'RTP', value: 'RTP' }, { label: 'RTSP', value: 'RTSP' }])
+    vManager.getVideoDevices(function (err, data) {
+      // The code returns a data object, not individual arguments
+      assert.notEqual(data, null)
+      assert.equal(data.active, false)
+      assert.notEqual(data.networkInterfaces, null)
+
+      // Defaults defined in the class when scan fails or mock runs
+      assert.equal(data.selectedUseUDPIP, '127.0.0.1')
+      assert.equal(data.selectedUseUDPPort, 5400)
+      assert.equal(data.selectedUseTimestamp, false)
+      assert.deepEqual(data.selectedMavStreamURI, { label: '127.0.0.1', value: '127.0.0.1' })
+
+      // Check structure of return object
+      assert.ok(Array.isArray(data.devices))
+      assert.ok(Array.isArray(data.fpsOptions))
+      done()
+    })
+  }).timeout(5000)
+
+  it('#getStillDevices()', function (done) {
+    // Scanning for still photo devices (CSI and UVC cameras)
+    settings.clear()
+    const vManager = new VideoStream(settings)
+
+    vManager.getStillDevices(function (err, data) {
+      // The function should return a data object with devices and capabilities
+      assert.notEqual(data, null)
+      assert.ok(Array.isArray(data.devices))
+      assert.ok(data.capabilities !== null)
+      assert.ok(typeof data.capabilities.cv2 === 'boolean')
+      assert.ok(typeof data.capabilities.picamera2 === 'boolean')
+      // err may be non-null if v4l2-ctl is not available in CI environment
       done()
     })
   }).timeout(5000)
@@ -62,19 +75,207 @@ describe('Video Functions', function () {
     assert.equal(res, true)
   })
 
-  it('#videomanagerstartStopStreaming()', function (done) {
+  it('#helperOptions()', function () {
     settings.clear()
     const vManager = new VideoStream(settings)
 
-    vManager.startStopStreaming(true, 'testsrc', '1080', '1920', 'video/x-h264', '0', '1000', '5', "RTP", false, false, false, true, false, '0', "H264", function (err, status) {
+    // Compression Select
+    let comp = vManager.getCompressionSelect('H265')
+    assert.equal(comp.value, 'H265')
+    comp = vManager.getCompressionSelect('INVALID') // Should default to H264 (index 0)
+    assert.equal(comp.value, 'H264')
+
+    // Transport Select
+    let trans = vManager.getTransportSelect('RTP')
+    assert.equal(trans.value, 'RTP')
+    trans = vManager.getTransportSelect('INVALID') // Should default to RTSP
+    assert.equal(trans.value, 'RTSP')
+
+    // Transport Options
+    const options = vManager.getTransportOptions()
+    assert.equal(options.length, 2)
+  })
+
+  it('#pathHelpers()', function () {
+    settings.clear()
+    const vManager = new VideoStream(settings)
+
+    assert.equal(vManager.toRelativePath(''), '')
+    assert.equal(vManager.toRelativePath('.'), '')
+    assert.equal(vManager.toRelativePath('subdir'), 'subdir')
+
+    const absoluteDest = path.join(logpaths.mediaDir, 'saved')
+    assert.equal(vManager.toRelativePath(absoluteDest), 'saved')
+
+    assert.equal(vManager.toAbsolutePath(''), logpaths.mediaDir)
+    assert.equal(vManager.toAbsolutePath('saved'), path.join(logpaths.mediaDir, 'saved'))
+  })
+
+  it('#settingsManagement()', function () {
+    settings.clear()
+    const vManager = new VideoStream(settings)
+
+    // Setup fake settings
+    vManager.active = true
+    vManager.cameraMode = 'video'
+    vManager.videoSettings = { width: 1920, height: 1080 }
+
+    // Test Save
+    vManager.saveSettings()
+    assert.equal(settings.value('camera.active'), true)
+    assert.equal(settings.value('camera.mode'), 'video')
+    assert.deepEqual(settings.value('camera.videoSettings'), { width: 1920, height: 1080 })
+
+    // Test Reset
+    vManager.resetCamera()
+    assert.equal(vManager.active, false)
+    assert.equal(vManager.videoSettings, null)
+    assert.equal(settings.value('camera.active'), false)
+  })
+
+  it('#stopCamera()', function (done) {
+    settings.clear()
+    const vManager = new VideoStream(settings)
+
+    // Mock an active stream
+    vManager.active = true
+    vManager.intervalObj = setInterval(() => { }, 1000) // Dummy interval
+    vManager.deviceStream = {
+      kill: (signal) => {
+        assert.equal(signal, 'SIGTERM')
+      }
+    }
+
+    vManager.stopCamera((err, status) => {
       assert.equal(err, null)
-      assert.equal(status, true)
-      assert.notEqual(vManager.deviceStream.pid, null)
-      vManager.startStopStreaming(false, 'testsrc', '1080', '1920', 'video/x-h264', '0', '1000', '5', "RTP", false, false, false, true, false, '0', "H264", function (err, status) {
-        assert.equal(err, null)
-        assert.equal(status, false)
-        done()
-      })
+      assert.equal(status, false)
+      assert.equal(vManager.active, false)
+      assert.equal(vManager.deviceStream, null)
+      assert.equal(vManager.intervalObj, null)
+      done()
     })
   })
+
+
+  it('#captureStillPhoto()', function (done) {
+    settings.clear()
+    const vManager = new VideoStream(settings)
+
+    // Simulate active camera
+    vManager.active = true
+    let signalSent = false
+
+    vManager.deviceStream = {
+      kill: (signal) => {
+        if (signal === 'SIGUSR1') signalSent = true
+      }
+    }
+
+    // Listen for the MAVLink events that should be emitted
+    let triggerReceived = false
+    vManager.eventEmitter.on('cameratrigger', (msg, compId) => {
+      triggerReceived = true
+      assert.ok(msg.timeUsec > 0)
+      assert.equal(msg.seq, 0) // First photo
+    })
+
+    vManager.captureStillPhoto(1, 1, 1)
+
+    // Allow event loop to process
+    setTimeout(() => {
+      assert.equal(signalSent, true, "Should send SIGUSR1 to python process")
+      assert.equal(triggerReceived, true, "Should emit cameratrigger MAVLink message")
+      assert.equal(vManager.photoSeq, 1, "Should increment photo sequence")
+      done()
+    }, 50)
+  })
+
+  it('#toggleVideoRecording()', function () {
+    settings.clear()
+    const vManager = new VideoStream(settings)
+
+    vManager.active = true
+    let signalSent = false
+    vManager.deviceStream = {
+      kill: (signal) => {
+        if (signal === 'SIGUSR1') signalSent = true
+      }
+    }
+
+    vManager.toggleVideoRecording()
+    assert.equal(signalSent, true, "Should send SIGUSR1 to toggle recording")
+  })
+
+  it('#sendCameraInformation()', function (done) {
+    settings.clear()
+    const vManager = new VideoStream(settings)
+
+    // Mock settings to ensure model name extraction works
+    vManager.videoSettings = { device: 'imx219' }
+
+    vManager.eventEmitter.on('camerainfo', (msg, sysId, compId) => {
+      // Decode vendor name (Uint8Array to string)
+      const vendorText = new TextDecoder().decode(msg.vendorName).replace(/\0/g, '')
+      assert.equal(vendorText, 'Rpanion')
+      assert.equal(msg.flags, 256) // Default streaming flag
+      done()
+    })
+
+    vManager.sendCameraInformation(1, 1, 1)
+  })
+
+  it('#sendVideoStreamInformation()', function (done) {
+    settings.clear()
+    const vManager = new VideoStream(settings)
+
+    vManager.videoSettings = {
+      width: 1280,
+      height: 720,
+      fps: 30,
+      bitrate: 2000,
+      rotation: 0,
+      compression: 'H264',
+      useUDP: false,
+      mavStreamSelected: '127.0.0.1'
+    }
+
+    // Mock addresses so URI generation works
+    vManager.deviceAddresses = ['rtsp://127.0.0.1:8554/test']
+
+    vManager.eventEmitter.on('videostreaminfo', (msg) => {
+      assert.equal(msg.streamId, 1)
+      assert.equal(msg.resolutionH, 1280)
+      assert.equal(msg.type, 0) // RTSP
+      assert.equal(msg.encoding, 1) // H264
+      assert.ok(msg.uri.includes('rtsp://'))
+      done()
+    })
+
+    vManager.sendVideoStreamInformation(1, 1, 1)
+  })
+
+  it('#sendCameraSettings()', function (done) {
+    settings.clear()
+    const vManager = new VideoStream(settings)
+
+    // Test photo mode
+    vManager.cameraMode = 'photo'
+    let photoModeSettingsReceived = false
+    vManager.eventEmitter.on('camerasettings', (msg) => {
+      if (!photoModeSettingsReceived) {
+        photoModeSettingsReceived = true
+        assert.equal(msg.modeId, 0) // IMAGE mode
+        // Test video mode
+        vManager.cameraMode = 'video'
+        vManager.sendCameraSettings(1, 1, 1)
+      } else {
+        assert.equal(msg.modeId, 1) // VIDEO mode
+        done()
+      }
+    })
+
+    vManager.sendCameraSettings(1, 1, 1)
+  })
+
+
 })

--- a/src/AppRouter.jsx
+++ b/src/AppRouter.jsx
@@ -64,14 +64,14 @@ function AppRouter () {
         <div id="sidebarheading" className="sidebar-heading">Rpanion Web UI</div>
         <div id="sidebar-items" className="list-group list-group-flush">
           <Link className='list-group-item list-group-item-action bg-light' to="/">Home</Link>
-          <Link className='list-group-item list-group-item-action bg-light' to="/flightlogs">Flight Logs</Link>
+          <Link className='list-group-item list-group-item-action bg-light' to="/flightlogs">Flight Logs and Media</Link>
           <Link className='list-group-item list-group-item-action bg-light' to="/controller">Flight Controller</Link>
           <Link className='list-group-item list-group-item-action bg-light' to="/ppp">PPP Config</Link>
           <Link className='list-group-item list-group-item-action bg-light' to="/ntrip">NTRIP Config</Link>
           <Link className='list-group-item list-group-item-action bg-light' to="/network">Network Config</Link>
           <Link className='list-group-item list-group-item-action bg-light' to="/adhoc">Adhoc Wifi Config</Link>
           <Link className='list-group-item list-group-item-action bg-light' to="/apclients">Access Point Clients</Link>
-          <Link className='list-group-item list-group-item-action bg-light' to="/video">Video Streaming</Link>
+          <Link className='list-group-item list-group-item-action bg-light' to="/video">Photo and Video</Link>
           <Link className='list-group-item list-group-item-action bg-light' to="/cloud">Cloud Upload</Link>
           <Link className='list-group-item list-group-item-action bg-light' to="/vpn">VPN Config</Link>
           <Link className='list-group-item list-group-item-action bg-light' to="/about">About</Link>

--- a/src/flightcontroller.jsx
+++ b/src/flightcontroller.jsx
@@ -345,6 +345,13 @@ class FCPage extends basePage {
         <p>Connection Status: {this.state.FCStatus.conStatus}</p>
         <p>Vehicle Type: {this.state.FCStatus.vehType}</p>
         <p>Vehicle Firmware: {this.state.FCStatus.FW}{this.state.FCStatus.fcVersion === '' ? '' : (', Version: ' + this.state.FCStatus.fcVersion)}</p>
+        {this.state.FCStatus.vehiclePosition &&
+          <>
+            <p>Position: {this.state.FCStatus.vehiclePosition.lat.toFixed(7)}, {this.state.FCStatus.vehiclePosition.lon.toFixed(7)}</p>
+            <p>Altitude: {this.state.FCStatus.vehiclePosition.relAlt.toFixed(2)}m (Rel) / {this.state.FCStatus.vehiclePosition.alt.toFixed(2)}m (MSL)</p>
+            <p>Heading: {this.state.FCStatus.vehiclePosition.hdg.toFixed(0)}°</p>
+          </>
+        }
         <label>Console Output:
           <textarea readOnly rows="5" cols="50" value={this.state.FCStatus.statusText}></textarea>
         </label>

--- a/src/home.jsx
+++ b/src/home.jsx
@@ -71,6 +71,23 @@ class Home extends basePage {
   }
 
   renderContent () {
+    
+    // Get the exact state of the camrea
+    const videoStatus = (this.state.VideoStreamStatus || '').toString();
+    let cameraBadgeLabel = 'Inactive';
+    if (videoStatus.toLowerCase().includes('inactive') || videoStatus.toLowerCase().includes('not')) {
+      cameraBadgeLabel = 'Inactive';
+    } else if (videoStatus.toLowerCase().includes('streaming')) {
+      cameraBadgeLabel = 'Active (Streaming)';
+    } else if (videoStatus.toLowerCase().includes('photo')) {
+      cameraBadgeLabel = 'Active (Photo)';
+    } else if (videoStatus.toLowerCase().includes('recording')) {
+      cameraBadgeLabel = 'Recording';
+    } else if (videoStatus.toLowerCase().includes('video')) {
+      cameraBadgeLabel = 'Active (Video)';
+    }
+    const cameraBadgeVariant = this.getStatusVariant(videoStatus);
+
     return (
       <div style={{ width: 650 }}>
         <div className="mb-4">
@@ -140,14 +157,14 @@ class Home extends basePage {
             <Card>
               <Card.Header>
                 <h5 className="mb-0">
-                  Video Streaming
-                  <Badge bg={this.getStatusVariant(this.state.VideoStreamStatus)} className="ms-2">
-                    {this.state.VideoStreamStatus.includes('Active') ? 'Active' : 'Inactive'}
+                  Camera
+                  <Badge bg={cameraBadgeVariant} className="ms-2">
+                    {cameraBadgeLabel}
                   </Badge>
                 </h5>
               </Card.Header>
               <Card.Body>
-                <p>{this.state.VideoStreamStatus}</p>
+                <p>{videoStatus}</p>
               </Card.Body>
             </Card>
           </Col>

--- a/src/logBrowser.jsx
+++ b/src/logBrowser.jsx
@@ -15,14 +15,19 @@ class LoggerPage extends basePage {
       TlogFiles: [],
       BinlogFiles: [],
       KMZlogFiles: [],
+      MediaFiles: [],
       diskSpaceStatus: "",
       conversionLogStatus: 'N/A',
+      videoStreamStatus: 'N/A',
       doLogConversion: true
     }
 
     //Socket.io client for reading update values
     this.socket.on('LogConversionStatus', function (msg) {
       this.setState({ conversionLogStatus: msg })
+    }.bind(this))
+    this.socket.on('VideoStreamStatus', function (msg) {
+    this.setState({ videoStreamStatus: msg })
     }.bind(this))
     this.socket.on('reconnect', function () {
       //refresh state
@@ -52,15 +57,33 @@ class LoggerPage extends basePage {
   }
 
   renderTitle() {
-    return "Flight Log Browser";
+    return "Flight Log and Media Browser";
   }
 
-  //create a html table from a list of logfiles
+  // create an html table from a list of logfiles
   renderLogTableData(logfilelist) {
     return logfilelist.map((log) => {
       return (
         <tr key={log.key}>
-          <td><a href={this.state.url + "/logdownload/" + log.key} download>{log.name}</a></td>
+          <td><a href={this.state.url + "/logdownload/" + log.key} download={log.name}>{log.key}</a></td>
+          <td>{log.size} KB</td>
+          <td>{log.modified}</td>
+        </tr>
+      )
+    });
+  }
+
+  // create an html table from a list of media files, sorted from newest to oldest
+  renderMediaTableData(logfilelist) {
+    // clone the list and sort with newest first
+    const sorted = [...logfilelist].sort((a, b) => {
+      return new Date(b.modified) - new Date(a.modified);
+    });
+
+    return sorted.map((log) => {
+      return (
+        <tr key={log.key}>
+          <td><a href={this.state.url + "/media/" + log.key} download={log.name}>{log.key}</a></td>
           <td>{log.size} KB</td>
           <td>{log.modified}</td>
         </tr>
@@ -97,7 +120,7 @@ class LoggerPage extends basePage {
   renderContent() {
     return (
       <div style={{ width: 600 }}>
-        <p><i>Save and download flight logs</i></p>
+        <p><i>Save and download flight logs and saved photos/videos</i></p>
         <p>Disk Space: {this.state.diskSpaceStatus}</p>
         <Accordion defaultActiveKey="0">
           <Accordion.Item eventKey="0">
@@ -162,6 +185,38 @@ class LoggerPage extends basePage {
                   {this.renderLogTableData(this.state.KMZlogFiles)}
                 </tbody>
               </Table>
+            </Accordion.Body>
+          </Accordion.Item>
+          <Accordion.Item eventKey="3">
+            <Accordion.Header>Photo and Video Files</Accordion.Header>
+            <Accordion.Body>
+              <p>Photos and video files recorded by Rpanion</p>
+              
+              <div className="form-group row" style={{ marginBottom: '5px' }}>
+                <div className="col-sm-8">
+                  <p>Status: {this.state.videoStreamStatus}</p>
+                </div>
+              </div>
+              <div className="form-group row" style={{ marginBottom: '5px' }}>
+                <div className="form-group row" style={{ marginBottom: '5px' }}>
+                <div className="col-sm-8">
+                <Button id='media' onClick={this.clearLogs}>Delete all media files and subdirectories</Button>
+                </div>
+              </div>
+              </div>
+              <Table id='Mediafile' striped bordered hover size="sm">
+                <thead>
+                  <tr><th>File Name</th><th>Size</th><th>Modified</th></tr>
+                </thead>
+              </Table>
+
+              <div style={{ maxHeight: '300px', overflowY: 'auto' }}>
+                <Table striped bordered hover size="sm">
+                  <tbody>
+                    {this.renderMediaTableData(this.state.MediaFiles)}
+                  </tbody>
+                </Table>
+              </div>
             </Accordion.Body>
           </Accordion.Item>
         </Accordion>

--- a/src/video.jsx
+++ b/src/video.jsx
@@ -2,7 +2,9 @@ import Button from 'react-bootstrap/Button';
 import Accordion from 'react-bootstrap/Accordion';
 import Form from 'react-bootstrap/Form';
 import React from 'react'
+import { Link } from 'react-router-dom';
 import IPAddressInput from './components/IPAddressInput.jsx';
+import { io as ioClient } from 'socket.io-client';
 
 import basePage from './basePage.jsx';
 
@@ -13,13 +15,36 @@ class VideoPage extends basePage {
     super(props);
     this.state = {
       ...this.state,
+      appRoot: '',
       ifaces: [],
       dev: [],
-      vidDeviceSelected: this.props.vidDeviceSelected || '',
-      vidres: [],
-      vidResSelected: 0,
-      streamingStatus: this.props.streamingStatus,
+
+      // Video State
+      videoDevices: [],
+      vidDeviceSelected: this.props.selectedVideoDevice || '',
+      videoCaps: [],
+      vidCapSelected: this.props.selectedVideoCap || '',
+      videoIsRecording: false,
+      // Notification text to show when a photo or video file is saved
+      notification: '',
+      currentVideoFile: '',
+      
+      // Still Photo State
+      stillDevices: [],
+      stillDeviceSelected: this.props.selectedStillDevice || '',
+      stillCaps: [],
+      stillCapSelected: this.props.selectedStillCap || '',
+      videoMediaDestination: this.props.videoMediaDestination || '',
+      stillMediaDestination: this.props.stillMediaDestination || '',
+
+      // Global state
+      active: this.props.streamingStatus || false,
+      cameraMode: this.props.cameraMode || 'streaming', // Default to streaming mode; other options are 'photo', 'video'
       streamAddresses: [],
+      photoVideoAvailable: true, // Whether photo/video modes are available based on installed libraries
+      showOpenCVWarning: true, // Whether to show the OpenCV missing libraries warning
+
+      // Video options
       rotations: [{ label: "0°", value: 0 }, { label: "90°", value: 90 }, { label: "180°", value: 180 }, { label: "270°", value: 270 }],
       rotSelected: 0,
       bitrate: 1000,
@@ -28,71 +53,342 @@ class VideoPage extends basePage {
       useUDPIP: "127.0.0.1",
       useUDPPort: 5600,
       FPSMax: 0,
-      fps: [],
+      fpsOptions: [],
       fpsSelected: 1,
       timestamp: false,
-      enableCameraHeartbeat: false,
-      mavStreamSelected: this.props.mavStreamSelected || '',
+      
+      // Transport options
       multicastString: " ",
       compression: 'H264',
       compressionOptions: [{ value: 'H264', label: 'H.264' }, { value: 'H265', label: 'H.265' }],
-      customRTSPSource: this.props.customRTSPSource || ''
+      customRTSPSource: this.props.customRTSPSource || '',
+
+      // Mavlink options
+      enableCameraHeartbeat: false,
+      mavStreamSelected: this.props.mavStreamSelected || ''
     }
   }
 
   componentDidMount() {
-    fetch(`/api/videodevices`, {headers: {Authorization: `Bearer ${this.state.token}`}}).then(response => response.json()).then(state => { 
-      this.setState(state); 
-      this.isMulticastUpdateIP(state.useUDPIP); 
-      this.loadDone() 
-    });
+    // Fetch app root path
+    fetch(`/api/approot`, { headers: { Authorization: `Bearer ${this.state.token}` } })
+      .then(res => res.json())
+      .then(data => {
+        this.setState({
+          appRoot: data.appRoot,
+          photoMediaDestination: this.state.photoMediaDestination || '',
+          videoMediaDestination: this.state.videoMediaDestination || ''
+        });
+      })
+      .catch(err => console.error('Failed to fetch app root:', err));
+
+    // Fetch both Video and Still device lists
+    Promise.all([
+      fetch(`/api/videodevices`, { headers: { Authorization: `Bearer ${this.state.token}` } }),
+      fetch(`/api/camera/still_devices`, { headers: { Authorization: `Bearer ${this.state.token}` } })
+    ])
+      .then(async ([videoRes, stillRes]) => {
+        const videoData = await videoRes.json();
+        const stillData = await stillRes.json();
+
+        // --- Process Video Data ---
+        const vidDevs = videoData.devices || [];
+        const selVidDev = videoData.selectedDevice || (vidDevs.length > 0 ? vidDevs[0] : null);
+        const vidCaps = selVidDev ? selVidDev.caps : [];
+        const selVidCap = videoData.selectedCap || (vidCaps.length > 0 ? vidCaps[0] : null);
+
+        // FPS processing
+        const currentFpsOpts = selVidCap ? selVidCap.fps : [];
+        const currentFpsMax = selVidCap ? selVidCap.fpsmax : 0;
+        let selFps = videoData.selectedFps;
+        if (selFps == null) {
+          selFps = currentFpsMax > 0 ? currentFpsMax : (currentFpsOpts.length > 0 ? currentFpsOpts[0].value : 30);
+        }
+
+        // --- Process Still Data ---
+        const stillDevs = stillData.devices || [];
+        const selStillDev = stillData.selectedDevice || (stillDevs.length > 0 ? stillDevs[0] : null);
+        const stillCaps = selStillDev ? selStillDev.caps : [];
+        const selStillCap = stillData.selectedCap || (stillCaps.length > 0 ? stillCaps[0] : null);
+
+        // --- Check if photo/video modes are available ---
+        const capabilities = stillData.capabilities || { cv2: false, picamera2: false };
+        const photoVideoAvailable = capabilities.cv2; // cv2 is required for photo and video modes
+
+        // Determine Transport Mode from backend data (RTP vs RTSP)
+        const isRTP = videoData.selectedUseUDP === true;
+
+        // If photo/video isn't available, force streaming mode
+        const cameraModeToUse = (!photoVideoAvailable && (videoData.cameraMode === 'photo' || videoData.cameraMode === 'video')) 
+          ? 'streaming' 
+          : (videoData.cameraMode || 'streaming');
+
+        // Load the correct set of capabilities for the selected camera mode
+        let initialVidDevSel = selVidDev ? selVidDev.value : '';
+        let initialVidCaps = vidCaps;
+        let initialVidCapSel = selVidCap ? selVidCap.value : '';
+        let initialFpsOpts = currentFpsOpts;
+        let initialFpsMax = currentFpsMax;
+        let initialFps = selFps;
+        
+        if (cameraModeToUse === 'video') {
+            const savedDeviceValue = videoData.selectedDevice ? videoData.selectedDevice.value : null;
+            let matchingStillDev = stillDevs.find(d => d.id === savedDeviceValue);
+            
+            if (!matchingStillDev && stillDevs.length > 0) {
+                matchingStillDev = stillDevs[0];
+            }
+
+            if (matchingStillDev) {
+                initialVidDevSel = matchingStillDev.id;
+                initialVidCaps = matchingStillDev.caps ||[];
+                const matchedCap = initialVidCaps.length > 0 ? initialVidCaps[0] : null;
+                initialVidCapSel = matchedCap ? this.getStillCapValue(matchedCap) : '';
+                initialFpsOpts =[];
+                initialFpsMax = 120; // Allow typing manual FPS up to 120
+                initialFps = selFps || 30;
+            } else {
+                initialVidDevSel = '';
+                initialVidCaps = [];
+                initialVidCapSel = '';
+                initialFpsOpts =[];
+                initialFpsMax = 120;
+            }
+        }
+
+
+        this.setState({
+          // Network
+          ifaces: (videoData.networkInterfaces || []).map(ip => ip), // Keep as array of strings
+
+          // Video State
+          videoDevices: vidDevs,
+          vidDeviceSelected: initialVidDevSel,
+          videoCaps: initialVidCaps,
+          vidCapSelected: initialVidCapSel,
+          videoIsRecording: false,
+
+          // Still State
+          stillDevices: stillDevs,
+          stillDeviceSelected: selStillDev ? selStillDev.id : '',
+          stillCaps: stillCaps,
+          stillCapSelected: selStillCap ? this.getStillCapValue(selStillCap) : '',
+
+          // Common
+          active: videoData.active || false,
+          cameraMode: cameraModeToUse,
+          streamAddresses: videoData.streamAddresses || [],
+          photoVideoAvailable: photoVideoAvailable,
+
+          // Options
+          transportSelected: isRTP ? "RTP" : "RTSP",
+          useUDPIP: videoData.selectedUseUDPIP || "127.0.0.1",
+          useUDPPort: videoData.selectedUseUDPPort || 5600,
+          bitrate: videoData.selectedBitrate || 1100,
+          rotSelected: (videoData.selectedRotation && videoData.selectedRotation.value != null) ? videoData.selectedRotation.value : 0,
+          timestamp: videoData.selectedUseTimestamp || false,
+          enableCameraHeartbeat: videoData.selectedUseCameraHeartbeat || false,
+          mavStreamSelected: (videoData.selectedMavStreamURI && videoData.selectedMavStreamURI.value) ? videoData.selectedMavStreamURI.value : (this.state.ifaces[0] || '127.0.0.1'),
+
+          FPSMax: initialFpsMax,
+          fpsOptions: initialFpsOpts,
+          fpsSelected: initialFps,
+
+          compression: (videoData.compression && videoData.compression.value) ? videoData.compression.value : 'H264',
+
+          videoMediaDestination: videoData.videoMediaDestination || '',
+          stillMediaDestination: stillData.stillMediaDestination || '',
+        });
+
+        if (videoData.selectedUseUDPIP) this.isMulticastUpdateIP(videoData.selectedUseUDPIP);
+        this.loadDone();
+
+        // Open socket and listen for file saves
+        this.socket = ioClient();
+        this.socket.on('camera:filesaved', (data) => {
+          const fname = data && (data.filename || data.file);
+          if (fname) {
+            // Store the filename in the state
+            this.setState(prevState => {
+              const isRecording = prevState.videoIsRecording;
+              const cameraMode = prevState.cameraMode;
+              let notification = '';
+
+              // Change the notification after recording is stopped
+              if (cameraMode === 'video') {
+                notification = isRecording
+                ? `Recording video to ${fname}`
+                : `Recorded video to ${fname}`
+              } else {
+                notification = `Saved photo to ${fname}`
+              }
+
+              return {
+                currentVideoFile: fname,
+                notification: notification
+              };
+            });
+        }
+      });
+      })
+      .catch(err => {
+        console.error("Error loading devices:", err);
+        this.setState({ error: "Failed to load camera configuration." });
+        this.loadDone();
+      });
+    }
+
+// Disconnect the socket that listens for file save events
+componentWillUnmount() {
+  if (this.socket) {
+    this.socket.off('camera:filesaved');
+    this.socket.disconnect();
+    this.socket = null;
+  }
+  if (super.componentWillUnmount) super.componentWillUnmount();
+}
+
+  // Helper to generate a unique string value for still caps (since they don't always have a 'value' property)
+  getStillCapValue(cap) {
+    if (!cap) return '';
+    if (cap.value) return cap.value;
+    return `${cap.width}x${cap.height}x${cap.format}`;
   }
 
-  handleVideoChange = (event) => {
-    //new video device
+  handleCameraModeChange = (event) => {
+    const newMode = event.target.value;
+    const updates = { cameraMode: newMode };
+
+    // Reset device/resolution selections when switching between streaming and video modes
+    if (newMode === 'video') {
+      const firstStillDevice = this.state.stillDevices.length > 0 ? this.state.stillDevices[0] : null;
+      const firstCap = firstStillDevice && firstStillDevice.caps.length > 0 ? firstStillDevice.caps[0] : null;
+
+      updates.vidDeviceSelected = firstStillDevice ? firstStillDevice.id : '';
+      updates.videoCaps = firstStillDevice ? firstStillDevice.caps :[];
+      updates.vidCapSelected = firstCap ? this.getStillCapValue(firstCap) : '';
+      updates.FPSMax = 120;
+      updates.fpsOptions =[];
+      updates.fpsSelected = 30;
+    } else if (newMode === 'streaming') {
+      // Reset back to Streaming capabilities
+      const firstVidDevice = this.state.videoDevices.length > 0 ? this.state.videoDevices[0] : null;
+      const firstCap = firstVidDevice && firstVidDevice.caps.length > 0 ? firstVidDevice.caps[0] : null;
+
+      updates.vidDeviceSelected = firstVidDevice ? firstVidDevice.value : '';
+      updates.videoCaps = firstVidDevice ? firstVidDevice.caps :[];
+      updates.vidCapSelected = firstCap ? firstCap.value : '';
+      
+      const newFpsOpts = firstCap ? (firstCap.fps || []) :[];
+      const newFpsMax = firstCap ? (firstCap.fpsmax || 0) : 0;
+      updates.FPSMax = newFpsMax;
+      updates.fpsOptions = newFpsOpts;
+      updates.fpsSelected = newFpsMax > 0 ? newFpsMax : (newFpsOpts.length > 0 ? newFpsOpts[0].value : 30);
+    }
+
+    this.setState(updates);
+  }
+
+  // --- Video Device Handlers ---
+  handleVideoDeviceChange = (event) => {
     const value = event.target.value;
-    const device = this.state.dev.find(d => d.value === value);
-    
-    this.setState({ vidDeviceSelected: value, vidres: device.caps }, () => {
-      this.handleResChange(null, this.state.streamingStatus !== true ? device.caps[0].value : this.state.vidResSelected.value);
-    });
-    
+    const device = this.state.videoDevices.find(d => d.value === value);
+
+    if (device) {
+      const newCaps = device.caps || [];
+      const defaultCap = newCaps.length > 0 ? newCaps[0] : null;
+
+      // Recalculate FPS
+      const newFpsOpts = defaultCap ? defaultCap.fps : [];
+      const newFpsMax = defaultCap ? defaultCap.fpsmax : 0;
+      const newFps = newFpsMax > 0 ? newFpsMax : (newFpsOpts.length > 0 ? newFpsOpts[0].value : 30);
+
+      this.setState({
+        vidDeviceSelected: value,
+        videoCaps: newCaps,
+        vidCapSelected: defaultCap ? defaultCap.value : '',
+        FPSMax: newFpsMax,
+        fpsOptions: newFpsOpts,
+        fpsSelected: newFps
+      });
+
+      // Auto-set compression if H264 native
+      if (defaultCap && defaultCap.format === "video/x-h264") {
+        this.setState({ compression: 'H264' });
+      }
+    }
   }
 
-  handleResChange = (event, capsOverride) => {
-    //resolution box new selected value
-    let caps = {};
-    if (event !== null) {
-      caps = event.target.value;
-    } else {
-      caps = capsOverride;
-    }
-    //get the corrsponding caps object
-    const device = this.state.dev.find(d => d.value === this.state.vidDeviceSelected);
-    const capsObj = device.caps.find(c => c.value === caps);
-    console.log('Selected caps: ' + JSON.stringify(capsObj));
-    
-    if (capsObj.fpsmax !== 0) {
-      this.setState({ 
-        vidResSelected: caps, 
-        FPSMax: capsObj.fpsmax,
-        fps: capsObj.fps,
-        fpsSelected: Math.min(capsObj.fpsmax, 10), 
-      });
-    } else {
-      console.log('Setting fps to first value: ' + JSON.stringify(capsObj.fps[0].value));
-      this.setState({ 
-        vidResSelected: caps, 
-        FPSMax: capsObj.fpsmax,
-        fps: capsObj.fps,
-        fpsSelected: capsObj.fps[0].value,
+  handleVideoRecordingDeviceChange = (event) => {
+    // Handler for video recording mode using still devices
+    const value = event.target.value;
+    const device = this.state.stillDevices.find(d => d.id === value);
+
+    if (device) {
+      const newCaps = device.caps || [];
+      const defaultCap = newCaps.length > 0 ? newCaps[0] : null;
+
+      this.setState({
+        vidDeviceSelected: value,
+        videoCaps: newCaps,
+        vidCapSelected: defaultCap ? this.getStillCapValue(defaultCap) : '',
+        fpsSelected: 30,
+        // Allow manual FPS inputs:
+        FPSMax: 120,
+        fpsOptions:[]
       });
     }
-    
-    //override if a h264 format is selected
-    if (capsObj.format === "video/x-h264") {
-      this.setState({ compression: 'H264' });
+  }
+
+  handleVideoResChange = (event) => {
+    const value = event.target.value;
+    const cap = this.state.videoCaps.find(c => c.value === value);
+
+    if (cap) {
+      const newFpsOpts = cap.fps || [];
+      const newFpsMax = cap.fpsmax || 0;
+
+      this.setState({
+        vidCapSelected: value,
+        FPSMax: newFpsMax,
+        fpsOptions: newFpsOpts,
+        fpsSelected: newFpsMax > 0 ? Math.min(newFpsMax, 10) : (newFpsOpts.length > 0 ? newFpsOpts[0].value : 30)
+      });
+
+    if (cap.format === "video/x-h264") {
+        this.setState({ compression: 'H264' });
+      }
     }
+  }
+
+  handleVideoRecordingResChange = (event) => {
+    // Resolution change for video recording mode using still device caps
+    const value = event.target.value;
+    const cap = this.state.videoCaps.find(c => this.getStillCapValue(c) === value);
+
+    if (cap) {
+      this.setState({
+        vidCapSelected: value
+      });
+    }
+  }
+
+  handleStillDeviceChange = (event) => {
+    const id = event.target.value;
+    const device = this.state.stillDevices.find(d => d.id === id);
+
+    if (device) {
+      const newCaps = device.caps || [];
+      this.setState({
+        stillDeviceSelected: id,
+        stillCaps: newCaps,
+        stillCapSelected: newCaps.length > 0 ? this.getStillCapValue(newCaps[0]) : ''
+      });
+    }
+  }
+
+  handleStillCapChange = (event) => {
+    this.setState({ stillCapSelected: event.target.value });
   }
 
   handleRotChange = (event) => {
@@ -159,42 +455,219 @@ class VideoPage extends basePage {
     this.setState({ mavStreamSelected: event.target.value });
   }
 
-  handleStreaming = () => {
-    //user clicked start/stop streaming
-    const device = this.state.dev.find(d => d.value === this.state.vidDeviceSelected);
-    const capsObj = device.caps.find(c => c.value === this.state.vidResSelected);
-    this.setState({ waiting: true }, () => {
-      fetch('/api/startstopvideo', {
+  handleMediaDestinationChange = (event, mode) => {
+    // Update media destination paths for photos and videos
+    if (mode === 'video') {
+      this.setState({ videoMediaDestination: event.target.value });
+    } else {
+      this.setState({ stillMediaDestination: event.target.value });
+    }
+  }
+
+  handleCaptureStill = () => {
+    if (!this.state.active || this.state.cameraMode !== 'photo') {
+      this.setState({ error: "Camera must be active in Photo Mode." });
+      return;
+    }
+    this.setState({ waiting: true, error: null });
+    fetch('/api/capturestillphoto', {
+      method: 'POST',
+      headers: { 'Authorization': `Bearer ${this.state.token}` }
+    })
+      .then(res => { if (!res.ok) throw new Error("Capture failed"); })
+      .catch(err => this.setState({ error: err.message }))
+      .finally(() => this.setState({ waiting: false }));
+  }
+
+  handleToggleVideoRecording = () => {
+    if (!this.state.active || this.state.cameraMode !== 'video') {
+      this.setState({ error: "Camera must be active in Video Mode." });
+      return;
+    }
+    this.setState({ waiting: true, error: null });
+
+    fetch('/api/togglevideorecording', {
+      method: 'POST',
+      headers: { 'Authorization': `Bearer ${this.state.token}` }
+    })
+      .then(res => { if (!res.ok) throw new Error("Toggle recording failed"); })
+      .then(() => {
+        // Toggle the recording state
+        this.setState(prevState => {
+          const starting = !prevState.videoIsRecording;
+          let newNotification = prevState.notification;
+          if (starting) {
+            // Display an interim notification until the filename is available
+            newNotification = 'Starting video recording...';
+          } else if (prevState.currentVideoFile){
+            // Change the notification to display the filename after recording was stopped
+              newNotification = `Recorded video to ${prevState.currentVideoFile}`;            
+          } else {
+              newNotification = 'Video recording stopped';
+          }
+        return {
+          videoIsRecording: starting,
+          currentVideoFile: starting ? '' : prevState.currentVideoFile,
+          notification: newNotification
+        };
+        });
+      })
+      .catch(err => this.setState({ error: err.message }))
+      .finally(() => this.setState({ waiting: false }));
+  }
+
+  handleStartCamera = () => {
+    const {
+      cameraMode, vidDeviceSelected, vidCapSelected, videoCaps, videoDevices,
+      stillDeviceSelected, stillCapSelected, stillCaps, stillDevices
+    } = this.state;
+
+    this.setState({ waiting: true, error: null });
+
+    let body = {
+      cameraMode: cameraMode,
+      useCameraHeartbeat: this.state.enableCameraHeartbeat
+    };
+
+    try {
+      if (cameraMode === 'streaming') {
+        // Streaming mode: use videoDevices
+        // 1. Find the device
+        const device = videoDevices.find(d => d.value === vidDeviceSelected);
+
+        // SAFETY CHECK: If device isn't found
+        if (!device) {
+          throw new Error("Video device not found. Please select a device from the list.");
+        }
+
+        // 2. Find the resolution (capability)
+        const capsObj = device.caps.find(c => c.value === vidCapSelected);
+
+        // SAFETY CHECK: If resolution isn't found
+        if (!capsObj) {
+          throw new Error("Selected resolution is not valid for this device. Please select a Resolution.");
+        }
+
+        body = {
+          ...body,
+          videoDevice: vidDeviceSelected,
+          height: capsObj.height,
+          width: capsObj.width,
+          format: capsObj.format,
+          rotation: this.state.rotSelected,
+          fps: parseInt(this.state.fpsSelected), // Make sure FPS is an integer
+          bitrate: parseInt(this.state.bitrate), // Make sure bitrate is an integer
+          useUDP: this.state.transportSelected === 'RTP',
+          useUDPIP: this.state.useUDPIP,
+          useUDPPort: this.state.useUDPPort,
+          useTimestamp: this.state.timestamp,
+          mavStreamSelected: this.state.mavStreamSelected,
+          compression: this.state.compression
+        };
+
+      } else if (cameraMode === 'video') {
+        // Video recording mode: use stillDevices
+        const device = stillDevices.find(d => d.id === vidDeviceSelected);
+        if (!device) throw new Error("Video device not found. Please select a device from the list.");
+
+        const capObj = device.caps.find(c => this.getStillCapValue(c) === vidCapSelected);
+        if (!capObj) throw new Error("Selected resolution is not valid for this device.");
+
+        body = {
+          ...body,
+          videoDevice: vidDeviceSelected,
+          height: capObj.height,
+          width: capObj.width,
+          format: capObj.format,
+          rotation: this.state.rotSelected,
+          fps: parseInt(this.state.fpsSelected),
+          bitrate: parseInt(this.state.bitrate),
+          mediaDestination: this.state.videoMediaDestination
+        };
+
+      } else if (cameraMode === 'photo') {
+
+        const device = stillDevices.find(d => d.id === stillDeviceSelected);
+        if (!device) throw new Error("Photo device not found.");
+
+        const capObj = stillCaps.find(c => this.getStillCapValue(c) === stillCapSelected);
+        if (!capObj) throw new Error("Photo resolution not valid.");
+
+        body = {
+          ...body,
+          stillDevice: stillDeviceSelected,
+          stillWidth: capObj.width,
+          stillHeight: capObj.height,
+          stillFormat: capObj.format,
+          mediaDestination: this.state.stillMediaDestination
+        };
+      }
+
+      console.log("Starting camera with:", body);
+
+      fetch('/api/camera/start', {
         method: 'POST',
         headers: {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
           'Authorization': `Bearer ${this.state.token}`
         },
-        body: JSON.stringify({
-          active: !this.state.streamingStatus,
-          device: this.state.vidDeviceSelected,
-          height: capsObj.height,
-          width: capsObj.width,
-          format: capsObj.format,
-          rotation: this.state.rotSelected,
-          fps: this.state.FPSMax !== 0 ? this.state.fpsSelected : Number(typeof this.state.fpsSelected === 'object' ? this.state.fpsSelected : this.state.fpsSelected),
-          //fps: this.state.fpsSelected,
-          bitrate: this.state.bitrate,
-          transport: this.state.transportSelected,
-          useUDPIP: this.state.useUDPIP,
-          useUDPPort: this.state.useUDPPort,
-          useTimestamp: this.state.timestamp,
-          useCameraHeartbeat: this.state.enableCameraHeartbeat,
-          mavStreamSelected: this.state.mavStreamSelected,
-          compression: this.state.compression,
-          customRTSPSource: this.state.customRTSPSource
+        body: JSON.stringify(body)
+      })
+        .then(res => res.json().then(data => ({ ok: res.ok, data })))
+        .then(({ ok, data }) => {
+          if (!ok) throw new Error(data.error || "Failed to start camera");
+          this.setState({
+            active: data.active,
+            streamAddresses: data.addresses || [],
+            videoIsRecording: false
+          });
+
+          // Re-fetch devices to update status if necessary
+          return fetch('/api/videodevices', { headers: { Authorization: `Bearer ${this.state.token}` } });
         })
-      }).then(response => response.json()).then(state => { 
-        this.setState(state); 
-        this.setState({ waiting: false }) 
-      });
-    });
+        .then(res => res.json())
+        .then(data => {
+          // Update network interfaces if they changed
+          if (data.networkInterfaces) this.setState({ ifaces: data.networkInterfaces });
+        })
+        .catch(err => {
+          console.error("Start error:", err);
+          this.setState({ error: err.message });
+        })
+        .finally(() => this.setState({ waiting: false }));
+
+    } catch (err) {
+      this.setState({ error: err.message, waiting: false });
+    }
+  }
+
+  handleStopCamera = () => {
+    this.setState({ waiting: true, error: null });
+
+    // Before stopping the camera, check if it's chandleStopCameraurrently recording
+    const wasRecording = this.state.videoIsRecording;
+    const lastFile = this.state.currentVideoFile;
+
+
+    fetch('/api/camera/stop', {
+      method: 'POST',
+      headers: { 'Authorization': `Bearer ${this.state.token}` }
+    })
+      .then(res => res.json())
+      .then(data => {
+        this.setState({
+          active: data.active,
+          streamAddresses: [],
+          videoIsRecording: false,
+          // If the camera was recording, update the notification
+          notification: (wasRecording && lastFile)
+            ? `Recorded video to ${lastFile}`
+            : this.state.notification
+        });
+      })
+      .catch(err => this.setState({ error: err.message }))
+      .finally(() => this.setState({ waiting: false }));
   }
 
   isrtspSourceSelected() {
@@ -267,174 +740,274 @@ class VideoPage extends basePage {
   }
 
   renderTitle() {
-    return "Video Streaming";
+    return "Photo and Video";
   }
 
-  renderContent() {   
+renderContent() {
+    const { active, cameraMode, loading, waiting } = this.state;
+    const isStreaming = cameraMode === 'streaming';
+    const isVideo = cameraMode === 'video';
+    const isPhoto = cameraMode === 'photo';
+
+    // Determine which settings to show based on mode
+    const showVideoSettings = isStreaming || isVideo;
+    const showPhotoSettings = isPhoto;
+    const showStreamingOptions = isStreaming;
+
     return (
       <Form style={{ width: 600 }}>
-        <p><i>Stream live video from any connected camera devices. Only 1 camera can be streamed at a time. Multicast IP addresses are supported in RTP mode.</i></p>
+        <p><i>Configure camera operation: live video streaming, still photo capture, or local video recording. Only one mode can be active at a time. Multicast IP addresses are supported in RTP mode.</i></p>
+        <p>Locally saved photos and videos can be viewed or deleted from the <Link to="/flightlogs">Flight Logs and Media</Link> page.</p>
+        {!isStreaming && (
+          <p>Media destination folder (an optional relative sub-folder inside: <i>{this.state.appRoot}/media/</i>)</p>
+        )}
+
+        {/* Camera Mode Selection */}
+        <div className="form-group row" style={{ marginBottom: '15px' }}>
+          <label className="col-sm-4 col-form-label">Camera Mode</label>
+          <div className="col-sm-8">
+            <Form.Check
+              inline
+              type="radio"
+              label="Streaming"
+              name="cameramode"
+              value="streaming"
+              disabled={active}
+              onChange={this.handleCameraModeChange}
+              checked={isStreaming}
+            />
+            <Form.Check
+              inline
+              type="radio"
+              label="Photo"
+              name="cameramode"
+              value="photo"
+              disabled={active || !this.state.photoVideoAvailable}
+              onChange={this.handleCameraModeChange}
+              checked={isPhoto}
+            />
+            <Form.Check
+              inline
+              type="radio"
+              label="Video Recording"
+              name="cameramode"
+              value="video"
+              disabled={active || !this.state.photoVideoAvailable}
+              onChange={this.handleCameraModeChange}
+              checked={isVideo}
+            />
+          </div>
+        </div>
+
+        {!this.state.photoVideoAvailable && this.state.showOpenCVWarning && (
+          <div className="alert alert-warning" role="alert" style={{ marginBottom: '15px' }}>
+            <strong>Photo and Video modes unavailable:</strong> OpenCV is not installed on this system. Only Streaming mode is available.
+            <Button variant="link" onClick={() => this.setState({ showOpenCVWarning: false })} style={{ marginLeft: '8px', padding: 0 }}>Dismiss</Button>
+          </div>
+        )}
+
         <Accordion defaultActiveKey="0">
           <Accordion.Item eventKey="0">
+
             <Accordion.Header>Configuration</Accordion.Header>
+
             <Accordion.Body>
-              <div className="form-group row" style={{ marginBottom: '5px' }}>
-                <label className="col-sm-4 col-form-label">Streaming Mode</label>
-                <div className="col-sm-8">
-                  <Form.Select
-                    disabled={this.state.streamingStatus}
-                    value={this.state.transportSelected}
-                    onChange={(e) => this.setState({ transportSelected: e.target.value })}
-                  >
-                    {this.state.transportOptions.map((option, idx) => (
-                      <option key={idx} value={option.value}>{option.label}</option>
-                    ))}
-                  </Form.Select>
-                </div>
-              </div>
+              {/* --- Streaming / Video Mode Settings --- */}
+              <div style={{ display: showVideoSettings ? 'block' : 'none' }}>
 
-              <div className="form-group row" style={{ marginBottom: '5px' }}>
-                <label className="col-sm-4 col-form-label">Device</label>
-                <div className="col-sm-8">
-                  <Form.Select 
-                    disabled={this.state.streamingStatus} 
-                    onChange={this.handleVideoChange} 
-                    value={this.state.vidDeviceSelected}
-                  >
-                    {this.state.dev.map((device, idx) => (
-                      <option key={idx} value={device.value}>{device.label}</option>
-                    ))}
-                  </Form.Select>
-                </div>
-              </div>
+                {/* Streaming Transport (Only for Streaming Mode) */}
+                {showStreamingOptions && (
+                  <div className="form-group row" style={{ marginBottom: '5px' }}>
+                    <label className="col-sm-4 col-form-label">Streaming Mode</label>
+                    <div className="col-sm-8">
+                      <Form.Select disabled={active} value={this.state.transportSelected} onChange={(e) => this.setState({ transportSelected: e.target.value })}>
+                        {this.state.transportOptions.map((opt, idx) => <option key={idx} value={opt.value}>{opt.label}</option>)}
+                      </Form.Select>
+                    </div>
+                  </div>
+                )}
 
-              <div style={{ display: this.isrtspSourceSelected() ? "block" : "none" }}>
+                {/* Video Device Select - Different sources based on mode */}
                 <div className="form-group row" style={{ marginBottom: '5px' }}>
-                  <label className="col-sm-4 col-form-label">RTSP Source URL</label>
+                  <label className="col-sm-4 col-form-label">Video Device</label>
                   <div className="col-sm-8">
-                    <Form.Control 
-                      type="text" 
-                      name="rtspsource" 
-                      disabled={this.state.streamingStatus} 
-                      value={this.state.customRTSPSource} 
-                      onChange={(e) => this.setState({ customRTSPSource: e.target.value })}
-                      placeholder="e.g. rtsp://username:password@url:port/stream" 
-                    />
+                    {isVideo ? (
+                      // Video recording mode: use still devices
+                      <Form.Select disabled={active} onChange={this.handleVideoRecordingDeviceChange} value={this.state.vidDeviceSelected}>
+                        {this.state.stillDevices.map((d, idx) => <option key={idx} value={d.id}>{d.type}: {d.card_name}</option>)}
+                      </Form.Select>
+                    ) : (
+                      // Streaming mode: use video devices
+                      <Form.Select disabled={active} onChange={this.handleVideoDeviceChange} value={this.state.vidDeviceSelected}>
+                        {this.state.videoDevices.map((d, idx) => <option key={idx} value={d.value}>{d.label}</option>)}
+                      </Form.Select>
+                    )}
                   </div>
                 </div>
+
+                {/* RTSP Source Input (If specific device selected) */}
+                {this.isrtspSourceSelected() && (
+                  <div className="form-group row" style={{ marginBottom: '5px' }}>
+                    <label className="col-sm-4 col-form-label">RTSP Source URL</label>
+                    <div className="col-sm-8">
+                      <Form.Control type="text" disabled={active} value={this.state.customRTSPSource} onChange={(e) => this.setState({ customRTSPSource: e.target.value })} />
+                    </div>
+                  </div>
+                )}
+
+                {/* Video Resolution */}
+                {!this.isrtspSourceSelected() && (
+                  <div className="form-group row" style={{ marginBottom: '5px' }}>
+                    <label className="col-sm-4 col-form-label">Resolution</label>
+                    <div className="col-sm-8">
+                      {isVideo ? (
+                        // Video recording mode: use still device caps format
+                        <Form.Select disabled={active} onChange={this.handleVideoRecordingResChange} value={this.state.vidCapSelected}>
+                          {this.state.videoCaps.map((c, idx) => <option key={idx} value={this.getStillCapValue(c)}>{c.width}x{c.height} ({c.format})</option>)}
+                        </Form.Select>
+                      ) : (
+                        // Streaming mode: use video device caps format
+                        <Form.Select disabled={active} onChange={this.handleVideoResChange} value={this.state.vidCapSelected}>
+                          {this.state.videoCaps.map((c, idx) => <option key={idx} value={c.value}>{c.width}x{c.height} ({c.format})</option>)}
+                        </Form.Select>
+                      )}
+                    </div>
+                  </div>
+                )}
+
+                {/* Rotation, Bitrate, Timestamp, Compression (Standard Video Settings) */}
+                {!this.isrtspSourceSelected() && (
+                  <>
+                    {/* Rotation (Hide if H264 native sometimes, but keeping logic simpler here) */}
+                    <div className="form-group row" style={{ marginBottom: '5px' }}>
+                      <label className="col-sm-4 col-form-label">Rotation</label>
+                      <div className="col-sm-8">
+                        <Form.Select disabled={active} onChange={this.handleRotChange} value={this.state.rotSelected}>
+                          {this.state.rotations.map((r, i) => <option key={i} value={r.value}>{r.label}</option>)}
+                        </Form.Select>
+                      </div>
+                    </div>
+
+                    <div className="form-group row" style={{ marginBottom: '5px' }}>
+                      <label className="col-sm-4 col-form-label">Max Bitrate</label>
+                      <div className="col-sm-8">
+                        <Form.Control disabled={active} type="number" min="50" max="50000" step="100" onChange={this.handleBitrateChange} value={this.state.bitrate} style={{ width: '100px', display: 'inline-block' }} /> kbps
+                      </div>
+                    </div>
+
+                    {/* Hide the timestamp control in video recording mode since it's not supported*/}
+                    {!isVideo && (
+                      <div className="form-group row" style={{ marginBottom: '5px' }}>
+                        <label className="col-sm-4 col-form-label">Timestamp</label>
+                        <div className="col-sm-8">
+                          <Form.Check
+                            type="checkbox"
+                            disabled={active}
+                            onChange={this.handleTimestampChange}
+                            checked={this.state.timestamp} /></div>
+                      </div>
+                    )}
+
+                    {/* Also hide the compression control since we don't have the ability to change ccompression options*/}
+                    {!isVideo && (
+                      <div className="form-group row" style={{ marginBottom: '5px' }}>
+                        <label className="col-sm-4 col-form-label">Compression</label>
+                        <div className="col-sm-8">
+                          <Form.Select disabled={active} value={this.state.compression} onChange={(e) => this.setState({ compression: e.target.value })}>
+                            {this.state.compressionOptions.map((o, i) => <option key={i} value={o.value}>{o.label}</option>)}
+                          </Form.Select>
+                        </div>
+                      </div>
+                    )}
+
+                    <div className="form-group row" style={{ marginBottom: '5px' }}>
+                      <label className="col-sm-4 col-form-label">Framerate</label>
+                      <div className="col-sm-8">
+                        {this.state.FPSMax === 0 ? (
+                          <Form.Select disabled={active} value={this.state.fpsSelected} onChange={this.handleFPSChange}>
+                            {this.state.fpsOptions.map((f, i) => <option key={i} value={f.value}>{f.label}</option>)}
+
+                          </Form.Select>
+                        ) : (
+                          <>
+                            <Form.Control disabled={active} type="number" min="1" max={this.state.FPSMax} onChange={this.handleFPSChange} value={this.state.fpsSelected} style={{ width: '80px', display: 'inline-block' }} />
+                            <span> fps (max: {this.state.FPSMax})</span>
+                          </>
+                        )}
+                      </div>
+                    </div>
+                  </>
+                )}
+
+                {/* RTP Settings (Only if Streaming + RTP) */}
+                {isStreaming && this.state.transportSelected === 'RTP' && (
+                  <>
+                    <div className="form-group row" style={{ marginBottom: '5px' }}>
+                      <label className="col-sm-4 col-form-label">Destination IP</label>
+                      <div className="col-sm-7">
+                        <IPAddressInput name="ipaddress" value={this.state.useUDPIP} onChange={this.handleUDPIPChange} disabled={active} />
+                      </div>
+                    </div>
+                    <div className="form-group row" style={{ marginBottom: '5px' }}>
+                      <label className="col-sm-4 col-form-label">Destination Port</label>
+                      <div className="col-sm-8">
+                        <Form.Control type="number" disabled={active} value={this.state.useUDPPort} onChange={this.handleUDPPortChange} />
+                      </div>
+                    </div>
+                  </>
+                )}
+
+                {/* Media Destinations */}
+                {isVideo && (
+                  <div className="form-group row" style={{ marginBottom: '5px' }}>
+                    <label className="col-sm-4 col-form-label">Media Destination</label>
+                    <div className="col-sm-8">
+                      <Form.Control 
+                        disabled={active} 
+                        type="text" 
+                        onChange={(e) => this.handleMediaDestinationChange(e, 'video')}
+                        value={this.state.videoMediaDestination}
+                        placeholder="e.g., flight_01"
+                      />
+                    </div>
+                  </div>
+                )}
               </div>
-              <div style={{ display: (this.isrtspSourceSelected()) ? "none" : "block" }}>
-                <div className="form-group row" style={{ marginBottom: '5px'}}>
+
+              {/* --- Photo Mode Settings --- */}
+              <div style={{ display: showPhotoSettings ? 'block' : 'none' }}>
+                <div className="form-group row" style={{ marginBottom: '5px' }}>
+                  <label className="col-sm-4 col-form-label">Photo Device</label>
+                  <div className="col-sm-8">
+                    <Form.Select disabled={active}
+                      onChange={this.handleStillDeviceChange}
+                      value={this.state.stillDeviceSelected}>
+                      {this.state.stillDevices.map((d, i) => <option key={i} value={d.id}>{d.type}: {d.card_name}</option>)}
+                    </Form.Select>
+                  </div>
+                </div>
+                <div className="form-group row" style={{ marginBottom: '5px' }}>
                   <label className="col-sm-4 col-form-label">Resolution</label>
                   <div className="col-sm-8">
-                    <Form.Select disabled={this.state.streamingStatus} onChange={this.handleResChange} value={this.state.vidResSelected}>
-                      {this.state.vidres.map((res, idx) => (
-                        <option key={idx} value={res.value}>{res.width}x{res.height} ({res.format})</option>
-                      ))}
+                    <Form.Select disabled={active} onChange={this.handleStillCapChange} value={this.state.stillCapSelected}>
+                      {this.state.stillCaps.map((c, i) => <option key={i} value={this.getStillCapValue(c)}>{c.width}x{c.height} ({c.format})</option>)}
                     </Form.Select>
                   </div>
                 </div>
-              </div>
-              <div style={{ display: (typeof this.state.vidResSelected !== 'undefined' && this.state.vidResSelected.format !== "video/x-h264" && !this.isrtspSourceSelected()) ? "block" : "none" }}>
                 <div className="form-group row" style={{ marginBottom: '5px' }}>
-                  <label className="col-sm-4 col-form-label">Rotation</label>
-                  <div className="col-sm-8">
-                    <Form.Select 
-                      disabled={this.state.streamingStatus} 
-                      onChange={this.handleRotChange} 
-                      value={this.state.rotSelected}
-                    >
-                      {this.state.rotations.map((rot, idx) => (
-                        <option key={idx} value={rot.value}>{rot.label}</option>
-                      ))}
-                    </Form.Select>
-                  </div>
-                </div>
-
-                <div className="form-group row" style={{ marginBottom: '5px' }}>
-                  <label className="col-sm-4 col-form-label">Maximum Bitrate</label>
+                  <label className="col-sm-4 col-form-label">Media Destination</label>
                   <div className="col-sm-8">
                     <Form.Control 
-                      disabled={this.state.streamingStatus} 
-                      type="number" 
-                      name="bitrate" 
-                      min="50" 
-                      max="50000" 
-                      step="10" 
-                      onChange={this.handleBitrateChange} 
-                      value={this.state.bitrate} 
-                    /> kbps
-                  </div>
-                </div>
-
-                <div className="form-group row" style={{ marginBottom: '5px' }}>
-                  <label className="col-sm-4 col-form-label">Timestamp Overlay</label>
-                  <div className="col-sm-8">
-                    <Form.Check 
-                      type="checkbox" 
-                      disabled={this.state.streamingStatus} 
-                      onChange={this.handleTimestampChange} 
-                      checked={this.state.timestamp} 
-                    />
-                  </div>
-                </div>
-
-                <div className="form-group row" style={{ marginBottom: '5px' }}>
-                  <label className="col-sm-4 col-form-label">Compression</label>
-                  <div className="col-sm-8">
-                    <Form.Select
-                      disabled={this.state.streamingStatus}
-                      value={this.state.compression}
-                      onChange={(e) => this.setState({ compression: e.target.value })}
-                    >
-                      {this.state.compressionOptions.map((option, idx) => (
-                        <option key={idx} value={option.value}>{option.label}</option>
-                      ))}
-                    </Form.Select>
-                  </div>
-                </div>
-              </div>
-              <div style={{ display: (this.isrtspSourceSelected()) ? "none" : "block" }}>
-                <div className="form-group row" style={{ marginBottom: '5px' }}>
-                  <label className="col-sm-4 col-form-label">Framerate</label>
-                  <div className="col-sm-8" style={{ display: (this.state.FPSMax === 0) ? "block" : "none" }}>
-                    <Form.Select disabled={this.state.streamingStatus} value={this.state.fpsSelected} onChange={this.handleFPSChangeSelect}>
-                      {this.state.fps.map((fps, idx) => (
-                        <option key={idx} value={fps.value}>{fps.label}</option>
-                      ))}
-                    </Form.Select>
-                  </div>
-                  <div className="col-sm-8" style={{ display: (this.state.FPSMax !== 0) ? "block" : "none" }}>
-                    <input disabled={this.state.streamingStatus} type="number" name="fps" min="1" max={this.state.FPSMax} step="1" onChange={this.handleFPSChange} value={this.state.fpsSelected} />fps (max: {this.state.FPSMax})
-                  </div>
-                </div>
-              </div>
-
-              <div style={{ display: (this.state.transportSelected === 'RTP') ? "block" : "none" }}>
-                <div className="form-group row" style={{ marginBottom: '5px' }}>
-                  <label className="col-sm-4 col-form-label ">Destination IP</label>
-                  <div className="col-sm-7">
-                    <IPAddressInput
-                      name="ipaddress"
-                      value={this.state.useUDPIP || ''}
-                      onChange={this.handleUDPIPChange}
-                      disabled={!(this.state.transportSelected === 'RTP') || this.state.streamingStatus}
-                    />
-                  </div>
-                </div>
-                <div className="form-group row" style={{ marginBottom: '5px' }}>
-                  <label className="col-sm-4 col-form-label">Destination Port</label>
-                  <div className="col-sm-8">
-                    <Form.Control 
+                      disabled={active} 
                       type="text" 
-                      name="port" 
-                      disabled={!(this.state.transportSelected === 'RTP') || this.state.streamingStatus} 
-                      value={this.state.useUDPPort} 
-                      onChange={this.handleUDPPortChange} 
+                      onChange={(e) => this.handleMediaDestinationChange(e, 'photo')}
+                      value={this.state.stillMediaDestination}
+                      placeholder="e.g., flight_01"
                     />
                   </div>
                 </div>
               </div>
+
             </Accordion.Body>
           </Accordion.Item>
 
@@ -445,104 +1018,131 @@ class VideoPage extends basePage {
               <div className="form-group row" style={{ marginBottom: '5px' }}>
                 <label className="col-sm-4 col-form-label">Enable camera heartbeats</label>
                 <div className="col-sm-7">
-                  <Form.Check 
-                    type="checkbox" 
-                    disabled={this.state.streamingStatus} 
-                    checked={this.state.enableCameraHeartbeat} 
-                    onChange={this.handleUseCameraHeartbeatChange} 
+                  <Form.Check
+                    type="checkbox"
+                      disabled={active}
+                      checked={this.state.enableCameraHeartbeat}
+                      onChange={this.handleUseCameraHeartbeatChange}
                   />
                 </div>
               </div>
-              <div style={{ display: (this.state.enableCameraHeartbeat && (!(this.state.transportSelected === 'RTP'))) ? "block" : "none" }}>
+              {/* Show Source IP only if Heartbeat Enabled AND Streaming Mode AND RTSP (Server) mode */}
+              {(this.state.enableCameraHeartbeat && isStreaming && this.state.transportSelected === 'RTSP') && (
                 <div className="form-group row" style={{ marginBottom: '5px' }}>
                   <label className="col-sm-4 col-form-label">Video source IP Address</label>
                   <div className="col-sm-8">
-                    <Form.Select 
-                      disabled={this.state.streamingStatus} 
-                      onChange={this.handleMavStreamChange} 
+                    <Form.Select
+                      disabled={active}
+                      onChange={this.handleMavStreamChange}
                       value={this.state.mavStreamSelected}
                     >
-                      {this.state.ifaces.map((iface, idx) => (
-                        <option key={idx} value={iface}>{iface}</option>
+                      {this.state.ifaces.map((ip, i) => (
+                        <option key={i} value={ip}>{ip}</option>
                       ))}
                     </Form.Select>
                   </div>
                 </div>
-              </div>
+              )}
             </Accordion.Body>
           </Accordion.Item>
         </Accordion>
 
-        <div className="form-group row" style={{ marginBottom: '5px' }}>
-          <div className="col-sm-8">
-            <Button onClick={this.handleStreaming} className="btn btn-primary">
-              {this.state.streamingStatus ? "Stop Streaming" : "Start Streaming"}
+        {/* --- Control Buttons --- */}
+        <div style={{ marginTop: '15px', display: 'flex', justifyContent: 'center' }}>
+          <div style={{ width: '600px', textAlign: 'center' }}>
+
+            {/* Take Photo Button */}
+            {active && isPhoto && (
+              <Button onClick={this.handleCaptureStill} variant="secondary" disabled={waiting} style={{ marginRight: '10px', marginBottom: '10px' }}>
+                Take Photo
+              </Button>
+            )}
+
+            {/* Toggle Recording Button */}
+            {active && isVideo && (
+              <Button onClick={this.handleToggleVideoRecording} variant="secondary" disabled={waiting} style={{ marginRight: '10px', marginBottom: '10px' }}>
+                {this.state.videoIsRecording ? 'Stop Recording' : 'Start Recording'}
+              </Button>
+            )}
+
+            {/* Main Start/Stop Button */}
+            <Button onClick={active ? this.handleStopCamera : this.handleStartCamera} disabled={waiting} className="btn btn-primary" style={{ marginBottom: '10px' }}>
+              {waiting ? 'Processing...' : (active
+                ? `Stop ${isStreaming ? 'Streaming' : (isPhoto ? 'Photo Mode' : 'Video Mode')}`
+                : `Start ${isStreaming ? 'Streaming' : (isPhoto ? 'Photo Mode' : 'Video Mode')}`
+              )}
             </Button>
+                {/* Photo/video taken notification text box */}
+                {this.state.notification && (
+                  <div 
+                      className={`alert ${this.state.videoIsRecording ? 'alert-warning' : 'alert-info'}`} 
+                      role="alert" 
+                      style={{marginBottom: '0px'}}
+                  >
+                    {this.state.notification}
+                    <Button variant="link" onClick={() => this.setState({ notification: '' })} style={{ marginLeft: '8px', padding: 0 }}>Dismiss</Button>
+                  </div>
+                )}
           </div>
           <br/>
         </div>
 
-        <br />
-        <h3 style={{ display: (this.state.streamingStatus) ? "block" : "none" }}>Connection strings for video stream</h3>
-        <Accordion defaultActiveKey="0" style={{ display: (this.state.streamingStatus && !(this.state.transportSelected === 'RTP')) ? "block" : "none" }}>
-          <Accordion.Item eventKey="0">
-            <Accordion.Header>
-              + RTSP Streaming Addresses (for VLC, etc)
-            </Accordion.Header>
-            <Accordion.Body>
-              {this.state.streamAddresses.map((item, index) => (
-                <p key={index} style={{ fontFamily: "monospace" }}>{item}</p>
-              ))}
-            </Accordion.Body>
-          </Accordion.Item>
-          <Accordion.Item eventKey="1">
-            <Accordion.Header>
-              + GStreamer Connection Strings
-            </Accordion.Header>
-            <Accordion.Body>
-              {this.state.streamAddresses.map((item, index) => (
-                <p key={index} style={{ fontFamily: "monospace" }}>gst-launch-1.0 rtspsrc location={item} latency=0 is-live=True ! queue ! decodebin ! autovideosink</p>
-              ))}
-            </Accordion.Body>
-          </Accordion.Item>
-          <Accordion.Item eventKey="2">
-            <Accordion.Header>
-              + Mission Planner Connection Strings
-            </Accordion.Header>
-            <Accordion.Body>
-              {this.state.streamAddresses.map((item, index) => (
-                <p key={index} style={{ fontFamily: "monospace" }}>rtspsrc location={item} latency=0 is-live=True ! queue ! application/x-rtp ! {this.state.compression === "H264" ? "rtph264depay" : "rtph265depay"} ! {this.state.compression === "H264" ? "avdec_h264" : "avdec_h265"} ! videoconvert ! video/x-raw,format=BGRA ! appsink name=outsink</p>
-              ))}
-            </Accordion.Body>
-          </Accordion.Item>
-        </Accordion>
-        <Accordion defaultActiveKey="0" style={{ display: (this.state.streamingStatus && (this.state.transportSelected === 'RTP')) ? "block" : "none" }}>
-          <Accordion.Item eventKey="0">
-            <Accordion.Header>
-              + QGroundControl
-            </Accordion.Header>
-            <Accordion.Body>
-              <p style={{ fontFamily: "monospace" }}>{this.doQGCformatselection()}</p>
-              <p style={{ fontFamily: "monospace" }}>Port: {this.state.useUDPPort}</p>
-            </Accordion.Body>
-          </Accordion.Item>
-          <Accordion.Item eventKey="1">
-            <Accordion.Header>
-              + GStreamer
-            </Accordion.Header>
-            <Accordion.Body>
-              <p style={{ fontFamily: "monospace" }}>{this.doGstreamerRTPString()}</p>
-            </Accordion.Body>
-          </Accordion.Item>
-          <Accordion.Item eventKey="2">
-            <Accordion.Header>
-              + Mission Planner Connection Strings
-            </Accordion.Header>
-            <Accordion.Body>
-              <p style={{ fontFamily: "monospace" }}>{this.doMissionPlannerRTPString()}</p>
-            </Accordion.Body>
-          </Accordion.Item>
-        </Accordion>
+        {/* --- Connection Strings (Streaming Only) --- */}
+        {active && isStreaming && (
+          <>
+            <br />
+            <h3>Connection strings for video stream</h3>
+
+            {/* RTSP Strings */}
+            {this.state.transportSelected === 'RTSP' && (
+              <Accordion defaultActiveKey="0">
+                <Accordion.Item eventKey="0">
+                  <Accordion.Header>+ RTSP Streaming Addresses</Accordion.Header>
+                  <Accordion.Body>
+                    {this.state.streamAddresses.map((item, index) => <p key={index} style={{ fontFamily: "monospace" }}>{item}</p>)}
+                  </Accordion.Body>
+                </Accordion.Item>
+                <Accordion.Item eventKey="1">
+                  <Accordion.Header>+ GStreamer</Accordion.Header>
+                  <Accordion.Body>
+                    {this.state.streamAddresses.map((item, index) => <p key={index} style={{ fontFamily: "monospace" }}>gst-launch-1.0 rtspsrc location={item} latency=0 is-live=True ! queue ! decodebin ! autovideosink</p>)}
+                  </Accordion.Body>
+                </Accordion.Item>
+                <Accordion.Item eventKey="2">
+                  <Accordion.Header>+ Mission Planner</Accordion.Header>
+                  <Accordion.Body>
+                    {this.state.streamAddresses.map((item, index) => <p key={index} style={{ fontFamily: "monospace" }}>rtspsrc location={item} latency=0 is-live=True ! queue ! application/x-rtp ! {this.state.compression === "H264" ? "rtph264depay" : "rtph265depay"} ! {this.state.compression === "H264" ? "avdec_h264" : "avdec_h265"} ! videoconvert ! video/x-raw,format=BGRA ! appsink name=outsink</p>)}
+                  </Accordion.Body>
+                </Accordion.Item>
+              </Accordion>
+            )}
+
+            {/* RTP Strings */}
+            {this.state.transportSelected === 'RTP' && (
+              <Accordion defaultActiveKey="0">
+                <Accordion.Item eventKey="0">
+                  <Accordion.Header>+ QGroundControl</Accordion.Header>
+                  <Accordion.Body>
+                    <p style={{ fontFamily: "monospace" }}>{this.doQGCformatselection()}</p>
+                    <p style={{ fontFamily: "monospace" }}>Port: {this.state.useUDPPort}</p>
+                  </Accordion.Body>
+                </Accordion.Item>
+                <Accordion.Item eventKey="1">
+                  <Accordion.Header>+ GStreamer</Accordion.Header>
+                  <Accordion.Body>
+                    <p style={{ fontFamily: "monospace" }}>{this.doGstreamerRTPString()}</p>
+                  </Accordion.Body>
+                </Accordion.Item>
+                <Accordion.Item eventKey="2">
+                  <Accordion.Header>+ Mission Planner</Accordion.Header>
+                  <Accordion.Body>
+                    <p style={{ fontFamily: "monospace" }}>{this.doMissionPlannerRTPString()}</p>
+                  </Accordion.Body>
+                </Accordion.Item>
+              </Accordion>
+            )}
+          </>
+        )}
       </Form>
     );
   }


### PR DESCRIPTION
~~This draft PR is a work in progress to address feature request #167 and continues where PR #229 left off. It's **incomplete** and _some parts are likely still broken._ Adding the PR now for visibility into the proposed changes and to solicit feedback if there is any.~~

This reorganizes the camera system into three distinct modes:

- live streaming (i.e., what exists now)
- still photo capture (saved locally on the companion computer)
- local video recording (saved locally on the CC)

It adds a Python helper script to detect all of the camera devices available for still/video capture (get_camera_caps.py), and a backend/server script (photovideo.py) that listens for a SIGUSR1 from Rpanion to trigger it to either take a still photo, or to toggle video recording on and off.

By default, photovideo.py will use the first available camera supported by Picamera2(). If that's not available, or if a V4l2 device path is specified, it will use V4L2 instead.

To do list (for this PR):
- ~~Testing and bug fixes as required to make sure all of the above works correctly~~
- ~~Confirm that camera service still responds correctly to MAVLink commands~~
- ~~Add/update unit tests~~

To do list for future PR(s):
- ~~Add geotagging ability~~ Added in this PR
- Implement MAVLink gimbal control
- Implement more camera settings (exposure, white balance, etc.) (#228)
- (Edit: moved to future PR to-do list) Investigate and implement measures to support Mission Planner stream auto-discovery (#282 and probably also #169) 