### PR TITLE
Add an option to disable authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,8 @@ on the "User Management" page.
 Usernames and passwords are stored in the ``user.json`` file in the Rpanion-server folder. Resetting this file (via ``git checkout user.json``)
 will reset the usernames/passwords back to it's defaults.
 
+If Rpanion-server runs in a trusted network or you ensure access control by other means, you can choose to disable the built-in access control by adding the member `"authRequired": false` to `settings.json`.
+
 ## Tests
 
 Unit tests are split into separate commands for the frontend (ReactJS) and backend.

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ on the "User Management" page.
 Usernames and passwords are stored in the ``user.json`` file in the Rpanion-server folder. Resetting this file (via ``git checkout user.json``)
 will reset the usernames/passwords back to it's defaults.
 
-If Rpanion-server runs in a trusted network or you ensure access control by other means, you can choose to disable the built-in access control by adding the member `"authRequired": false` to `settings.json`.
+If Rpanion-server runs in a trusted network or you ensure access control by other means, you can choose to disable the built-in access control by setting an environment variable `DISABLE_AUTH=1` on the node process, e.g. in the systemd `rpanion-server.service`.
 
 ## Tests
 

--- a/server/index.js
+++ b/server/index.js
@@ -371,7 +371,7 @@ app.post('/api/auth', authenticateToken, async (req, res) => {
 // Middleware to check if the request has a valid token
 function authenticateToken(req, res, next) {
   // Skip authentication in development mode
-  if (process.env.NODE_ENV === 'development' || !settings.value('authRequired', true)) {
+  if (process.env.NODE_ENV === 'development' || process.env.DISABLE_AUTH === '1') {
     return next();
   }
 

--- a/server/index.js
+++ b/server/index.js
@@ -371,7 +371,7 @@ app.post('/api/auth', authenticateToken, async (req, res) => {
 // Middleware to check if the request has a valid token
 function authenticateToken(req, res, next) {
   // Skip authentication in development mode
-  if (process.env.NODE_ENV === 'development') {
+  if (process.env.NODE_ENV === 'development' || !settings.value('authRequired', true)) {
     return next();
   }
 

--- a/server/index.js
+++ b/server/index.js
@@ -364,8 +364,12 @@ app.post('/api/logout', authenticateToken, async (req, res) => {
 
 // Simple token authentication call
 app.post('/api/auth', authenticateToken, async (req, res) => {
+  const authEnabled = !(process.env.NODE_ENV === 'development' || process.env.DISABLE_AUTH === '1')
+
   res.setHeader('Content-Type', 'application/json')
-  res.send(JSON.stringify({error: null}))
+  res.send(JSON.stringify({
+    authEnabled
+  }))
 })
 
 // Middleware to check if the request has a valid token

--- a/src/AppRouter.jsx
+++ b/src/AppRouter.jsx
@@ -26,26 +26,22 @@ function AppRouter () {
     const userToken = JSON.parse(tokenString)
     const token = userToken?.token
 
-    if (token) {
-      fetch('/api/auth', {
-        method: 'POST',
-        headers: {
-          Authorization: `Bearer ${token}`,
-        },
-      })
-      .then((response) => {
-        if (!response.ok) {
-          setIsAuthenticated(false)
-        } else {
-          setIsAuthenticated(true)
-        }
-      })
-      .catch(() => {
+    fetch('/api/auth', {
+      method: 'POST',
+      headers: token
+        ? { Authorization: `Bearer ${token}` }
+        : {}, // always try the /api/auth endpoint, even with no token: maybe authRequired is false
+    })
+    .then((response) => {
+      if (!response.ok) {
         setIsAuthenticated(false)
-      })
-    } else {
+      } else {
+        setIsAuthenticated(true)
+      }
+    })
+    .catch(() => {
       setIsAuthenticated(false)
-    }
+    })
   }, [location.pathname])
 
   // Show nothing while checking authentication
@@ -83,7 +79,7 @@ function AppRouter () {
       <div className="page-content-wrapper" style={{ width: '100%' }}>
         <div className="container-fluid">
           <Routes>
-            <Route exact path="/" element={<Home />} />
+            <Route exact path="/" element={<Home showLogin={!isAuthenticated} />} />
             <Route exact path="/controller" element={<FCConfig />} />
             <Route exact path="/ppp" element={<PPPPage />} />
             <Route exact path="/network" element={<NetworkConfig />} />

--- a/src/AppRouter.jsx
+++ b/src/AppRouter.jsx
@@ -18,6 +18,7 @@ import PPPPage from './ppp.jsx'
 
 function AppRouter () {
   const [isAuthenticated, setIsAuthenticated] = useState(null)
+  const [isAuthEnabled, setIsAuthEnabled] = useState(true)
   const location = useLocation()
 
   useEffect(() => {
@@ -32,11 +33,16 @@ function AppRouter () {
         ? { Authorization: `Bearer ${token}` }
         : {}, // always try the /api/auth endpoint, even with no token: maybe DISABLE_AUTH is set
     })
-    .then((response) => {
+    .then(async (response) => {      
       if (!response.ok) {
         setIsAuthenticated(false)
       } else {
         setIsAuthenticated(true)
+
+        const data = await response.json()
+        if (data?.authEnabled === false) {
+          setIsAuthEnabled(false)
+        }
       }
     })
     .catch(() => {
@@ -72,7 +78,9 @@ function AppRouter () {
           <Link className='list-group-item list-group-item-action bg-light' to="/vpn">VPN Config</Link>
           <Link className='list-group-item list-group-item-action bg-light' to="/about">About</Link>
           <Link className='list-group-item list-group-item-action bg-light' to="/users">User Management</Link>
-          <Link className='list-group-item list-group-item-action bg-light' to="/logoutconfirm">Logout</Link>
+          {isAuthEnabled && (
+            <Link className='list-group-item list-group-item-action bg-light' to="/logoutconfirm">Logout</Link>
+          )}
         </div>
       </div>
 
@@ -91,7 +99,9 @@ function AppRouter () {
             <Route exact path="/adhoc" element={<AdhocConfig />} />
             <Route exact path="/cloud" element={<CloudConfig />} />
             <Route exact path="/vpn" element={<VPN/>} />
-            <Route exact path="/logoutconfirm" element={<Logout/>} />
+            {isAuthEnabled && (
+              <Route path="/logoutconfirm" element={<Logout />} />
+            )}
             <Route exact path="/users" element={<UserManagement/>} />
             <Route path="*" element={<NoMatch />} />
           </Routes>

--- a/src/AppRouter.jsx
+++ b/src/AppRouter.jsx
@@ -30,7 +30,7 @@ function AppRouter () {
       method: 'POST',
       headers: token
         ? { Authorization: `Bearer ${token}` }
-        : {}, // always try the /api/auth endpoint, even with no token: maybe authRequired is false
+        : {}, // always try the /api/auth endpoint, even with no token: maybe DISABLE_AUTH is set
     })
     .then((response) => {
       if (!response.ok) {

--- a/src/basePage.jsx
+++ b/src/basePage.jsx
@@ -6,6 +6,7 @@ import Button from 'react-bootstrap/Button';
 import Spinner from 'react-bootstrap/Spinner';
 import React from 'react'
 import Login from './login.jsx'
+import PropTypes from 'prop-types';
 
 class basePage extends Component {
   constructor(props, useSocketIO = false) {
@@ -97,7 +98,7 @@ class basePage extends Component {
   }
 
   render() {
-    if(!this.state.token) {
+    if(this.props.showLogin) {
       return (
         <div>
           <title>{this.renderTitle()}</title>
@@ -165,6 +166,11 @@ class basePage extends Component {
     }
   }
 
+}
+
+// PropTypes validation
+basePage.propTypes = {
+  showLogin: PropTypes.bool,
 }
 
 export default basePage;

--- a/src/basePage.jsx
+++ b/src/basePage.jsx
@@ -36,12 +36,8 @@ class basePage extends Component {
       })
       .then((response) => {
         if (!response.ok) {
-          // Handle HTTP errors
-          return response.json().then((errorData) => {
-            if (errorData) {
-              this.setState({ token: null })
-            }
-          });
+          this.setState({ token: null })
+          return
         }
         return response.json();
       })


### PR DESCRIPTION
I run Rpanion in a trusted network. Because of this, authentication is not really required, and having to fill out the login mask on each new install or new browser becomes tiresome. The same is conceivable if someone were to run Rpanion behind a reverse proxy that takes care of authentication.
Because having authentication is of course a useful feature in other scenarios, I chose to implement a new `settings.json` flag to make authentication optional.

This required a small change to the authentication flow: Now, the /api/auth endpoint is checked always, no matter if we have a token or not, or what that token may be. The server/backend has to make the decision whether or not to accept. Here, I extended the development mode logic and accept any request to /api/auth, now also in production mode if `authRequired` is false.

On the frontend, instead of deciding based on presence/absence of a token in localStorage, I pass the current state of `isAuthenticated` to basePage. Based on this, it is decided whether the frontent should show the login form or not.
Since `isAuthenticated = false` causes AppRouter to forward to `/` anyway, only `/` needs to be passed this variable.