### PR TITLE
Deploy: Remove zerotier keys when making disk image

### DIFF
--- a/deploy/pishrink.sh
+++ b/deploy/pishrink.sh
@@ -309,6 +309,13 @@ if [[ $prep == true ]]; then
   mountdir=$(mktemp -d)
   mount "$loopback" "$mountdir"
   rm -rf "$mountdir/var/cache/apt/archives/*" "$mountdir/var/lib/dhcpcd5/*" "$mountdir/var/log/*" "$mountdir/var/tmp/*" "$mountdir/tmp/*" "$mountdir/etc/ssh/*_host_*"
+  if [ -d "$mountdir/var/lib/zerotier-one" ]; then
+    info "Syspreping: Removing ZeroTier identity so each cloned device gets a unique node ID"
+    rm -f "$mountdir/var/lib/zerotier-one/identity.secret" \
+          "$mountdir/var/lib/zerotier-one/identity.public" \
+          "$mountdir/var/lib/zerotier-one/authtoken.secret"
+    rm -f "$mountdir/var/lib/zerotier-one/networks.d/"*
+  fi
   umount "$mountdir"
 fi
 


### PR DESCRIPTION
For #399.

I'd previously not installed Zerotier on the Rpanion-server disk image, as it contained the unique keys. This would result in every user of the Rpanion-server disk image having the same Zerotier ID and private key(s), creating network conflicts.

This PR adds in code to remove the Zerotier config from the disk image.

[Zerotier's already installed automatically via the ``install_common_libraries.sh`` script]