### PR TITLE
Video: Camera and MAVLink Improvements

### DIFF
--- a/mavlink/mavManager.js
+++ b/mavlink/mavManager.js
@@ -233,8 +233,13 @@ class mavManager {
       return
     }
 
+    // Get the Message ID
+    const msgId = msg.constructor ? msg.constructor.ID : (msg._id || msg.id);
+
     let protocol = null
-    if (this.version === 2) {
+    // Switch to V2 for messages >255
+    // Don't use strict equality ("===") because version might be stored as a string
+    if (this.version == 2 || (msgId && msgId > 255)) {
       protocol = new MavLinkProtocolV2(this.targetSystem, component)
     } else {
       protocol = new MavLinkProtocolV1(this.targetSystem, component)
@@ -245,8 +250,7 @@ class mavManager {
 
     this.udpStream.send(buffer, this.RinudpPort, this.RinudpIP, function (error) {
       if (error) {
-        this.udpStream.close()
-        console.log(error)
+        console.error("MAVLink UDP Send Error:", error)
       } else {
         // console.log(msgbuf)
         // console.log(buf)

--- a/python/get_camera_caps.py
+++ b/python/get_camera_caps.py
@@ -81,90 +81,76 @@ def get_card_name(dev_path):
 
     return None
 
-def get_libcamera_models():
-    """Get CSI camera model names from libcamera"""
+def get_subdev_name(dev_path):
+    """Read sensor model name from sysfs — fast file read, no subprocess."""
+    dev_name = os.path.basename(dev_path)  # e.g. v4l-subdev0
+    sysfs_path = f"/sys/class/video4linux/{dev_name}/name"
     try:
-        from picamera2 import Picamera2
-        models = {}
-        camera_info = Picamera2.global_camera_info()
-        
-        for idx, info in enumerate(camera_info):
-            model = info.get('Model', None)
-            if model and "usb@" not in info.get('Id', ''):
-                models[idx] = model
-        
-        return list(models.values())
-    except:
-        return []
+        with open(sysfs_path, 'r') as f:
+            # sysfs name is e.g. "imx219 10-0010" — take just the model part
+            return f.read().strip().split()[0]
+    except (FileNotFoundError, IndexError):
+        return None
 
+# Check library availability without importing picamera2 at all.
+# Saves ~10s on a Pi Zero 2W
 def get_capabilities():
-    """Check for availability of required libraries for photo/video modes"""
-    capabilities = {
-        'cv2': False,
-        'picamera2': False
+    """Check cv2 and picamera2 availability without triggering libcamera init."""
+    import importlib.util
+    return {
+        'cv2': importlib.util.find_spec('cv2') is not None,
+        'picamera2': importlib.util.find_spec('picamera2') is not None,
     }
-    
-    try:
-        import cv2
-        capabilities['cv2'] = True
-    except ImportError:
-        pass
-    
-    try:
-        from picamera2 import Picamera2
-        capabilities['picamera2'] = True
-    except (ImportError, OSError):
-        pass
-    
-    return capabilities
 
 check_if_v4l2_ctl_avail()
-
 devices = []
-
-# Get libcamera model names first
-libcamera_models = get_libcamera_models()
-model_idx = 0
-
-# Process CSI cameras
+ 
+# Query v4l2 subdevices before initializing libcamera.
+# On Pi, libcamera's daemon holds /dev/media0 open after global_camera_info(),
+# which causes v4l2-ctl subdev ioctls to fail or return no results.
+# Doing the v4l2 queries first avoids that conflict entirely.
+ 
+# Pass 1: enumerate CSI caps via v4l2-ctl (no libcamera yet)
+csi_devices = []
 for dev_path in get_subdev_paths():
     mbus_codes = get_mbus_codes(dev_path)
     if not mbus_codes:
         continue
-    
-    # Use libcamera model name if available, otherwise fall back to the v4l2 name
-    if model_idx < len(libcamera_models):
-        card_name = libcamera_models[model_idx]
-        model_idx += 1
-    else:
-        card_name = get_card_name(dev_path) or "Unnamed CSI Camera"
+
+    # Get card name here via v4l2 — avoids needing libcamera later
+    card_name = get_subdev_name(dev_path) or "Unnamed CSI Camera"
 
     device_caps = {
-        # Don't specify a device path for CSI cameras,
-        # but generate a unique ID for them.
         'id': f"CSI-{re.sub(r'[^a-zA-Z0-9]', '_', card_name)}",
         'device': None,
         'type': 'CSI',
         'card_name': card_name,
         'caps': []
     }
-
+ 
+    seen = set()
     for mbus_code, pixel_format in mbus_codes:
         resolutions = get_resolutions(dev_path, mbus_code)
-
         for res in resolutions:
-            fmt = pixel_format.split("MEDIA_BUS_FMT_")[1] if "MEDIA_BUS_FMT_" in pixel_format else pixel_format
-            cap_info = {
-                'format': fmt,
+            key = (res['width'], res['height'])
+            if key in seen:
+                continue
+            seen.add(key)
+            device_caps['caps'].append({
+                'format': 'YUV420',
                 'width': res['width'],
                 'height': res['height'],
-                'label': f"{res['width']}x{res['height']}_{fmt}",
-                'value': f"{mbus_code}_{fmt}_{res['width']}x{res['height']}"
-            }
-            device_caps['caps'].append(cap_info)
-
+                'label': f"{res['width']}x{res['height']}",
+                'value': f"{res['width']}x{res['height']}_YUV420"
+            })
+        break  # all mbus codes report the same resolutions — one query is enough
+ 
     if device_caps['caps']:
-        devices.append(device_caps)
+        csi_devices.append(device_caps)
+
+# Pass 2: Initialize libcamera to get friendly model names and capabilities.
+# v4l2-ctl is finished with the subdevs so there is no conflict.
+devices.extend(csi_devices)
 
 # Process UVC cameras
 for dev_path in get_video_device_paths():
@@ -178,12 +164,9 @@ for dev_path in get_video_device_paths():
             'caps': caps
         })
 
-# Get library capabilities and output as a single JSON object
-capabilities = get_capabilities()
-
 output = {
     'devices': devices,
-    'capabilities': capabilities
+    'capabilities': get_capabilities()
 }
 
 print(json.dumps(output, indent=4))

--- a/python/photovideo.py
+++ b/python/photovideo.py
@@ -136,6 +136,7 @@ def geotag_image(filepath):
 
     gps_file = '/tmp/rpanion_gps.json'
     if not os.path.exists(gps_file):
+        print("GPS coordinate data not found in /tmp/rpanion_gps.json")
         return
 
     try:

--- a/server/index.js
+++ b/server/index.js
@@ -70,6 +70,11 @@ const fcManager = new fcManagerClass(settings)
 const logManager = new flightLogger()
 const ntripClient = new ntrip(settings)
 const cloud = new cloudManager(settings)
+
+// Pass the fcManager instance to the videoStream,
+// so it can access position data for geotagging photos
+vManager.setFlightControllerManager(fcManager)
+
 const logConversion = new logConversionManager(settings)
 const adhocManager = new Adhoc(settings)
 const userMgmt = new userLogin()
@@ -203,7 +208,6 @@ app.post('/api/capturestillphoto', authenticateToken, function (req, res) {
     vManager.captureStillPhoto(null, null, null, currentPosition);
     res.status(200).send({ message: 'Capture signal sent.' });
   } else {
-    console.log("[API /api/capturestillphoto] Conditions NOT met. Sending 400.");
     res.status(400).send({ error: 'Camera not active or not in photo mode.' });
   }
 })
@@ -225,7 +229,18 @@ app.post('/api/togglevideorecording', authenticateToken, function (req, res) {
     }
   } else {
     console.log(`[API /togglevideorecording] Condition NOT met (active=${vManager.active}, mode=${vManager.cameraMode}). Sending 400.`);
-    res.status(400).send({ error: 'Camera is not active in video recording mode.' });
+    res.status(400).send({ error: 'Camera is not active or not in video recording mode.' });
+  }
+})
+
+// General command ack response with optional result code (default 0 = ACCEPTED)
+vManager.eventEmitter.on('camera_command_ack', (commandId, senderSysId, senderCompId, targetComponent, result = 0) => {
+  try {
+    if (fcManager.m) {
+      fcManager.m.sendCommandAck(commandId, 0, senderSysId, senderCompId, targetComponent)
+    }
+  } catch (err) {
+    console.log(`Error sending ACK for command ${commandId}:`, err);
   }
 })
 
@@ -257,7 +272,8 @@ vManager.eventEmitter.on('camerainfo', (msg, senderSysId, senderCompId, targetCo
   try {
     if (fcManager.m) {
       // Acknowledge the CAMERA_INFORMATION request
-      fcManager.m.sendCommandAck(common.CameraInformation.MSG_ID, 0, senderSysId, senderCompId, targetComponent)
+      // Ack the MAV_CMD_REQUEST_MESSAGE (512), NOT the requested message ID.
+      fcManager.m.sendCommandAck(512, 0, senderSysId, senderCompId, targetComponent)
       fcManager.m.sendData(msg, senderCompId)
     }
   } catch (err) {
@@ -270,7 +286,9 @@ vManager.eventEmitter.on('videostreaminfo', (msg, senderSysId, senderCompId, tar
   try {
     if (fcManager.m) {
       // Acknowledge the VIDEO_STREAM_INFORMATION request
-      fcManager.m.sendCommandAck(common.VideoStreamInformation.MSG_ID, 0, senderSysId, senderCompId, targetComponent)
+      // fcManager.m.sendCommandAck(common.VideoStreamInformation.MSG_ID, 0, senderSysId, senderCompId, targetComponent)
+      // Ack the MAV_CMD_REQUEST_MESSAGE (512), NOT the requested message ID.
+      fcManager.m.sendCommandAck(512, 0, senderSysId, senderCompId, targetComponent)
       fcManager.m.sendData(msg, senderCompId)
     }
   } catch (err) {
@@ -283,11 +301,28 @@ vManager.eventEmitter.on('camerasettings', (msg, senderSysId, senderCompId, targ
   try {
     if (fcManager.m) {
       // Acknowledge the CAMERA_SETTINGS request
-      fcManager.m.sendCommandAck(common.CameraSettings.MSG_ID, 0, senderSysId, senderCompId, targetComponent)
+      // fcManager.m.sendCommandAck(common.CameraSettings.MSG_ID, 0, senderSysId, senderCompId, targetComponent)
+      // Ack the MAV_CMD_REQUEST_MESSAGE (512), NOT the requested message ID.
+      fcManager.m.sendCommandAck(512, 0, senderSysId, senderCompId, targetComponent)
       fcManager.m.sendData(msg, senderCompId)
     }
   } catch (err) {
     console.log('Error sending CameraSettings:', err);
+    // console.log(err)
+  }
+})
+
+// Got a STORAGE_INFORMATION event, send to flight controller
+vManager.eventEmitter.on('storageinfo', (msg, senderSysId, senderCompId, targetComponent) => {
+  try {
+    if (fcManager.m) {
+      // Acknowledge the STORAGE_INFORMATION request
+      // Ack the MAV_CMD_REQUEST_MESSAGE (512), NOT the requested message ID.
+      fcManager.m.sendCommandAck(512, 0, senderSysId, senderCompId, targetComponent)
+      fcManager.m.sendData(msg, senderCompId)
+    }
+  } catch (err) {
+    console.log('Error sending StorageInformation:', err);
     // console.log(err)
   }
 })
@@ -301,6 +336,18 @@ vManager.eventEmitter.on('cameratrigger', (msg, senderCompId) => {
     }
   } catch (err) {
     console.log('Error sending CameraTrigger:', err);
+  }
+})
+
+// Got a CAMERA_IMAGE_CAPTURED event, send to flight controller
+vManager.eventEmitter.on('cameraimagecaptured', (msg, senderCompId,) => {
+  try {
+    if (fcManager.m) {
+      // Send the CAMERA_IMAGE_CAPTURED message to the flight controller
+      fcManager.m.sendData(msg, senderCompId)
+    }
+  } catch (err) {
+    console.log('Error sending CameraImageCaptured:', err);
   }
 })
 

--- a/server/videostream.js
+++ b/server/videostream.js
@@ -27,6 +27,7 @@ class videoStream {
     this.stillDevices = null; // Still devices
     this.videoSettings = null;
     this.stillSettings = null;
+    this.fcManager = null;    // Flight controller manager reference, set externally if available
 
     // Load saved settings from the 'camera' namespace
     this.active = this.settings.value('camera.active', false);
@@ -66,6 +67,11 @@ class videoStream {
     return dest ? path.join(logpaths.mediaDir, dest) : logpaths.mediaDir;
   }
 
+  // Reference the fcManager so we can access position data for geotagging
+  setFlightControllerManager(fcManager) {
+    this.fcManager = fcManager;
+  }
+
   async initialize() {
     try {
       // Discover Video Hardware and wait for data
@@ -80,8 +86,7 @@ class videoStream {
         });
       });
 
-      // 2. Discover Still Photo Hardware (We will add this function in Step 2)
-      // For now, we wrap it in a try/catch so it doesn't crash if the helper isn't there yet
+      // Discover Still Photo Hardware
       try {
         await new Promise((resolve, reject) => {
           this.getStillDevices((err) => err ? reject(err) : resolve());
@@ -90,7 +95,7 @@ class videoStream {
         console.log("Still hardware discovery skipped or failed.");
       }
 
-      // 3. Start the camera in the last saved mode
+      // Start the camera in the last saved mode
       this.startCamera((err) => {
         if (err) {
           console.error('Camera start error during init:', err);
@@ -129,7 +134,6 @@ class videoStream {
       })
     })
   }
-
 
   // Format and store all the possible rtsp addresses
   populateAddresses (factory) {
@@ -197,8 +201,8 @@ class videoStream {
 
   // video streaming
   getVideoDevices (callback) {
-    // get all video device details
-    //dont update if streaming is running, as some camera won't be detected if in use
+    // Get all video device details
+    // dont update if streaming is running, as some cameras won't be detected if in use
     const networkInterfaces = this.scanInterfaces();
 
     // Don't re-scan hardware if a stream is already running
@@ -218,7 +222,7 @@ class videoStream {
         fpsMax: 0
       };
 
-      // 1. Find the device and capability currently being used
+      // Find the device and capability currently being used
       if (this.videoSettings && this.devices) {
         responseData.selectedDevice = this.devices.find(d => d.value === this.videoSettings.device);
         if (responseData.selectedDevice) {
@@ -233,7 +237,7 @@ class videoStream {
           responseData.fpsOptions = responseData.selectedCap?.fps || [];
         }
 
-        // 2. Map raw numbers back to the UI's Object format
+        // Map raw numbers back to the UI's Object format
         responseData.selectedRotation = {
           label: (this.videoSettings.rotation || 0) + '°',
           value: (this.videoSettings.rotation || 0)
@@ -243,7 +247,7 @@ class videoStream {
           value: this.videoSettings.mavStreamSelected || '127.0.0.1'
         };
 
-        // 3. Map simple values
+        // Map simple values
         responseData.selectedisRecording = this.videoSettings.isRecording || false;
         responseData.selectedBitrate = this.videoSettings.bitrate || 1100;
         responseData.selectedFps = this.videoSettings.fps || 30;
@@ -356,7 +360,6 @@ class videoStream {
     });
   }
 
-
   saveSettings() {
     try {
       this.settings.setValue('camera.active', this.active);
@@ -466,6 +469,8 @@ class videoStream {
 
     // Start MAVLink heartbeats if enabled
     if (this.useCameraHeartbeat) {
+      // Send one immediate heartbeat before starting the timer
+      this.eventEmitter.emit('cameraheartbeat', minimal.MavType.CAMERA, minimal.MavAutopilot.INVALID, minimal.MavComponent.CAMERA);
       this.startHeartbeatInterval();
       this.sendVideoStreamInformation(null, minimal.MavComponent.CAMERA, null);
     }
@@ -500,8 +505,11 @@ class videoStream {
 
     // Start MAVLink heartbeats if enabled
     if (this.useCameraHeartbeat) {
+      // Send one immediate heartbeat before starting the timer
+      this.eventEmitter.emit('cameraheartbeat', minimal.MavType.CAMERA, minimal.MavAutopilot.INVALID, minimal.MavComponent.CAMERA);
       this.startHeartbeatInterval();
       this.sendCameraInformation(null, minimal.MavComponent.CAMERA, null);
+      this.sendCameraSettings(this.sendCameraInformation(null, minimal.MavComponent.CAMERA, null));
     }
   }
 
@@ -510,7 +518,7 @@ class videoStream {
 
     const dest = this.toAbsolutePath(this.videoSettings.mediaDestination);
 
-    // Convert bitrate from kbps to bps Picamera2
+    // Convert bitrate from kbps to bps for Picamera2
     const bitrateBps = this.videoSettings.bitrate * 1000;
 
     const args = [
@@ -542,8 +550,11 @@ class videoStream {
 
     // Start MAVLink heartbeats if enabled
     if (this.useCameraHeartbeat) {
+      // Send one immediate heartbeat before starting the timer
+      this.eventEmitter.emit('cameraheartbeat', minimal.MavType.CAMERA, minimal.MavAutopilot.INVALID, minimal.MavComponent.CAMERA);
       this.startHeartbeatInterval();
       this.sendCameraInformation(null, minimal.MavComponent.CAMERA, null);
+      this.sendCameraSettings(this.sendCameraInformation(null, minimal.MavComponent.CAMERA, null));
     }
   }
 
@@ -557,7 +568,7 @@ class videoStream {
 
       if (!callbackCalled) {
         callbackCalled = true;
-        console.log(`${modeName}: No response from script after 60s, assuming start.`);
+        console.log(`${modeName}: No response from script after 90s, assuming start.`);
         this.active = true;
         this.saveSettings();
         callback(null, { active: true, addresses: this.deviceAddresses });
@@ -715,17 +726,20 @@ class videoStream {
   }
 
   startHeartbeatInterval () {
+
     // start the 1-sec loop to send heartbeat events
     this.intervalObj = setInterval(() => {
       const mavType = minimal.MavType.CAMERA
       const autopilot = minimal.MavAutopilot.INVALID
       const component = minimal.MavComponent.CAMERA
 
+      // Emit the 1Hz camera heartbeat
       this.eventEmitter.emit('cameraheartbeat', mavType, autopilot, component)
+
     }, 1000)
   }
 
-  captureStillPhoto(senderSysId, senderCompId, targetComponent, positionData = null) {
+  captureStillPhoto(senderSysId, senderCompId, targetComponent, positionData = null, commandId = null) {
     console.log('Attempting captureStillPhoto. Internal state: active=', this.active, 'mode=', this.cameraMode, 'deviceStream exists=', !!this.deviceStream);
 
     // Capture a single still photo
@@ -747,6 +761,7 @@ class videoStream {
         console.error('Failed to write GPS temp file:', e);
       }
     } else {
+      console.error('GPS data not available for geotagging. Check that "Enable datastream requests" is enabled on the Flight Controller page.');
       // Clean up old file to prevent stale tags
       if (fs.existsSync('/tmp/rpanion_gps.json')) {
         fs.unlinkSync('/tmp/rpanion_gps.json');
@@ -760,11 +775,63 @@ class videoStream {
     const msg = new common.CameraTrigger()
     // Date.now() returns time in milliseconds
     msg.timeUsec = BigInt(Date.now() * 1000)
-    // Increment the photo counter
-    msg.seq = this.photoSeq++
+    // Pre-increment the photo counter so that it's correct for
+    // both the CameraTrigger and the CameraImageCaptured messages
+    msg.seq = ++this.photoSeq
 
-    this.eventEmitter.emit('digicamcontrol', senderSysId, senderCompId, targetComponent)
+    // If triggered by a MAVLink command, emit a generalized ACK event
+    if (commandId && senderSysId !== null) {
+      this.eventEmitter.emit('camera_command_ack', commandId, senderSysId, senderCompId, targetComponent)
+    } else {
+      // Fallback for legacy listeners or safety
+      this.eventEmitter.emit('digicamcontrol', senderSysId, senderCompId, targetComponent)
+    }
+    
+    // Advertise that an image was captured
     this.eventEmitter.emit('cameratrigger', msg, senderCompId)
+    this.sendCameraImageCaptured(senderCompId)
+
+    // Send updated storage availability
+    this.sendStorageInfo(senderSysId, senderCompId, targetComponent)
+  }
+
+  sendCameraImageCaptured(senderCompId) {
+    const msg = new common.CameraImageCaptured();
+
+    // Import the most recently saved GPS coordinates
+    let latitude = null, longitude = null, altitude = null, relative_altitude = null;
+    if (fs.existsSync('/tmp/rpanion_gps.json')) {
+      try {
+        const data = JSON.parse(fs.readFileSync('/tmp/rpanion_gps.json', 'utf8'));
+        latitude = data.lat;
+        longitude = data.lon;
+        altitude = data.alt;
+        relative_altitude = data.relAlt;
+      } catch (e) {
+        console.error('sendCameraImageCaptured: Failed to read GPS file:', e);
+      }
+    } else {
+      console.log('sendCameraImageCaptured: GPS file not found, skipping geotagging.');
+    }
+
+    msg.timeBootMs = Math.floor(process.uptime() * 1000);
+    msg.timeUtc = BigInt(Date.now()) * 1000n;
+    msg.cameraId = 0;
+    // for the mavlink message, lat/lon need to be int32_t in degrees * 1e7
+    msg.lat = latitude !== null ? Math.round(latitude * 1e7) : 0;
+    msg.lon = longitude !== null ? Math.round(longitude * 1e7) : 0;
+    // alt/relativeAlt are int32_t in millimeters
+    msg.alt = altitude !== null ? Math.round(altitude * 1000) : 0;
+    msg.relativeAlt = relative_altitude !== null ? Math.round(relative_altitude * 1000) : 0;
+
+    msg.q = [1,0,0,0]; // [1,0,0,0] for zero rotation
+    msg.imageIndex = this.photoSeq;
+    msg.captureResult = 1;          // Hard-code that capture was a success (for now)
+    msg.fileUrl = '';               // Leave blank for now; not used
+
+    console.log('Sending MAVLink CameraImageCaptured packet.');
+
+    this.eventEmitter.emit('cameraimagecaptured', msg, senderCompId);
   }
 
   toggleVideoRecording() {
@@ -786,14 +853,20 @@ class videoStream {
     this.saveSettings();
   }
 
-  // Helper to convert JS strings to the Array<string> format node-mavlink expects for char[]
-  toMavChars(str, length) {
-    const buf = new Uint8Array(length);
-    if (!str) return buf;
+  // Helper to format uint8_t[] fields (e.g., vendorName, modelName) for mavlink messages
+  toMavUint8Array(str, length) {
+    const out = new Array(length).fill(0);
+    const s = (str || "").toString().slice(0, length);
+    for (let i = 0; i < s.length; i++) {
+      out[i] = s.charCodeAt(i);
+    }
+    return out;
+  }
 
-    const encoded = new TextEncoder().encode(str);
-    buf.set(encoded.slice(0, length));
-    return buf;
+  // Helper to format char[] fields (e.g., camDefinitionUri)
+  toMavString(str, length) {
+    if (!str) return "";
+    return str.toString().slice(0, length - 1);
   }
 
   sendCameraInformation(senderSysId, senderCompId, targetComponent) {
@@ -823,16 +896,18 @@ class videoStream {
       }
     }
 
-    msg.vendorName = this.toMavChars("Rpanion", 32);
-    msg.modelName = this.toMavChars(extractedModel, 32);
+    msg.timeBootMs = process.uptime()*1000;
+    msg.vendorName = this.toMavUint8Array("Rpanion", 32);
+    msg.modelName = this.toMavUint8Array(extractedModel, 32);
     msg.firmwareVersion = 0;
     msg.focalLength = 0;
     msg.sensorSizeH = 0;
     msg.sensorSizeV = 0;
     msg.lensId = 0;
     msg.camDefinitionVersion = 0;
-    msg.camDefinitionUri = ""; // send zero-length string if not known
-    msg.gimbalDeviceId = 0;
+    msg.camDefinitionUri = this.toMavString("", 140);
+    msg.gimbalDeviceId = 0; // No gimbal
+    msg.cameraDeviceId = 0; // 0 = MAVLink Camera with its own component ID
 
     // Mode-specific Configuration
     if (this.cameraMode === 'photo') {
@@ -843,7 +918,7 @@ class videoStream {
     else if (this.cameraMode === 'video') {
       msg.resolutionH = this.videoSettings?.width || 0;
       msg.resolutionV = this.videoSettings?.height || 0;
-      msg.flags = 4; // CAMERA_CAP_FLAGS_CAPTURE_VIDEO
+      msg.flags = 1; // CAMERA_CAP_FLAGS_CAPTURE_VIDEO
     }
     else {
       // Default: streaming
@@ -861,7 +936,7 @@ class videoStream {
     // build a CAMERA_SETTINGS packet
     const msg = new common.CameraSettings()
 
-    msg.timeBootMs = 0
+    msg.timeBootMs = process.uptime()*1000;
 
     // Camera modes: 0 = IMAGE, 1 = VIDEO, 2 = IMAGE_SURVEY
     if (this.cameraMode === 'photo') {
@@ -877,7 +952,8 @@ class videoStream {
   }
 
   sendVideoStreamInformation(senderSysId, senderCompId, targetComponent) {
-    console.log('Responding to MAVLink request for VideoStreamInformation')
+    // Log the SysID and CompID of the requester
+    console.log(`Responding to MAVLink request for VideoStreamInformation from SysID: ${senderSysId}, CompID: ${targetComponent}`)
 
     // build a VIDEO_STREAM_INFORMATION packet
     const msg = new common.VideoStreamInformation()
@@ -886,13 +962,15 @@ class videoStream {
     msg.streamId = 1
     msg.count = 1
 
+    let uriString = "";
+
     // msg.type and msg.uri need to be different depending on whether RTP or RTSP is selected
     if (this.videoSettings && this.videoSettings.useUDP) {
       // msg.type = 0 = VIDEO_STREAM_TYPE_RTSP
       // msg.type = 1 = VIDEO_STREAM_TYPE_RTPUDP
       msg.type = 1
       // For RTP, just send the destination UDP port instead of a full URI
-      msg.uri = this.videoSettings.useUDPPort.toString();
+      uriString  = this.videoSettings.useUDPPort.toString();
     } else {
       msg.type = 0
       msg.encoding = this.videoSettings.compression === 'H264' ? 1 : (this.videoSettings.compression === 'H265' ? 2 : 0);
@@ -903,47 +981,175 @@ class videoStream {
         addr.includes(this.videoSettings.mavStreamSelected)
       );
 
-      msg.uri = matchedAddress || "";
+      uriString  = matchedAddress || "";
 
     }
+
+    // Convert URI string to a fixed-size Uint8Array of 230 bytes
+    msg.uri = this.toMavString(uriString, 230);
 
     // 1 = VIDEO_STREAM_STATUS_FLAGS_RUNNING
     msg.flags = 1;
     msg.framerate = this.videoSettings.fps;
     msg.resolutionH = this.videoSettings.width;
     msg.resolutionV = this.videoSettings.height;
-    msg.bitrate = this.videoSettings.bitrate;
+    // Convert bitrate from kbps (shown in Web UI) to bps (as per MAVLink spec)
+    msg.bitrate = this.videoSettings.bitrate * 1000;
     msg.rotation = this.videoSettings.rotation;
     // Rpanion doesn't collect field of view values, so set to zero
     msg.hfov = 0;
-    // Set the stream name (usually the device path)
-    msg.name = this.videoSettings.device;
+    // Convert the device name string to a fixed-size Uint8Array of 32 bytes
+    msg.name = this.toMavString(this.videoSettings.device || "", 32);
 
     this.eventEmitter.emit('videostreaminfo', msg, senderSysId, senderCompId, targetComponent)
   }
 
-  onMavPacket(packet, data) {
-    if (packet.header.msgid === common.CommandLong.MSG_ID &&
-      data.targetComponent === minimal.MavComponent.CAMERA) {
-      if (data._param1 === common.CameraInformation.MSG_ID) {
-        console.log('Responding to MAVLink request for CameraInformation')
-        this.sendCameraInformation(packet.header.sysid, minimal.MavComponent.CAMERA, packet.header.compid);
-      }
-      else if (data._param1 === common.VideoStreamInformation.MSG_ID && this.cameraMode === "streaming") {
-        console.log('Responding to MAVLink request for VideoStreamInformation')
-        this.sendVideoStreamInformation(packet.header.sysid, minimal.MavComponent.CAMERA, packet.header.compid);
-      }
-      else if (data._param1 === common.CameraSettings.MSG_ID) {
-        console.log('Responding to MAVLink request for CameraSettings')
-        this.sendCameraSettings(packet.header.sysid, minimal.MavComponent.CAMERA, packet.header.compid)
-      }
-      // 203 = MAV_CMD_DO_DIGICAM_CONTROL
-      else if (data.command === 203) {
-        console.log('Received DoDigicamControl command')
-        this.captureStillPhoto(packet.header.sysid, minimal.MavComponent.CAMERA, packet.header.compid)
-      }
+  // Find how much media space there is in total, and how much is available
+  async getStorageStats() {
+    try {
+      const s = await fs.promises.statfs(logpaths.mediaDir);
+      const total = BigInt(s.bsize) * BigInt(s.blocks);
+      const free = BigInt(s.bsize) * BigInt(s.bfree);
+      const avail = BigInt(s.bsize) * BigInt(s.bavail);
+      const used = total - free;
+      const totalMiB = Number(total / BigInt(1024 * 1024));
+      const usedMiB = Number(used / BigInt(1024 * 1024));
+      const availableMiB = Number(avail / BigInt(1024 * 1024));
+      return { totalMiB, usedMiB, availableMiB };
+    } catch (e) {
+      return { totalMiB: 0, usedMiB: 0, availableMiB: 0 };
     }
   }
+
+  async sendStorageInfo(senderSysId, senderCompId, targetComponent) {
+    console.log('Sending MAVLink StorageInformation packet')
+
+    // Build a STORAGE_INFORMATION packet
+    const msg = new common.StorageInformation()
+
+    // Try to get real storage stats for mediaDir; fall back to safe defaults
+    const stats = await this.getStorageStats().catch(() => ({ totalMiB: 0, usedMiB: 0 }));
+
+    msg.timeBootMs = process.uptime()*1000;
+    msg.storageId = 1;           // First storage device
+    msg.storageCount = 1;       // One storage device available
+    msg.status = common.StorageStatus.STORAGE_STATUS_READY;
+    msg.totalCapacity = stats.totalMiB;   // Capacity in MiB
+    msg.usedCapacity = stats.usedMiB;
+    msg.availableCapacity = Math.max(0, stats.availableMiB || 0);
+    msg.readSpeed = 0;         // Speeds in MiB/s, just send zeroes for now
+    msg.writeSpeed = 0;
+    msg.type = common.StorageType.STORAGE_TYPE_MICROSD;
+    msg.name = this.toMavString('Rpanion Storage', 32);
+    msg.storageUsage = 6; // Usage bitmask; 2 = Photo, 4 = Video
+
+    this.eventEmitter.emit('storageinfo', msg, senderSysId, senderCompId, targetComponent)
+  }
+
+  // Helper to log and emit an UNSUPPORTED ACK for MAVLink commands/messages we haven't implemented
+  sendUnsupportedAck(emittedCommand, sysid, compid) {
+      console.log(`MAVLink command ${emittedCommand} is unsupported. Sending UNSUPPORTED ACK.`)
+      this.eventEmitter.emit('camera_command_ack', emittedCommand, sysid, minimal.MavComponent.CAMERA, compid, 3);
+    }
+
+  onMavPacket(packet, data) {
+      if (packet.header.msgid === common.CommandLong.MSG_ID &&
+        data.targetComponent === minimal.MavComponent.CAMERA) {
+
+        let handled = false;
+
+        // Get the vehicle position if fcManager is available,
+        // for operations that need it (e.g., photo geotagging).
+        const currentPosition = this.fcManager?.getSystemStatus?.()?.vehiclePosition || null;
+        
+        // Handle message request commands (MAV_CMD_REQUEST_MESSAGE = 512)
+        if (data.command === 512) {
+          const requestedMsgId = data._param1;
+
+          // This if-else block handles information requests
+          if (requestedMsgId === common.CameraInformation.MSG_ID) {
+            // Log the SysID and CompID of the requester
+            console.log(`Responding to MAVLink request for CameraInformation from SysID: ${packet.header.sysid}, CompID: ${packet.header.compid}`)
+            this.sendCameraInformation(packet.header.sysid, minimal.MavComponent.CAMERA, packet.header.compid);
+            handled = true;
+          }
+          else if (requestedMsgId === common.VideoStreamInformation.MSG_ID && this.cameraMode === "streaming") {
+            console.log('Responding to MAVLink request for VideoStreamInformation')
+            this.sendVideoStreamInformation(packet.header.sysid, minimal.MavComponent.CAMERA, packet.header.compid);
+            handled = true;
+          }
+          else if (requestedMsgId === common.CameraSettings.MSG_ID) {
+            // Log the SysID and CompID of the requester
+            console.log(`Responding to MAVLink request for VideoStreamInformation from SysID: ${packet.header.sysid}, CompID: ${packet.header.compid}`)
+            this.sendCameraSettings(packet.header.sysid, minimal.MavComponent.CAMERA, packet.header.compid)
+            handled = true;
+          }
+          else if (requestedMsgId === common.StorageInformation.MSG_ID) {
+            // Log the SysID and CompID of the requester
+            console.log(`Responding to MAVLink request for StorageInformation from SysID: ${packet.header.sysid}, CompID: ${packet.header.compid}`)
+            this.sendStorageInfo(packet.header.sysid, minimal.MavComponent.CAMERA, packet.header.compid)
+            handled = true;
+          }
+
+          if (!handled) {
+            this.sendUnsupportedAck(512, packet.header.sysid, packet.header.compid, `MAVLink requested message ${requestedMsgId} is unsupported.`)
+            handled = true;
+          }
+        } // Closes data.command === 512
+        
+        // Handle message rate requests (MAV_CMD_SET_MESSAGE_INTERVAL = 511)
+        else if (data.command === 511) {
+          console.log(`Received SET_MESSAGE_INTERVAL command for msgId: ${data._param1}. Replying with ACCEPTED.`);
+          this.eventEmitter.emit('camera_command_ack', 511, packet.header.sysid, minimal.MavComponent.CAMERA, packet.header.compid, 0); // 0 is MAV_RESULT_ACCEPTED
+          handled = true;
+        }
+
+        // 203 = MAV_CMD_DO_DIGICAM_CONTROL
+        else if (data.command === 203) {
+          console.log('Received MAV_CMD_DO_DIGICAM_CONTROL command')
+          this.captureStillPhoto(packet.header.sysid, minimal.MavComponent.CAMERA, packet.header.compid, currentPosition, 203)
+          handled = true;
+        }
+        // Handle MAVLink camera protocol v2 image capture commands (2000, 2001)
+        else if (data.command === 2000) {
+          // MAV_CMD_IMAGE_START_CAPTURE - Take picture
+          console.log('Received IMAGE_START_CAPTURE command')
+          this.captureStillPhoto(packet.header.sysid, minimal.MavComponent.CAMERA, packet.header.compid, currentPosition, 2000)
+          handled = true;
+        }
+        else if (data.command === 2001) {
+          console.log('Received IMAGE_STOP_CAPTURE command')
+          this.eventEmitter.emit('camera_command_ack', 2001, packet.header.sysid, minimal.MavComponent.CAMERA, packet.header.compid)
+          handled = true;
+        }
+        // Handle MAVLink camera protocol v2 video commands (2500, 2501)
+        else if (data.command === 2500) {
+          // MAV_CMD_VIDEO_START_CAPTURE - Start recording video
+          console.log('Received VIDEO_START_CAPTURE command')
+          if (this.cameraMode === 'video' && !this.videoSettings.isRecording) {
+            this.toggleVideoRecording()
+          }
+          // Emit general ACK for starting video capture
+          this.eventEmitter.emit('camera_command_ack', 2500, packet.header.sysid, minimal.MavComponent.CAMERA, packet.header.compid)
+          handled = true;
+        }
+        else if (data.command === 2501) {
+          // MAV_CMD_VIDEO_STOP_CAPTURE - Stop recording video
+          console.log('Received VIDEO_STOP_CAPTURE command')
+          if (this.cameraMode === 'video' && this.videoSettings.isRecording) {
+            this.toggleVideoRecording()
+          }
+          // Emit general ACK for stopping video capture
+          this.eventEmitter.emit('camera_command_ack', 2501, packet.header.sysid, minimal.MavComponent.CAMERA, packet.header.compid)
+          handled = true;
+        }
+
+        // If any unsupported camera-targeted commands are received, explicitly ACK it with MAV_RESULT_UNSUPPORTED (3)
+        if (!handled) {
+          this.sendUnsupportedAck(data.command, packet.header.sysid, packet.header.compid)
+        }
+      }
+    }
 }
 
 module.exports = videoStream

--- a/server/videostream.test.js
+++ b/server/videostream.test.js
@@ -1,6 +1,8 @@
 const assert = require('assert')
 const path = require('path')
+const fs = require('fs')
 const settings = require('settings-store')
+const { minimal, common } = require('node-mavlink')
 const logpaths = require('./paths')
 const VideoStream = require('./videostream')
 
@@ -119,18 +121,26 @@ describe('Video Functions', function () {
     vManager.active = true
     vManager.cameraMode = 'video'
     vManager.videoSettings = { width: 1920, height: 1080 }
+    vManager.stillSettings = { device: 'imx219', width: 4056, height: 3040 }
+    vManager.useCameraHeartbeat = true
 
     // Test Save
     vManager.saveSettings()
     assert.equal(settings.value('camera.active'), true)
     assert.equal(settings.value('camera.mode'), 'video')
     assert.deepEqual(settings.value('camera.videoSettings'), { width: 1920, height: 1080 })
+    assert.deepEqual(settings.value('camera.stillSettings'), { device: 'imx219', width: 4056, height: 3040 })
+    assert.equal(settings.value('camera.useHeartbeat'), true)
 
     // Test Reset
     vManager.resetCamera()
     assert.equal(vManager.active, false)
     assert.equal(vManager.videoSettings, null)
+    assert.equal(vManager.stillSettings, null)
     assert.equal(settings.value('camera.active'), false)
+    assert.equal(settings.value('camera.videoSettings'), null)
+    assert.equal(settings.value('camera.stillSettings'), null)
+    assert.equal(settings.value('camera.useHeartbeat'), false)
   })
 
   it('#stopCamera()', function (done) {
@@ -157,7 +167,7 @@ describe('Video Functions', function () {
   })
 
 
-  it('#captureStillPhoto()', function (done) {
+  it('#captureStillPhoto() - camera active', function (done) {
     settings.clear()
     const vManager = new VideoStream(settings)
 
@@ -190,7 +200,121 @@ describe('Video Functions', function () {
     }, 50)
   })
 
-  it('#toggleVideoRecording()', function () {
+  it('#captureStillPhoto() - does nothing when camera is inactive', function () {
+    settings.clear()
+    const vManager = new VideoStream(settings)
+ 
+    vManager.active = false
+    let signalSent = false
+    vManager.deviceStream = {
+      kill: () => { signalSent = true }
+    }
+ 
+    let eventEmitted = false
+    vManager.eventEmitter.on('cameratrigger', () => { eventEmitted = true })
+ 
+    vManager.captureStillPhoto(1, 1, 1)
+ 
+    assert.equal(signalSent, false, "Should not send signal when camera is inactive")
+    assert.equal(eventEmitted, false, "Should not emit events when camera is inactive")
+    assert.equal(vManager.photoSeq, 0, "Should not increment photo sequence")
+  })
+
+  it('#captureStillPhoto() - emits camera_command_ack when commandId is provided', function (done) {
+    settings.clear()
+    const vManager = new VideoStream(settings)
+ 
+    vManager.active = true
+    vManager.deviceStream = { kill: () => {} }
+ 
+    let ackEmitted = false
+    let digicamEmitted = false
+ 
+    vManager.eventEmitter.on('camera_command_ack', (commandId, sysId, compId, targetComp) => {
+      ackEmitted = true
+      assert.equal(commandId, 203, "Should pass through the commandId")
+      assert.equal(sysId, 1)
+    })
+    vManager.eventEmitter.on('digicamcontrol', () => { digicamEmitted = true })
+ 
+    // Pass a non-null commandId — triggers the ack branch
+    vManager.captureStillPhoto(1, 1, 1, null, 203)
+ 
+    setTimeout(() => {
+      assert.equal(ackEmitted, true, "Should emit camera_command_ack when commandId is set")
+      assert.equal(digicamEmitted, false, "Should not emit digicamcontrol when commandId is set")
+      done()
+    }, 50)
+  })
+ 
+  it('#captureStillPhoto() - emits digicamcontrol as fallback when no commandId', function (done) {
+    settings.clear()
+    const vManager = new VideoStream(settings)
+ 
+    vManager.active = true
+    vManager.deviceStream = { kill: () => {} }
+ 
+    let ackEmitted = false
+    let digicamEmitted = false
+ 
+    vManager.eventEmitter.on('camera_command_ack', () => { ackEmitted = true })
+    vManager.eventEmitter.on('digicamcontrol', () => { digicamEmitted = true })
+ 
+    // No commandId passed — triggers the digicamcontrol fallback
+    vManager.captureStillPhoto(1, 1, 1)
+ 
+    setTimeout(() => {
+      assert.equal(digicamEmitted, true, "Should emit digicamcontrol when no commandId is set")
+      assert.equal(ackEmitted, false, "Should not emit camera_command_ack when commandId is null")
+      done()
+    }, 50)
+  })
+ 
+  it('#captureStillPhoto() - writes GPS data to temp file when positionData is provided', function (done) {
+    settings.clear()
+    const vManager = new VideoStream(settings)
+ 
+    vManager.active = true
+    vManager.deviceStream = { kill: () => {} }
+ 
+    const positionData = { lat: 49.2827, lon: -123.1207, alt: 100 }
+    const gpsFilePath = '/tmp/rpanion_gps.json'
+ 
+    // Clean up any existing file first
+    if (fs.existsSync(gpsFilePath)) fs.unlinkSync(gpsFilePath)
+ 
+    vManager.captureStillPhoto(1, 1, 1, positionData)
+ 
+    setTimeout(() => {
+      assert.ok(fs.existsSync(gpsFilePath), "Should write GPS temp file")
+      const written = JSON.parse(fs.readFileSync(gpsFilePath, 'utf8'))
+      assert.deepEqual(written, positionData, "GPS file should contain the positionData payload")
+      fs.unlinkSync(gpsFilePath) // cleanup
+      done()
+    }, 50)
+  })
+ 
+  it('#captureStillPhoto() - removes stale GPS file when positionData is null', function (done) {
+    settings.clear()
+    const vManager = new VideoStream(settings)
+ 
+    vManager.active = true
+    vManager.deviceStream = { kill: () => {} }
+ 
+    const gpsFilePath = '/tmp/rpanion_gps.json'
+ 
+    // Pre-create a stale GPS file to simulate a prior capture
+    fs.writeFileSync(gpsFilePath, JSON.stringify({ lat: 0, lon: 0, alt: 0 }))
+ 
+    vManager.captureStillPhoto(1, 1, 1, null)
+ 
+    setTimeout(() => {
+      assert.equal(fs.existsSync(gpsFilePath), false, "Should remove stale GPS file when positionData is null")
+      done()
+    }, 50)
+  })
+
+  it('#toggleVideoRecording() - sends SIGUSR1 when camera is active', function () {
     settings.clear()
     const vManager = new VideoStream(settings)
 
@@ -205,6 +329,236 @@ describe('Video Functions', function () {
     vManager.toggleVideoRecording()
     assert.equal(signalSent, true, "Should send SIGUSR1 to toggle recording")
   })
+ 
+  it('#toggleVideoRecording() - does nothing when camera is inactive', function () {
+    settings.clear()
+    const vManager = new VideoStream(settings)
+ 
+    vManager.active = false
+    let signalSent = false
+    vManager.deviceStream = {
+      kill: () => { signalSent = true }
+    }
+ 
+    vManager.toggleVideoRecording()
+    assert.equal(signalSent, false, "Should not send signal when camera is inactive")
+  })
+ 
+  it('#toggleVideoRecording() - does nothing when deviceStream is null', function () {
+    settings.clear()
+    const vManager = new VideoStream(settings)
+ 
+    vManager.active = true
+    vManager.deviceStream = null
+ 
+    // Should return early without throwing
+    assert.doesNotThrow(() => vManager.toggleVideoRecording())
+  })
+
+  it('#startHeartbeatInterval()', function (done) {
+    settings.clear()
+    const vManager = new VideoStream(settings)
+ 
+    let heartbeatCount = 0
+    let lastMavType, lastAutopilot, lastComponent
+ 
+    vManager.eventEmitter.on('cameraheartbeat', (mavType, autopilot, component) => {
+      heartbeatCount++
+      lastMavType = mavType
+      lastAutopilot = autopilot
+      lastComponent = component
+    })
+ 
+    vManager.startHeartbeatInterval()
+ 
+    // intervalObj should be set immediately
+    assert.notEqual(vManager.intervalObj, null, "Should store interval reference in intervalObj")
+ 
+    // Wait long enough for at least two heartbeat ticks
+    setTimeout(() => {
+      clearInterval(vManager.intervalObj)
+      vManager.intervalObj = null
+
+      try {
+        assert.ok(heartbeatCount >= 2, "Should emit cameraheartbeat on each 1-second tick")
+ 
+        // Verify the MAVLink field values sent with each heartbeat
+        const { minimal } = require('node-mavlink')
+        assert.equal(lastMavType, minimal.MavType.CAMERA, "Should use MavType.CAMERA")
+        assert.equal(lastAutopilot, minimal.MavAutopilot.INVALID, "Should use MavAutopilot.INVALID")
+        assert.equal(lastComponent, minimal.MavComponent.CAMERA, "Should use MavComponent.CAMERA")
+ 
+        done()
+      } catch (err) {
+        done(err)
+      }
+    }, 2200)
+  }).timeout(5000)
+
+
+  it('#setRecordingFlag()', function () {
+    settings.clear()
+    const vManager = new VideoStream(settings)
+ 
+    // setRecordingFlag is a no-op when videoSettings is null
+    vManager.videoSettings = null
+    assert.doesNotThrow(() => vManager.setRecordingFlag(true))
+    assert.equal(vManager.videoSettings, null, "Should not set videoSettings when it is null")
+ 
+    // With videoSettings present, it should update isRecording immutably and persist
+    vManager.videoSettings = { width: 1280, height: 720, isRecording: false }
+    const originalRef = vManager.videoSettings
+ 
+    vManager.setRecordingFlag(true)
+    assert.equal(vManager.videoSettings.isRecording, true, "Should set isRecording to true")
+    assert.notEqual(vManager.videoSettings, originalRef, "Should replace the object rather than mutating it")
+    assert.equal(settings.value('camera.videoSettings').isRecording, true, "Should persist the flag via saveSettings")
+ 
+    vManager.setRecordingFlag(false)
+    assert.equal(vManager.videoSettings.isRecording, false, "Should set isRecording to false")
+    assert.equal(settings.value('camera.videoSettings').isRecording, false, "Should persist the cleared flag via saveSettings")
+  })
+
+
+  it('#toMavString()', function () {
+    settings.clear()
+    const vManager = new VideoStream(settings)
+ 
+    // Null/undefined/empty input returns empty string
+    assert.equal(vManager.toMavString(null, 32), "")
+    assert.equal(vManager.toMavString(undefined, 32), "")
+    assert.equal(vManager.toMavString("", 32), "")
+ 
+    // String shorter than limit passes through unchanged
+    assert.equal(vManager.toMavString("Rpanion", 32), "Rpanion")
+ 
+    // String that exactly fills the buffer (length === limit) must be truncated
+    // to length - 1 to leave room for the trailing null byte
+    const exactly32 = "A".repeat(32)
+    const result32 = vManager.toMavString(exactly32, 32)
+    assert.equal(result32.length, 31, "Should truncate to length - 1 to guarantee a null terminator slot")
+ 
+    // String much longer than limit is truncated to length - 1
+    const long = "B".repeat(300)
+    const resultLong = vManager.toMavString(long, 32)
+    assert.equal(resultLong.length, 31, "Should truncate long strings to length - 1")
+ 
+    // Non-string input is coerced via toString()
+    const numResult = vManager.toMavString(12345, 32)
+    assert.equal(numResult, "12345")
+  })
+
+  it('#getStorageStats()', async function () {
+    settings.clear()
+    const vManager = new VideoStream(settings)
+ 
+    const stats = await vManager.getStorageStats()
+ 
+    // Whether or not mediaDir is accessible, the returned shape must always be valid
+    assert.ok(typeof stats.totalMiB === 'number', "totalMiB should be a number")
+    assert.ok(typeof stats.usedMiB === 'number', "usedMiB should be a number")
+    assert.ok(typeof stats.availableMiB === 'number', "availableMiB should be a number")
+    assert.ok(stats.totalMiB >= 0, "totalMiB should be non-negative")
+    assert.ok(stats.usedMiB >= 0, "usedMiB should be non-negative")
+    assert.ok(stats.availableMiB >= 0, "availableMiB should be non-negative")
+  })
+ 
+  it('#sendStorageInfo()', function (done) {
+    settings.clear()
+    const vManager = new VideoStream(settings)
+ 
+    vManager.eventEmitter.on('storageinfo', (msg, sysId, compId) => {
+      assert.equal(msg.storageId, 1, "Should report storageId 1")
+      assert.equal(msg.storageCount, 1, "Should report storageCount 1")
+      assert.equal(msg.readSpeed, 0)
+      assert.equal(msg.writeSpeed, 0)
+      assert.equal(msg.hfov, undefined) // not a field on StorageInformation
+      assert.ok(typeof msg.totalCapacity === 'number', "totalCapacity should be a number")
+      assert.ok(typeof msg.usedCapacity === 'number', "usedCapacity should be a number")
+      assert.ok(msg.availableCapacity >= 0, "availableCapacity should be non-negative")
+ 
+      // Verify the name field is set (may be truncated via toMavString)
+      assert.ok(msg.name.includes('Rpanion'), "name should contain 'Rpanion'")
+ 
+      // Verify caller arguments are forwarded correctly
+      assert.equal(sysId, 1)
+      assert.equal(compId, 1)
+ 
+      done()
+    })
+ 
+    vManager.sendStorageInfo(1, 1, 1)
+  }).timeout(5000)
+
+  it('#sendCameraImageCaptured() without GPS file', function (done) {
+    settings.clear()
+    const vManager = new VideoStream(settings)
+    vManager.photoSeq = 5
+ 
+    // Ensure GPS file does not exist for this test
+    const gpsPath = '/tmp/rpanion_gps.json'
+    if (fs.existsSync(gpsPath)) {
+      fs.unlinkSync(gpsPath)
+    }
+ 
+    vManager.eventEmitter.on('cameraimagecaptured', (msg, compId) => {
+      assert.equal(msg.cameraId, 0)
+      assert.equal(msg.lat, 0, "lat should default to 0 when GPS file is missing")
+      assert.equal(msg.lon, 0, "lon should default to 0 when GPS file is missing")
+      assert.equal(msg.alt, 0, "alt should default to 0 when GPS file is missing")
+      assert.equal(msg.relativeAlt, 0, "relativeAlt should default to 0 when GPS file is missing")
+      assert.deepEqual(msg.q, [1, 0, 0, 0])
+      assert.equal(msg.imageIndex, 5)
+      assert.equal(msg.captureResult, 1)
+      assert.equal(msg.fileUrl, '')
+      assert.ok(typeof msg.timeBootMs === 'number')
+      assert.ok(typeof msg.timeUtc === 'bigint')
+      assert.equal(compId, 42)
+ 
+      done()
+    })
+ 
+    vManager.sendCameraImageCaptured(42)
+  })
+ 
+  it('#sendCameraImageCaptured() with GPS file', function (done) {
+    settings.clear()
+    const vManager = new VideoStream(settings)
+    vManager.photoSeq = 7
+ 
+    const gpsPath = '/tmp/rpanion_gps.json'
+    const gpsData = { lat: -27.5, lon: 153.0, alt: 100.25, relAlt: 50.5 }
+    fs.writeFileSync(gpsPath, JSON.stringify(gpsData))
+ 
+    vManager.eventEmitter.on('cameraimagecaptured', (msg, compId) => {
+      assert.equal(msg.lat, Math.round(-27.5 * 1e7))
+      assert.equal(msg.lon, Math.round(153.0 * 1e7))
+      assert.equal(msg.alt, Math.round(100.25 * 1000))
+      assert.equal(msg.relativeAlt, Math.round(50.5 * 1000))
+      assert.equal(msg.imageIndex, 7)
+ 
+      // Clean up the GPS file
+      fs.unlinkSync(gpsPath)
+ 
+      done()
+    })
+ 
+    vManager.sendCameraImageCaptured(42)
+  })
+
+  it('#sendUnsupportedAck()', function (done) {
+    settings.clear()
+    const vManager = new VideoStream(settings)
+ 
+    vManager.eventEmitter.on('camera_command_ack', (command, sysId, compId, targetComp, result) => {
+      assert.equal(command, 9999, "Should pass through the emitted command")
+      assert.equal(sysId, 2)
+      assert.equal(result, 3, "Result should be 3 (MAV_RESULT_UNSUPPORTED)")
+      done()
+    })
+ 
+    vManager.sendUnsupportedAck(9999, 2, 1)
+  })
 
   it('#sendCameraInformation()', function (done) {
     settings.clear()
@@ -214,9 +568,9 @@ describe('Video Functions', function () {
     vManager.videoSettings = { device: 'imx219' }
 
     vManager.eventEmitter.on('camerainfo', (msg, sysId, compId) => {
-      // Decode vendor name (Uint8Array to string)
-      const vendorText = new TextDecoder().decode(msg.vendorName).replace(/\0/g, '')
-      assert.equal(vendorText, 'Rpanion')
+      // vendorName is now a Uint8Array returned by toMavUint8Array()
+      const vendorName = Buffer.from(msg.vendorName).toString('utf8').replace(/\0+$/, '')
+      assert.equal(vendorName, 'Rpanion')
       assert.equal(msg.flags, 256) // Default streaming flag
       done()
     })
@@ -277,5 +631,338 @@ describe('Video Functions', function () {
     vManager.sendCameraSettings(1, 1, 1)
   })
 
+})
 
+// ---------------------------------------------------------------------------
+// onMavPacket testing: helper functions
+// ---------------------------------------------------------------------------
+
+/** Build a synthetic MAVLink packet header */
+function makePacket (sysid = 1, compid = 1) {
+  return { header: { sysid, compid, msgid: common.CommandLong.MSG_ID } }
+}
+
+/** Build the decoded data payload for a CommandLong */
+function makeCommandLong (command, targetComponent, param1 = 0) {
+  return {
+    command,
+    targetComponent,
+    _param1: param1
+  }
+}
+
+/** Shorthand: camera-targeted packet + data */
+function cameraPacket (command, param1 = 0, sysid = 1, compid = 100) {
+  return {
+    packet: makePacket(sysid, compid),
+    data: makeCommandLong(command, minimal.MavComponent.CAMERA, param1)
+  }
+}
+
+// ---------------------------------------------------------------------------
+// onMavPacket testing: Shared setup for all the following tests
+// ---------------------------------------------------------------------------
+
+function makeManager (overrides = {}) {
+  settings.clear()
+  const vm = new VideoStream(settings)
+  // Provide minimal videoSettings so branches that read it don't throw
+  vm.videoSettings = {
+    device: 'imx219',
+    width: 1280,
+    height: 720,
+    fps: 30,
+    bitrate: 1100,
+    rotation: 0,
+    compression: 'H264',
+    useUDP: false,
+    useUDPIP: '127.0.0.1',
+    useUDPPort: 5600,
+    mavStreamSelected: '127.0.0.1',
+    isRecording: false
+  }
+  vm.deviceAddresses = ['rtsp://127.0.0.1:8554/devvideo0']
+  vm.cameraMode = 'streaming'
+  Object.assign(vm, overrides)
+  return vm
+}
+
+// ---------------------------------------------------------------------------
+// onMavPacket testing: Tests
+// ---------------------------------------------------------------------------
+
+describe('onMavPacket()', function () {
+
+  // ── Packet filtering ────────────────────────────────────────────────────
+
+  it('ignores packets not targeting the CAMERA component', function () {
+    const vm = makeManager()
+    let emitted = false
+    vm.eventEmitter.on('camera_command_ack', () => { emitted = true })
+    vm.eventEmitter.on('camerainfo',         () => { emitted = true })
+
+    const packet = makePacket(1, 1)
+    const data   = makeCommandLong(512, minimal.MavComponent.AUTOPILOT1, common.CameraInformation.MSG_ID)
+    vm.onMavPacket(packet, data)
+
+    assert.equal(emitted, false, 'Should not react to packets targeting other components')
+  })
+
+  // ── Command 512 – REQUEST_MESSAGE ────────────────────────────────────────
+
+  it('command 512 – CameraInformation.MSG_ID emits camerainfo', function (done) {
+    const vm = makeManager()
+    const { packet, data } = cameraPacket(512, common.CameraInformation.MSG_ID)
+
+    vm.eventEmitter.on('camerainfo', (msg, sysId, compId, targetComp) => {
+      assert.ok(msg, 'Should emit a CameraInformation message object')
+      assert.equal(sysId, packet.header.sysid)
+      done()
+    })
+
+    vm.onMavPacket(packet, data)
+  })
+
+  it('command 512 – VideoStreamInformation.MSG_ID in streaming mode emits videostreaminfo', function (done) {
+    const vm = makeManager({ cameraMode: 'streaming' })
+    const { packet, data } = cameraPacket(512, common.VideoStreamInformation.MSG_ID)
+
+    vm.eventEmitter.on('videostreaminfo', (msg) => {
+      assert.equal(msg.streamId, 1)
+      done()
+    })
+
+    vm.onMavPacket(packet, data)
+  })
+
+  it('command 512 – VideoStreamInformation.MSG_ID in non-streaming mode sends unsupported ACK', function (done) {
+    const vm = makeManager({ cameraMode: 'photo' })
+    const { packet, data } = cameraPacket(512, common.VideoStreamInformation.MSG_ID)
+
+    vm.eventEmitter.on('camera_command_ack', (command, sysId, compId, targetComp, result) => {
+      assert.equal(result, 3, 'Result should be MAV_RESULT_UNSUPPORTED (3)')
+      done()
+    })
+
+    vm.onMavPacket(packet, data)
+  })
+
+  it('command 512 – CameraSettings.MSG_ID emits camerasettings', function (done) {
+    const vm = makeManager()
+    const { packet, data } = cameraPacket(512, common.CameraSettings.MSG_ID)
+
+    vm.eventEmitter.on('camerasettings', (msg) => {
+      assert.ok(msg, 'Should emit a CameraSettings message object')
+      done()
+    })
+
+    vm.onMavPacket(packet, data)
+  })
+
+  it('command 512 – StorageInformation.MSG_ID emits storageinfo', function (done) {
+    const vm = makeManager()
+    const { packet, data } = cameraPacket(512, common.StorageInformation.MSG_ID)
+
+    vm.eventEmitter.on('storageinfo', (msg) => {
+      assert.equal(msg.storageId, 1)
+      done()
+    })
+
+    vm.onMavPacket(packet, data)
+  }).timeout(5000)
+
+  it('command 512 – unknown requested MSG_ID sends unsupported ACK', function (done) {
+    const vm = makeManager()
+    const unknownMsgId = 9999
+    const { packet, data } = cameraPacket(512, unknownMsgId)
+
+    vm.eventEmitter.on('camera_command_ack', (command, sysId, compId, targetComp, result) => {
+      assert.equal(result, 3, 'Result should be MAV_RESULT_UNSUPPORTED (3)')
+      done()
+    })
+
+    vm.onMavPacket(packet, data)
+  })
+
+  // ── Command 511 – SET_MESSAGE_INTERVAL ───────────────────────────────────
+
+  it('command 511 emits camera_command_ack with result ACCEPTED (0)', function (done) {
+    const vm = makeManager()
+    const { packet, data } = cameraPacket(511)
+
+    vm.eventEmitter.on('camera_command_ack', (command, sysId, compId, targetComp, result) => {
+      assert.equal(command, 511)
+      assert.equal(sysId, packet.header.sysid)
+      assert.equal(result, 0, 'Result should be MAV_RESULT_ACCEPTED (0)')
+      done()
+    })
+
+    vm.onMavPacket(packet, data)
+  })
+
+  // ── Command 203 – DO_DIGICAM_CONTROL ─────────────────────────────────────
+
+  it('command 203 triggers captureStillPhoto', function (done) {
+    const vm = makeManager()
+    vm.active = true
+    vm.deviceStream = { kill: () => {} }
+    const { packet, data } = cameraPacket(203)
+
+    vm.eventEmitter.on('camera_command_ack', (commandId) => {
+      assert.equal(commandId, 203)
+      done()
+    })
+
+    vm.onMavPacket(packet, data)
+  })
+
+  // ── Command 2000 – IMAGE_START_CAPTURE ───────────────────────────────────
+
+  it('command 2000 triggers captureStillPhoto', function (done) {
+    const vm = makeManager()
+    vm.active = true
+    vm.deviceStream = { kill: () => {} }
+    const { packet, data } = cameraPacket(2000)
+
+    vm.eventEmitter.on('camera_command_ack', (commandId) => {
+      assert.equal(commandId, 2000)
+      done()
+    })
+
+    vm.onMavPacket(packet, data)
+  })
+
+  // ── Command 2001 – IMAGE_STOP_CAPTURE ────────────────────────────────────
+
+  it('command 2001 emits camera_command_ack for 2001', function (done) {
+    const vm = makeManager()
+    const { packet, data } = cameraPacket(2001)
+
+    vm.eventEmitter.on('camera_command_ack', (commandId, sysId) => {
+      assert.equal(commandId, 2001)
+      assert.equal(sysId, packet.header.sysid)
+      done()
+    })
+
+    vm.onMavPacket(packet, data)
+  })
+
+  // ── Command 2500 – VIDEO_START_CAPTURE ───────────────────────────────────
+
+  it('command 2500 in video mode (not recording) toggles recording and emits ACK', function (done) {
+    const vm = makeManager({ cameraMode: 'video' })
+    vm.videoSettings.isRecording = false
+    vm.active = true
+    let signalSent = false
+    vm.deviceStream = { kill: (sig) => { if (sig === 'SIGUSR1') signalSent = true } }
+    const { packet, data } = cameraPacket(2500)
+
+    vm.eventEmitter.on('camera_command_ack', (commandId) => {
+      assert.equal(commandId, 2500)
+      assert.equal(signalSent, true, 'Should toggle recording via SIGUSR1')
+      done()
+    })
+
+    vm.onMavPacket(packet, data)
+  })
+
+  it('command 2500 when already recording does NOT toggle (just ACKs)', function (done) {
+    const vm = makeManager({ cameraMode: 'video' })
+    vm.videoSettings.isRecording = true
+    vm.active = true
+    let signalSent = false
+    vm.deviceStream = { kill: (sig) => { if (sig === 'SIGUSR1') signalSent = true } }
+    const { packet, data } = cameraPacket(2500)
+
+    vm.eventEmitter.on('camera_command_ack', (commandId) => {
+      assert.equal(commandId, 2500)
+      assert.equal(signalSent, false, 'Should not toggle when already recording')
+      done()
+    })
+
+    vm.onMavPacket(packet, data)
+  })
+
+  it('command 2500 in non-video mode just emits ACK without toggling', function (done) {
+    const vm = makeManager({ cameraMode: 'streaming' })
+    vm.active = true
+    let signalSent = false
+    vm.deviceStream = { kill: (sig) => { if (sig === 'SIGUSR1') signalSent = true } }
+    const { packet, data } = cameraPacket(2500)
+
+    vm.eventEmitter.on('camera_command_ack', (commandId) => {
+      assert.equal(commandId, 2500)
+      assert.equal(signalSent, false, 'Should not toggle when not in video mode')
+      done()
+    })
+
+    vm.onMavPacket(packet, data)
+  })
+
+  // ── Command 2501 – VIDEO_STOP_CAPTURE ────────────────────────────────────
+
+  it('command 2501 in video mode (is recording) toggles recording and emits ACK', function (done) {
+    const vm = makeManager({ cameraMode: 'video' })
+    vm.videoSettings.isRecording = true
+    vm.active = true
+    let signalSent = false
+    vm.deviceStream = { kill: (sig) => { if (sig === 'SIGUSR1') signalSent = true } }
+    const { packet, data } = cameraPacket(2501)
+
+    vm.eventEmitter.on('camera_command_ack', (commandId) => {
+      assert.equal(commandId, 2501)
+      assert.equal(signalSent, true, 'Should toggle recording via SIGUSR1')
+      done()
+    })
+
+    vm.onMavPacket(packet, data)
+  })
+
+  it('command 2501 when not recording does NOT toggle (just ACKs)', function (done) {
+    const vm = makeManager({ cameraMode: 'video' })
+    vm.videoSettings.isRecording = false
+    vm.active = true
+    let signalSent = false
+    vm.deviceStream = { kill: (sig) => { if (sig === 'SIGUSR1') signalSent = true } }
+    const { packet, data } = cameraPacket(2501)
+
+    vm.eventEmitter.on('camera_command_ack', (commandId) => {
+      assert.equal(commandId, 2501)
+      assert.equal(signalSent, false, 'Should not toggle when already stopped')
+      done()
+    })
+
+    vm.onMavPacket(packet, data)
+  })
+
+  it('command 2501 in non-video mode just emits ACK without toggling', function (done) {
+    const vm = makeManager({ cameraMode: 'streaming' })
+    vm.active = true
+    let signalSent = false
+    vm.deviceStream = { kill: (sig) => { if (sig === 'SIGUSR1') signalSent = true } }
+    const { packet, data } = cameraPacket(2501)
+
+    vm.eventEmitter.on('camera_command_ack', (commandId) => {
+      assert.equal(commandId, 2501)
+      assert.equal(signalSent, false, 'Should not toggle when not in video mode')
+      done()
+    })
+
+    vm.onMavPacket(packet, data)
+  })
+
+  // ── Unknown command targeting CAMERA ────────────────────────────────────
+
+  it('unknown camera-targeted command sends unsupported ACK', function (done) {
+    const vm = makeManager()
+    const { packet, data } = cameraPacket(9876)
+
+    vm.eventEmitter.on('camera_command_ack', (command, sysId, compId, targetComp, result) => {
+      assert.equal(command, 9876)
+      assert.equal(result, 3, 'Result should be MAV_RESULT_UNSUPPORTED (3)')
+      done()
+    })
+
+    vm.onMavPacket(packet, data)
+  })
 })

--- a/src/video.jsx
+++ b/src/video.jsx
@@ -131,21 +131,23 @@ class VideoPage extends basePage {
         let initialFps = selFps;
         
         if (cameraModeToUse === 'video') {
+            // Video recording mode now uses the same device/cap source as streaming mode
+            // so both modes offer the same resolution list.
             const savedDeviceValue = videoData.selectedDevice ? videoData.selectedDevice.value : null;
-            let matchingStillDev = stillDevs.find(d => d.id === savedDeviceValue);
+            let matchingVidDev = vidDevs.find(d => d.value === savedDeviceValue);
             
-            if (!matchingStillDev && stillDevs.length > 0) {
-                matchingStillDev = stillDevs[0];
+            if (!matchingVidDev && vidDevs.length > 0) {
+                matchingVidDev = vidDevs[0];
             }
 
-            if (matchingStillDev) {
-                initialVidDevSel = matchingStillDev.id;
-                initialVidCaps = matchingStillDev.caps ||[];
+            if (matchingVidDev) {
+                initialVidDevSel = matchingVidDev.value;
+                initialVidCaps = matchingVidDev.caps ||[];
                 const matchedCap = initialVidCaps.length > 0 ? initialVidCaps[0] : null;
-                initialVidCapSel = matchedCap ? this.getStillCapValue(matchedCap) : '';
-                initialFpsOpts =[];
-                initialFpsMax = 120; // Allow typing manual FPS up to 120
-                initialFps = selFps || 30;
+                initialVidCapSel = matchedCap ? matchedCap.value : '';
+                initialFpsOpts = matchedCap ? (matchedCap.fps || []) : [];
+                initialFpsMax = matchedCap ? (matchedCap.fpsmax || 0) : 0;
+                initialFps = initialFpsMax > 0 ? initialFpsMax : (initialFpsOpts.length > 0 ? initialFpsOpts[0].value : 30);
             } else {
                 initialVidDevSel = '';
                 initialVidCaps = [];
@@ -257,15 +259,16 @@ componentWillUnmount() {
 
     // Reset device/resolution selections when switching between streaming and video modes
     if (newMode === 'video') {
-      const firstStillDevice = this.state.stillDevices.length > 0 ? this.state.stillDevices[0] : null;
-      const firstCap = firstStillDevice && firstStillDevice.caps.length > 0 ? firstStillDevice.caps[0] : null;
+      // Video recording mode now uses the same device/cap source as streaming mode
+      const firstVidDevice = this.state.videoDevices.length > 0 ? this.state.videoDevices[0] : null;
+      const firstCap = firstVidDevice && firstVidDevice.caps.length > 0 ? firstVidDevice.caps[0] : null;
 
-      updates.vidDeviceSelected = firstStillDevice ? firstStillDevice.id : '';
-      updates.videoCaps = firstStillDevice ? firstStillDevice.caps :[];
-      updates.vidCapSelected = firstCap ? this.getStillCapValue(firstCap) : '';
-      updates.FPSMax = 120;
-      updates.fpsOptions =[];
-      updates.fpsSelected = 30;
+      updates.vidDeviceSelected = firstVidDevice ? firstVidDevice.value : '';
+      updates.videoCaps = firstVidDevice ? firstVidDevice.caps : [];
+      updates.vidCapSelected = firstCap ? firstCap.value : '';
+      updates.fpsOptions = firstCap ? (firstCap.fps || []) : [];
+      updates.FPSMax = firstCap ? (firstCap.fpsmax || 0) : 0;
+      updates.fpsSelected = updates.FPSMax > 0 ? updates.FPSMax : (updates.fpsOptions.length > 0 ? updates.fpsOptions[0].value : 30);
     } else if (newMode === 'streaming') {
       // Reset back to Streaming capabilities
       const firstVidDevice = this.state.videoDevices.length > 0 ? this.state.videoDevices[0] : null;
@@ -562,11 +565,11 @@ componentWillUnmount() {
         };
 
       } else if (cameraMode === 'video') {
-        // Video recording mode: use stillDevices
-        const device = stillDevices.find(d => d.id === vidDeviceSelected);
+        // Video recording mode now uses videoDevices instead of stillDevices
+        const device = videoDevices.find(d => d.value === vidDeviceSelected);
         if (!device) throw new Error("Video device not found. Please select a device from the list.");
 
-        const capObj = device.caps.find(c => this.getStillCapValue(c) === vidCapSelected);
+        const capObj = device.caps.find(c => c.value === vidCapSelected);
         if (!capObj) throw new Error("Selected resolution is not valid for this device.");
 
         body = {
@@ -827,17 +830,12 @@ renderContent() {
                 <div className="form-group row" style={{ marginBottom: '5px' }}>
                   <label className="col-sm-4 col-form-label">Video Device</label>
                   <div className="col-sm-8">
-                    {isVideo ? (
-                      // Video recording mode: use still devices
-                      <Form.Select disabled={active} onChange={this.handleVideoRecordingDeviceChange} value={this.state.vidDeviceSelected}>
-                        {this.state.stillDevices.map((d, idx) => <option key={idx} value={d.id}>{d.type}: {d.card_name}</option>)}
-                      </Form.Select>
-                    ) : (
-                      // Streaming mode: use video devices
-                      <Form.Select disabled={active} onChange={this.handleVideoDeviceChange} value={this.state.vidDeviceSelected}>
-                        {this.state.videoDevices.map((d, idx) => <option key={idx} value={d.value}>{d.label}</option>)}
-                      </Form.Select>
-                    )}
+                    {/* Both streaming and video recording modes now use
+                        videoDevices/handleVideoDeviceChange,
+                        so they share the same resolution list. */}
+                    <Form.Select disabled={active} onChange={this.handleVideoDeviceChange} value={this.state.vidDeviceSelected}>
+                      {this.state.videoDevices.map((d, idx) => <option key={idx} value={d.value}>{d.label}</option>)}
+                    </Form.Select>
                   </div>
                 </div>
 
@@ -856,17 +854,11 @@ renderContent() {
                   <div className="form-group row" style={{ marginBottom: '5px' }}>
                     <label className="col-sm-4 col-form-label">Resolution</label>
                     <div className="col-sm-8">
-                      {isVideo ? (
-                        // Video recording mode: use still device caps format
-                        <Form.Select disabled={active} onChange={this.handleVideoRecordingResChange} value={this.state.vidCapSelected}>
-                          {this.state.videoCaps.map((c, idx) => <option key={idx} value={this.getStillCapValue(c)}>{c.width}x{c.height} ({c.format})</option>)}
-                        </Form.Select>
-                      ) : (
-                        // Streaming mode: use video device caps format
-                        <Form.Select disabled={active} onChange={this.handleVideoResChange} value={this.state.vidCapSelected}>
-                          {this.state.videoCaps.map((c, idx) => <option key={idx} value={c.value}>{c.width}x{c.height} ({c.format})</option>)}
-                        </Form.Select>
-                      )}
+                      {/* Video and streaming modes now use the same videoCaps format (handleVideoResChange, c.value),
+                          since videoCaps is sourced from videoDevices in both modes. */}
+                      <Form.Select disabled={active} onChange={this.handleVideoResChange} value={this.state.vidCapSelected}>
+                        {this.state.videoCaps.map((c, idx) => <option key={idx} value={c.value}>{c.width}x{c.height} ({c.format})</option>)}
+                      </Form.Select>
                     </div>
                   </div>
                 )}


### PR DESCRIPTION
This PR introduces the following improvements to the MAVLink subsystem for camera control. Goal is to resolve #396 and add some additional enhancements/fixes.

* Force Rpanion to use MavLinkV2 for messages with ID > 255 (MavLinkV1 only supports IDs up to 255)
* Recognize and respond to a number of additional MavLink camera commands
* Send StorageInformation updates about free disk space
* Send CameraImageCaptured after every photo is captured
* Respond to unsupported requests with the appropriate ACK, rather than ignoring them
* Fixes an issue where geotagging worked when the camera was triggered in the web UI but not when triggered via MavLink
* Fixes the issue with video mode failing because the wrong camera modes were being saved
* Dramatically improved performance of get_camera_caps.py (from ~19s to <1s on Pi Zero 2W) by eliminating unnecessary calls to libcamera
* Add/update unit tests for better coverage

TODO still:
* Looks like there is a conflict with the latest upstream commit that I still need to resolve; creating the draft PR now before the branches get too far out of sync.
~~* Also need to do some more testing of video mode errors.~~ Done
~~* Add photo/video mode switching via MavLink~~ Defer to future PR - not mission critical