### PR TITLE
Video: neaten up streaming transport options

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -693,7 +693,9 @@ app.get('/api/softwareinfo', authenticateToken, (req, res) => {
 
 app.get('/api/videodevices', authenticateToken, (req, res) => {
   vManager.populateAddresses()
-  vManager.getVideoDevices((err, devices, active, seldevice, selRes, selRot, selbitrate, selfps, SeluseUDP, SeluseUDPIP, SeluseUDPPort, timestamp, fps, FPSMax, vidres, useCameraHeartbeat, selMavURI) => {
+  vManager.getVideoDevices((err, devices, active, seldevice, selRes, selRot, selbitrate,
+                            selfps, SeluseUDPIP, SeluseUDPPort, timestamp,
+                            fps, FPSMax, vidres, useCameraHeartbeat, selMavURI, compression, Seltransport, transportOptions) => {
     if (!err) {
       res.setHeader('Content-Type', 'application/json')
       res.send(JSON.stringify({
@@ -707,7 +709,8 @@ app.get('/api/videodevices', authenticateToken, (req, res) => {
         rotSelected: selRot,
         bitrate: selbitrate,
         fpsSelected: selfps,
-        UDPChecked: SeluseUDP,
+        transportSelected: Seltransport,
+        transportOptions: transportOptions,
         useUDPIP: SeluseUDPIP,
         useUDPPort: SeluseUDPPort,
         timestamp,
@@ -715,7 +718,8 @@ app.get('/api/videodevices', authenticateToken, (req, res) => {
         fps: fps,
         FPSMax: FPSMax,
         enableCameraHeartbeat: useCameraHeartbeat,
-        mavStreamSelected: selMavURI
+        mavStreamSelected: selMavURI,
+        compression: compression
       }))
     } else {
       res.setHeader('Content-Type', 'application/json')
@@ -976,7 +980,7 @@ app.post('/api/startstopvideo', authenticateToken, [check('active').isBoolean(),
   check('device').if(check('active').isIn([true])).isLength({ min: 2 }),
   check('height').if(check('active').isIn([true])).isInt({ min: 1 }),
   check('width').if(check('active').isIn([true])).isInt({ min: 1 }),
-  check('useUDP').if(check('active').isIn([true])).isBoolean(),
+  check('transport').if(check('active').isIn([true])).isIn(['RTP', 'RTSP']),
   check('useTimestamp').if(check('active').isIn([true])).isBoolean(),
   check('useCameraHeartbeat').if(check('active').isIn([true])).isBoolean(),
   check('useUDPPort').if(check('active').isIn([true])).isPort(),
@@ -994,7 +998,7 @@ app.post('/api/startstopvideo', authenticateToken, [check('active').isBoolean(),
   }
   // user wants to start/stop video streaming
   vManager.startStopStreaming(req.body.active, req.body.device, req.body.height, req.body.width, req.body.format, req.body.rotation,
-                              req.body.bitrate, req.body.fps, req.body.useUDP, req.body.useUDPIP, req.body.useUDPPort,
+                              req.body.bitrate, req.body.fps, req.body.transport, req.body.useUDPIP, req.body.useUDPPort,
                               req.body.useTimestamp, req.body.useCameraHeartbeat, req.body.mavStreamSelected, req.body.compression, (err, status, addresses) => {
     if (!err) {
       res.setHeader('Content-Type', 'application/json')

--- a/server/videostream.test.js
+++ b/server/videostream.test.js
@@ -30,7 +30,10 @@ describe('Video Functions', function () {
     const vManager = new VideoStream(settings)
 
     vManager.populateAddresses()
-    vManager.getVideoDevices(function (err, devices, active, seldevice, selRes, selRot, selbitrate, selfps, SeluseUDP, SeluseUDPIP, SeluseUDPPort, timestamp, fps, FPSMax, vidres, selMavURI) {
+    // err, devices, active, seldevice, selRes, selRot, selbitrate, selfps, SeluseUDPIP, SeluseUDPPort, timestamp, fps, FPSMax, vidres, cameraHeartbeat, selMavURI, compression, transport, transportOptions
+    vManager.getVideoDevices(function (err, devices, active, seldevice, selRes, selRot, selbitrate, selfps, SeluseUDPIP,
+                                       SeluseUDPPort, timestamp, fps, FPSMax, vidres, cameraHeartbeat, selMavURI,
+                                       compression, transport, transportOptions) {
       assert.equal(err, null)
       assert.equal(active, false)
       assert.notEqual(seldevice, null)
@@ -38,7 +41,6 @@ describe('Video Functions', function () {
       assert.notEqual(selRot, null)
       assert.notEqual(selbitrate, null)
       assert.notEqual(selfps, null)
-      assert.equal(SeluseUDP, false)
       assert.equal(SeluseUDPIP, '127.0.0.1')
       assert.equal(SeluseUDPPort, 5400)
       assert.equal(timestamp, false)
@@ -46,6 +48,9 @@ describe('Video Functions', function () {
       assert.notEqual(FPSMax, null)
       assert.notEqual(vidres, null)
       assert.notEqual(selMavURI, null)
+      assert.deepEqual(compression, { label: 'H.264', value: 'H264' })
+      assert.deepEqual(transport, { label: 'RTSP', value: 'RTSP' })
+      assert.deepEqual(transportOptions, [{ label: 'RTP', value: 'RTP' }, { label: 'RTSP', value: 'RTSP' }])
       done()
     })
   }).timeout(5000)


### PR DESCRIPTION
This was originally going to be an implementation of WebRTC as a transport option for video, but this requires a bunch of custom gstreamer build/compile to get the ``webrtcsink`` element.

I'll hold off until Ubuntu/Debian come with the gst element as an installable apt package.

For now, this is just neatening up the transport options.