### PR TITLE
Video: Camera and MAVLink Improvements (attempt 2)

### DIFF
--- a/mavlink/mavManager.js
+++ b/mavlink/mavManager.js
@@ -250,8 +250,7 @@ class mavManager {
 
     this.udpStream.send(buffer, this.RinudpPort, this.RinudpIP, function (error) {
       if (error) {
-        this.udpStream.close()
-        console.log(error)
+        console.error("MAVLink UDP Send Error:", error)
       } else {
         // console.log(msgbuf)
         // console.log(buf)

--- a/mavlink/mavManager.js
+++ b/mavlink/mavManager.js
@@ -233,8 +233,13 @@ class mavManager {
       return
     }
 
+    // Get the Message ID
+    const msgId = msg.constructor.MSG_ID
+
     let protocol = null
-    if (this.version === 2) {
+    // Switch to V2 for messages >255
+    // Don't use strict equality ("===") because version might be stored as a string
+    if (this.version == 2 || (msgId && msgId > 255)) {
       protocol = new MavLinkProtocolV2(this.targetSystem, component)
     } else {
       protocol = new MavLinkProtocolV1(this.targetSystem, component)

--- a/python/get_camera_caps.py
+++ b/python/get_camera_caps.py
@@ -81,67 +81,52 @@ def get_card_name(dev_path):
 
     return None
 
-def get_libcamera_models():
-    """Get CSI camera model names from libcamera"""
+def get_subdev_name(dev_path):
+    """Read sensor model name from sysfs — fast file read, no subprocess."""
+    dev_name = os.path.basename(dev_path)  # e.g. v4l-subdev0
+    sysfs_path = f"/sys/class/video4linux/{dev_name}/name"
     try:
-        from picamera2 import Picamera2
-        models = {}
-        camera_info = Picamera2.global_camera_info()
-        
-        for idx, info in enumerate(camera_info):
-            model = info.get('Model', None)
-            if model and "usb@" not in info.get('Id', ''):
-                models[idx] = model
-        
-        return list(models.values())
-    except:
-        return []
+        with open(sysfs_path, 'r') as f:
+            # sysfs name is e.g. "imx219 10-0010" — take just the model part
+            return f.read().strip().split()[0]
+    except (FileNotFoundError, IndexError):
+        return None
 
+# picamera2 is checked via find_spec() rather than actually imported, since
+# importing it triggers a slow libcamera init (~10s on a Pi Zero 2W). cv2 has
+# no such cost, so it's actually imported to correctly detect broken installs
+# (e.g. present on disk but missing native .so dependencies) that find_spec()
+# would otherwise report as available.
 def get_capabilities():
-    """Check for availability of required libraries for photo/video modes"""
-    capabilities = {
-        'cv2': False,
-        'picamera2': False
-    }
-    
+    """Check cv2 and picamera2 availability."""
     try:
-        import cv2
-        capabilities['cv2'] = True
+        import cv2  # noqa: F401
+        has_cv2 = True
     except ImportError:
-        pass
-    
-    try:
-        from picamera2 import Picamera2
-        capabilities['picamera2'] = True
-    except (ImportError, OSError):
-        pass
-    
-    return capabilities
+        has_cv2 = False
+
+    import importlib.util
+    return {
+        'cv2': has_cv2,
+        'picamera2': importlib.util.find_spec('picamera2') is not None,
+    }
 
 check_if_v4l2_ctl_avail()
-
 devices = []
 
-# Get libcamera model names first
-libcamera_models = get_libcamera_models()
-model_idx = 0
-
-# Process CSI cameras
+# Enumerate CSI camera capabilities via v4l2-ctl/sysfs only. libcamera is
+# never initialized by this script (see get_capabilities()), so there's no
+# separate libcamera pass to reconcile these against.
+csi_devices = []
 for dev_path in get_subdev_paths():
     mbus_codes = get_mbus_codes(dev_path)
     if not mbus_codes:
         continue
-    
-    # Use libcamera model name if available, otherwise fall back to the v4l2 name
-    if model_idx < len(libcamera_models):
-        card_name = libcamera_models[model_idx]
-        model_idx += 1
-    else:
-        card_name = get_card_name(dev_path) or "Unnamed CSI Camera"
+
+    # Get card name here via v4l2 — avoids needing libcamera later
+    card_name = get_subdev_name(dev_path) or "Unnamed CSI Camera"
 
     device_caps = {
-        # Don't specify a device path for CSI cameras,
-        # but generate a unique ID for them.
         'id': f"CSI-{re.sub(r'[^a-zA-Z0-9]', '_', card_name)}",
         'device': None,
         'type': 'CSI',
@@ -149,22 +134,26 @@ for dev_path in get_subdev_paths():
         'caps': []
     }
 
+    seen = set()
     for mbus_code, pixel_format in mbus_codes:
         resolutions = get_resolutions(dev_path, mbus_code)
-
         for res in resolutions:
-            fmt = pixel_format.split("MEDIA_BUS_FMT_")[1] if "MEDIA_BUS_FMT_" in pixel_format else pixel_format
-            cap_info = {
-                'format': fmt,
+            key = (res['width'], res['height'])
+            if key in seen:
+                continue
+            seen.add(key)
+            device_caps['caps'].append({
+                'format': 'YUV420',
                 'width': res['width'],
                 'height': res['height'],
-                'label': f"{res['width']}x{res['height']}_{fmt}",
-                'value': f"{mbus_code}_{fmt}_{res['width']}x{res['height']}"
-            }
-            device_caps['caps'].append(cap_info)
+                'label': f"{res['width']}x{res['height']}",
+                'value': f"{res['width']}x{res['height']}_YUV420"
+            })
 
     if device_caps['caps']:
-        devices.append(device_caps)
+        csi_devices.append(device_caps)
+
+devices.extend(csi_devices)
 
 # Process UVC cameras
 for dev_path in get_video_device_paths():
@@ -178,12 +167,9 @@ for dev_path in get_video_device_paths():
             'caps': caps
         })
 
-# Get library capabilities and output as a single JSON object
-capabilities = get_capabilities()
-
 output = {
     'devices': devices,
-    'capabilities': capabilities
+    'capabilities': get_capabilities()
 }
 
 print(json.dumps(output, indent=4))

--- a/python/photovideo.py
+++ b/python/photovideo.py
@@ -136,6 +136,7 @@ def geotag_image(filepath):
 
     gps_file = '/tmp/rpanion_gps.json'
     if not os.path.exists(gps_file):
+        print("GPS coordinate data not found in /tmp/rpanion_gps.json")
         return
 
     try:

--- a/server/index.js
+++ b/server/index.js
@@ -70,6 +70,11 @@ const fcManager = new fcManagerClass(settings)
 const logManager = new flightLogger()
 const ntripClient = new ntrip(settings)
 const cloud = new cloudManager(settings)
+
+// Pass the fcManager instance to the videoStream,
+// so it can access position data for geotagging photos
+vManager.setFlightControllerManager(fcManager)
+
 const logConversion = new logConversionManager(settings)
 const adhocManager = new Adhoc(settings)
 const userMgmt = new userLogin()

--- a/server/index.js
+++ b/server/index.js
@@ -323,6 +323,18 @@ vManager.eventEmitter.on('cameratrigger', (msg, senderCompId) => {
   }
 })
 
+// Got a CAMERA_IMAGE_CAPTURED event, send to flight controller
+vManager.eventEmitter.on('cameraimagecaptured', (msg, senderCompId) => {
+  try {
+    if (fcManager.m) {
+      // Send the CAMERA_IMAGE_CAPTURED message to the flight controller
+      fcManager.m.sendData(msg, senderCompId)
+    }
+  } catch (err) {
+    console.log('Error sending CameraImageCaptured:', err);
+  }
+})
+
 vManager.eventEmitter.on('filesaved', (filepath) => {
   try {
     io.sockets.emit('camera:filesaved', { filename: filepath });

--- a/server/index.js
+++ b/server/index.js
@@ -297,6 +297,20 @@ vManager.eventEmitter.on('camerasettings', (msg, senderSysId, senderCompId, targ
   }
 })
 
+// Got a STORAGE_INFORMATION event, send to flight controller
+vManager.eventEmitter.on('storageinfo', (msg, senderSysId, senderCompId, targetComponent) => {
+  try {
+    if (fcManager.m) {
+      // Acknowledge the STORAGE_INFORMATION request
+      // Ack the MAV_CMD_REQUEST_MESSAGE (512), NOT the requested message ID.
+      fcManager.m.sendCommandAck(512, 0, senderSysId, senderCompId, targetComponent)
+      fcManager.m.sendData(msg, senderCompId)
+    }
+  } catch (err) {
+    console.log('Error sending StorageInformation:', err);
+  }
+})
+
 // Got a CAMERA_TRIGGER event, send to flight controller
 vManager.eventEmitter.on('cameratrigger', (msg, senderCompId) => {
   try {

--- a/server/index.js
+++ b/server/index.js
@@ -230,7 +230,18 @@ app.post('/api/togglevideorecording', authenticateToken, function (req, res) {
     }
   } else {
     console.log(`[API /togglevideorecording] Condition NOT met (active=${vManager.active}, mode=${vManager.cameraMode}). Sending 400.`);
-    res.status(400).send({ error: 'Camera is not active in video recording mode.' });
+    res.status(400).send({ error: 'Camera is not active or not in video recording mode.' });
+  }
+})
+
+// General command ack response with optional result code (default 0 = ACCEPTED)
+vManager.eventEmitter.on('camera_command_ack', (commandId, senderSysId, senderCompId, targetComponent, result = 0) => {
+  try {
+    if (fcManager.m) {
+      fcManager.m.sendCommandAck(commandId, result, senderSysId, senderCompId, targetComponent)
+    }
+  } catch (err) {
+    console.log(`Error sending ACK for command ${commandId}:`, err);
   }
 })
 
@@ -262,7 +273,8 @@ vManager.eventEmitter.on('camerainfo', (msg, senderSysId, senderCompId, targetCo
   try {
     if (fcManager.m) {
       // Acknowledge the CAMERA_INFORMATION request
-      fcManager.m.sendCommandAck(common.CameraInformation.MSG_ID, 0, senderSysId, senderCompId, targetComponent)
+      // Ack the MAV_CMD_REQUEST_MESSAGE (512), NOT the requested message ID.
+      fcManager.m.sendCommandAck(common.MavCmd['REQUEST_MESSAGE'], 0, senderSysId, senderCompId, targetComponent)
       fcManager.m.sendData(msg, senderCompId)
     }
   } catch (err) {
@@ -275,7 +287,8 @@ vManager.eventEmitter.on('videostreaminfo', (msg, senderSysId, senderCompId, tar
   try {
     if (fcManager.m) {
       // Acknowledge the VIDEO_STREAM_INFORMATION request
-      fcManager.m.sendCommandAck(common.VideoStreamInformation.MSG_ID, 0, senderSysId, senderCompId, targetComponent)
+      // Ack the MAV_CMD_REQUEST_MESSAGE (512), NOT the requested message ID.
+      fcManager.m.sendCommandAck(common.MavCmd['REQUEST_MESSAGE'], 0, senderSysId, senderCompId, targetComponent)
       fcManager.m.sendData(msg, senderCompId)
     }
   } catch (err) {
@@ -288,7 +301,8 @@ vManager.eventEmitter.on('camerasettings', (msg, senderSysId, senderCompId, targ
   try {
     if (fcManager.m) {
       // Acknowledge the CAMERA_SETTINGS request
-      fcManager.m.sendCommandAck(common.CameraSettings.MSG_ID, 0, senderSysId, senderCompId, targetComponent)
+      // Ack the MAV_CMD_REQUEST_MESSAGE (512), NOT the requested message ID.
+      fcManager.m.sendCommandAck(common.MavCmd['REQUEST_MESSAGE'], 0, senderSysId, senderCompId, targetComponent)
       fcManager.m.sendData(msg, senderCompId)
     }
   } catch (err) {
@@ -303,7 +317,7 @@ vManager.eventEmitter.on('storageinfo', (msg, senderSysId, senderCompId, targetC
     if (fcManager.m) {
       // Acknowledge the STORAGE_INFORMATION request
       // Ack the MAV_CMD_REQUEST_MESSAGE (512), NOT the requested message ID.
-      fcManager.m.sendCommandAck(512, 0, senderSysId, senderCompId, targetComponent)
+      fcManager.m.sendCommandAck(common.MavCmd['REQUEST_MESSAGE'], 0, senderSysId, senderCompId, targetComponent)
       fcManager.m.sendData(msg, senderCompId)
     }
   } catch (err) {

--- a/server/videostream.js
+++ b/server/videostream.js
@@ -472,6 +472,8 @@ class videoStream {
 
     // Start MAVLink heartbeats if enabled
     if (this.useCameraHeartbeat) {
+      // Send one immediate heartbeat before starting the timer
+      this.eventEmitter.emit('cameraheartbeat', minimal.MavType.CAMERA, minimal.MavAutopilot.INVALID, minimal.MavComponent.CAMERA);
       this.startHeartbeatInterval();
       this.sendVideoStreamInformation(null, minimal.MavComponent.CAMERA, null);
     }
@@ -506,8 +508,11 @@ class videoStream {
 
     // Start MAVLink heartbeats if enabled
     if (this.useCameraHeartbeat) {
+      // Send one immediate heartbeat before starting the timer
+      this.eventEmitter.emit('cameraheartbeat', minimal.MavType.CAMERA, minimal.MavAutopilot.INVALID, minimal.MavComponent.CAMERA);
       this.startHeartbeatInterval();
       this.sendCameraInformation(null, minimal.MavComponent.CAMERA, null);
+      this.sendCameraSettings(null, minimal.MavComponent.CAMERA, null);
     }
   }
 
@@ -548,8 +553,11 @@ class videoStream {
 
     // Start MAVLink heartbeats if enabled
     if (this.useCameraHeartbeat) {
+      // Send one immediate heartbeat before starting the timer
+      this.eventEmitter.emit('cameraheartbeat', minimal.MavType.CAMERA, minimal.MavAutopilot.INVALID, minimal.MavComponent.CAMERA);
       this.startHeartbeatInterval();
       this.sendCameraInformation(null, minimal.MavComponent.CAMERA, null);
+      this.sendCameraSettings(null, minimal.MavComponent.CAMERA, null);
     }
   }
 
@@ -563,7 +571,7 @@ class videoStream {
 
       if (!callbackCalled) {
         callbackCalled = true;
-        console.log(`${modeName}: No response from script after 60s, assuming start.`);
+        console.log(`${modeName}: No response from script after 90s, assuming start.`);
         this.active = true;
         this.saveSettings();
         callback(null, { active: true, addresses: this.deviceAddresses });

--- a/server/videostream.js
+++ b/server/videostream.js
@@ -925,22 +925,43 @@ class videoStream {
   onMavPacket(packet, data) {
     if (packet.header.msgid === common.CommandLong.MSG_ID &&
       data.targetComponent === minimal.MavComponent.CAMERA) {
-      if (data._param1 === common.CameraInformation.MSG_ID) {
+      // Ardupilot camera mavlinkv2
+      if (data.command === common.RequestMessageCommand.MSG_ID && data.param1 === common.MavMsgId['CAMERA_INFORMATION']) {
         console.log('Responding to MAVLink request for CameraInformation')
         this.sendCameraInformation(packet.header.sysid, minimal.MavComponent.CAMERA, packet.header.compid);
       }
+      else if (data.command === common.MavCmd['IMAGE_START_CAPTURE']) {
+        console.log('Received MAVLink command to start image capture')
+        this.captureStillPhoto(packet.header.sysid, packet.header.compid, minimal.MavComponent.CAMERA)
+      }
+      else if (data.command === common.MavCmd['VIDEO_START_CAPTURE']) {
+        console.log('Received MAVLink command to start video capture')
+        this.toggleVideoRecording()
+      }
+      else if (data.command === common.MavCmd['VIDEO_STOP_CAPTURE']) {
+        console.log('Received MAVLink command to stop video capture')
+        this.toggleVideoRecording()
+      }
+      // Mission Planner???
       else if (data._param1 === common.VideoStreamInformation.MSG_ID && this.cameraMode === "streaming") {
         console.log('Responding to MAVLink request for VideoStreamInformation')
         this.sendVideoStreamInformation(packet.header.sysid, minimal.MavComponent.CAMERA, packet.header.compid);
       }
-      else if (data._param1 === common.CameraSettings.MSG_ID) {
+      else if (data.command === common.MavCmd['CAMERA_SETTINGS']) {
         console.log('Responding to MAVLink request for CameraSettings')
         this.sendCameraSettings(packet.header.sysid, minimal.MavComponent.CAMERA, packet.header.compid)
       }
-      // 203 = MAV_CMD_DO_DIGICAM_CONTROL
-      else if (data.command === 203) {
+      //MAVProxy
+      else if (data.command === common.MavCmd['DO_DIGICAM_CONFIGURE']) {
+        console.log('Received DoDigicamConfigureCommand command')
+        this.sendCameraInformation(packet.header.sysid, minimal.MavComponent.CAMERA, packet.header.compid);
+      }
+      else if (data.command === common.MavCmd['DO_DIGICAM_CONTROL']) {
         console.log('Received DoDigicamControl command')
         this.captureStillPhoto(packet.header.sysid, minimal.MavComponent.CAMERA, packet.header.compid)
+      }
+      else {
+        console.log('Received Unhandled MAVLink packet for camera:', packet.header.msgid, data);
       }
     }
   }

--- a/server/videostream.js
+++ b/server/videostream.js
@@ -27,6 +27,7 @@ class videoStream {
     this.stillDevices = null; // Still devices
     this.videoSettings = null;
     this.stillSettings = null;
+    this.fcManager = null;    // Flight controller manager reference, set externally if available
 
     // Load saved settings from the 'camera' namespace
     this.active = this.settings.value('camera.active', false);
@@ -64,6 +65,11 @@ class videoStream {
   toAbsolutePath(dest) {
     dest = this.toRelativePath(dest);
     return dest ? path.join(logpaths.mediaDir, dest) : logpaths.mediaDir;
+  }
+
+  // Reference the fcManager so we can access position data for geotagging
+  setFlightControllerManager(fcManager) {
+    this.fcManager = fcManager;
   }
 
   async initialize() {

--- a/server/videostream.js
+++ b/server/videostream.js
@@ -1049,46 +1049,83 @@ class videoStream {
     this.eventEmitter.emit('storageinfo', msg, senderSysId, senderCompId, targetComponent)
   }
 
+  // Helper to log and emit an UNSUPPORTED ACK for MAVLink commands/messages we haven't implemented
+  sendUnsupportedAck(emittedCommand, sysid, compid) {
+    console.log(`MAVLink command ${emittedCommand} is unsupported. Sending UNSUPPORTED ACK.`)
+    this.eventEmitter.emit('camera_command_ack', emittedCommand, sysid, minimal.MavComponent.CAMERA, compid, 3);
+  }
+
   onMavPacket(packet, data) {
     if (packet.header.msgid === common.CommandLong.MSG_ID &&
       data.targetComponent === minimal.MavComponent.CAMERA) {
-      // Ardupilot camera mavlinkv2
-      if (data.command === common.RequestMessageCommand.MSG_ID && data.param1 === common.MavMsgId['CAMERA_INFORMATION']) {
-        console.log('Responding to MAVLink request for CameraInformation')
-        this.sendCameraInformation(packet.header.sysid, minimal.MavComponent.CAMERA, packet.header.compid);
+
+      // Get the vehicle position if fcManager is available,
+      // for operations that need it (e.g., photo geotagging).
+      const currentPosition = this.fcManager?.getSystemStatus?.()?.vehiclePosition || null;
+
+      // Handle message request commands (MAV_CMD_REQUEST_MESSAGE)
+      if (data.command === common.MavCmd['REQUEST_MESSAGE']) {
+        const requestedMsgId = data._param1;
+
+        if (requestedMsgId === common.CameraInformation.MSG_ID) {
+          console.log(`Responding to MAVLink request for CameraInformation from SysID: ${packet.header.sysid}, CompID: ${packet.header.compid}`)
+          this.sendCameraInformation(packet.header.sysid, minimal.MavComponent.CAMERA, packet.header.compid);
+        }
+        else if (requestedMsgId === common.VideoStreamInformation.MSG_ID && this.cameraMode === "streaming") {
+          console.log('Responding to MAVLink request for VideoStreamInformation')
+          this.sendVideoStreamInformation(packet.header.sysid, minimal.MavComponent.CAMERA, packet.header.compid);
+        }
+        else if (requestedMsgId === common.CameraSettings.MSG_ID) {
+          console.log(`Responding to MAVLink request for CameraSettings from SysID: ${packet.header.sysid}, CompID: ${packet.header.compid}`)
+          this.sendCameraSettings(packet.header.sysid, minimal.MavComponent.CAMERA, packet.header.compid)
+        }
+        else if (requestedMsgId === common.StorageInformation.MSG_ID) {
+          console.log(`Responding to MAVLink request for StorageInformation from SysID: ${packet.header.sysid}, CompID: ${packet.header.compid}`)
+          this.sendStorageInfo(packet.header.sysid, minimal.MavComponent.CAMERA, packet.header.compid)
+        }
+        else {
+          this.sendUnsupportedAck(common.MavCmd['REQUEST_MESSAGE'], packet.header.sysid, packet.header.compid)
+        }
+      }
+      // Handle message rate requests (MAV_CMD_SET_MESSAGE_INTERVAL)
+      else if (data.command === common.MavCmd['SET_MESSAGE_INTERVAL']) {
+        console.log(`Received SET_MESSAGE_INTERVAL command for msgId: ${data._param1}. Replying with ACCEPTED.`);
+        // 0 is MAV_RESULT_ACCEPTED
+        this.eventEmitter.emit('camera_command_ack', common.MavCmd['SET_MESSAGE_INTERVAL'], packet.header.sysid, minimal.MavComponent.CAMERA, packet.header.compid, 0);
       }
       else if (data.command === common.MavCmd['IMAGE_START_CAPTURE']) {
         console.log('Received MAVLink command to start image capture')
-        this.captureStillPhoto(packet.header.sysid, packet.header.compid, minimal.MavComponent.CAMERA)
+        this.captureStillPhoto(packet.header.sysid, minimal.MavComponent.CAMERA, packet.header.compid, currentPosition, common.MavCmd['IMAGE_START_CAPTURE'])
+      }
+      else if (data.command === common.MavCmd['IMAGE_STOP_CAPTURE']) {
+        console.log('Received IMAGE_STOP_CAPTURE command')
+        this.eventEmitter.emit('camera_command_ack', common.MavCmd['IMAGE_STOP_CAPTURE'], packet.header.sysid, minimal.MavComponent.CAMERA, packet.header.compid)
       }
       else if (data.command === common.MavCmd['VIDEO_START_CAPTURE']) {
         console.log('Received MAVLink command to start video capture')
-        this.toggleVideoRecording()
+        if (this.cameraMode === 'video' && !this.videoSettings.isRecording) {
+          this.toggleVideoRecording()
+        }
+        this.eventEmitter.emit('camera_command_ack', common.MavCmd['VIDEO_START_CAPTURE'], packet.header.sysid, minimal.MavComponent.CAMERA, packet.header.compid)
       }
       else if (data.command === common.MavCmd['VIDEO_STOP_CAPTURE']) {
         console.log('Received MAVLink command to stop video capture')
-        this.toggleVideoRecording()
+        if (this.cameraMode === 'video' && this.videoSettings.isRecording) {
+          this.toggleVideoRecording()
+        }
+        this.eventEmitter.emit('camera_command_ack', common.MavCmd['VIDEO_STOP_CAPTURE'], packet.header.sysid, minimal.MavComponent.CAMERA, packet.header.compid)
       }
-      // Mission Planner???
-      else if (data._param1 === common.VideoStreamInformation.MSG_ID && this.cameraMode === "streaming") {
-        console.log('Responding to MAVLink request for VideoStreamInformation')
-        this.sendVideoStreamInformation(packet.header.sysid, minimal.MavComponent.CAMERA, packet.header.compid);
-      }
-      else if (data.command === common.MavCmd['CAMERA_SETTINGS']) {
-        console.log('Responding to MAVLink request for CameraSettings')
-        this.sendCameraSettings(packet.header.sysid, minimal.MavComponent.CAMERA, packet.header.compid)
-      }
-      //MAVProxy
+      // MAVProxy: responds to DO_DIGICAM_CONFIGURE by requesting our capabilities
       else if (data.command === common.MavCmd['DO_DIGICAM_CONFIGURE']) {
         console.log('Received DoDigicamConfigureCommand command')
         this.sendCameraInformation(packet.header.sysid, minimal.MavComponent.CAMERA, packet.header.compid);
       }
       else if (data.command === common.MavCmd['DO_DIGICAM_CONTROL']) {
-        console.log('Received DoDigicamControl command')
-        this.captureStillPhoto(packet.header.sysid, minimal.MavComponent.CAMERA, packet.header.compid)
+        console.log('Received MAV_CMD_DO_DIGICAM_CONTROL command')
+        this.captureStillPhoto(packet.header.sysid, minimal.MavComponent.CAMERA, packet.header.compid, currentPosition, common.MavCmd['DO_DIGICAM_CONTROL'])
       }
       else {
-        console.log('Received Unhandled MAVLink packet for camera:', packet.header.msgid, data);
+        this.sendUnsupportedAck(data.command, packet.header.sysid, packet.header.compid)
       }
     }
   }

--- a/server/videostream.js
+++ b/server/videostream.js
@@ -954,6 +954,48 @@ class videoStream {
     this.eventEmitter.emit('videostreaminfo', msg, senderSysId, senderCompId, targetComponent)
   }
 
+  // Find how much media space there is in total, and how much is available
+  async getStorageStats() {
+    try {
+      const s = await fs.promises.statfs(logpaths.mediaDir);
+      const total = BigInt(s.bsize) * BigInt(s.blocks);
+      const free = BigInt(s.bsize) * BigInt(s.bfree);
+      const avail = BigInt(s.bsize) * BigInt(s.bavail);
+      const used = total - free;
+      const totalMiB = Number(total / BigInt(1024 * 1024));
+      const usedMiB = Number(used / BigInt(1024 * 1024));
+      const availableMiB = Number(avail / BigInt(1024 * 1024));
+      return { totalMiB, usedMiB, availableMiB };
+    } catch (e) {
+      return { totalMiB: 0, usedMiB: 0, availableMiB: 0 };
+    }
+  }
+
+  async sendStorageInfo(senderSysId, senderCompId, targetComponent) {
+    console.log('Sending MAVLink StorageInformation packet')
+
+    // Build a STORAGE_INFORMATION packet
+    const msg = new common.StorageInformation()
+
+    // Try to get real storage stats for mediaDir; fall back to safe defaults
+    const stats = await this.getStorageStats().catch(() => ({ totalMiB: 0, usedMiB: 0 }));
+
+    msg.timeBootMs = process.uptime()*1000;
+    msg.storageId = 1;           // First storage device
+    msg.storageCount = 1;       // One storage device available
+    msg.status = common.StorageStatus.READY;
+    msg.totalCapacity = stats.totalMiB;   // Capacity in MiB
+    msg.usedCapacity = stats.usedMiB;
+    msg.availableCapacity = Math.max(0, stats.availableMiB || 0);
+    msg.readSpeed = 0;         // Speeds in MiB/s, just send zeroes for now
+    msg.writeSpeed = 0;
+    msg.type = common.StorageType.MICROSD;
+    msg.name = this.toMavString('Rpanion Storage', 32);
+    msg.storageUsage = 7; // Usage bitmask; 1 = Set (required), 2 = Photo, 4 = Video
+
+    this.eventEmitter.emit('storageinfo', msg, senderSysId, senderCompId, targetComponent)
+  }
+
   onMavPacket(packet, data) {
     if (packet.header.msgid === common.CommandLong.MSG_ID &&
       data.targetComponent === minimal.MavComponent.CAMERA) {

--- a/server/videostream.js
+++ b/server/videostream.js
@@ -739,7 +739,7 @@ class videoStream {
     }, 1000)
   }
 
-  captureStillPhoto(senderSysId, senderCompId, targetComponent, positionData = null) {
+  captureStillPhoto(senderSysId, senderCompId, targetComponent, positionData = null, commandId = null) {
     console.log('Attempting captureStillPhoto. Internal state: active=', this.active, 'mode=', this.cameraMode, 'deviceStream exists=', !!this.deviceStream);
 
     // Capture a single still photo
@@ -761,6 +761,7 @@ class videoStream {
         console.error('Failed to write GPS temp file:', e);
       }
     } else {
+      console.error('GPS data not available for geotagging. Check that "Enable datastream requests" is enabled on the Flight Controller page.');
       // Clean up old file to prevent stale tags
       if (fs.existsSync('/tmp/rpanion_gps.json')) {
         fs.unlinkSync('/tmp/rpanion_gps.json');
@@ -774,11 +775,63 @@ class videoStream {
     const msg = new common.CameraTrigger()
     // Date.now() returns time in milliseconds
     msg.timeUsec = BigInt(Date.now() * 1000)
-    // Increment the photo counter
-    msg.seq = this.photoSeq++
+    // Pre-increment the photo counter so that it's correct for
+    // both the CameraTrigger and the CameraImageCaptured messages
+    msg.seq = ++this.photoSeq
 
-    this.eventEmitter.emit('digicamcontrol', senderSysId, senderCompId, targetComponent)
+    // If triggered by a MAVLink command, emit a generalized ACK event
+    if (commandId && senderSysId !== null) {
+      this.eventEmitter.emit('camera_command_ack', commandId, senderSysId, senderCompId, targetComponent)
+    } else {
+      // Fallback for legacy listeners or safety
+      this.eventEmitter.emit('digicamcontrol', senderSysId, senderCompId, targetComponent)
+    }
+
+    // Advertise that an image was captured
     this.eventEmitter.emit('cameratrigger', msg, senderCompId)
+    this.sendCameraImageCaptured(senderCompId)
+
+    // Send updated storage availability
+    this.sendStorageInfo(senderSysId, senderCompId, targetComponent)
+  }
+
+  sendCameraImageCaptured(senderCompId) {
+    const msg = new common.CameraImageCaptured();
+
+    // Import the most recently saved GPS coordinates
+    let latitude = null, longitude = null, altitude = null, relative_altitude = null;
+    if (fs.existsSync('/tmp/rpanion_gps.json')) {
+      try {
+        const data = JSON.parse(fs.readFileSync('/tmp/rpanion_gps.json', 'utf8'));
+        latitude = data.lat;
+        longitude = data.lon;
+        altitude = data.alt;
+        relative_altitude = data.relAlt;
+      } catch (e) {
+        console.error('sendCameraImageCaptured: Failed to read GPS file:', e);
+      }
+    } else {
+      console.log('sendCameraImageCaptured: GPS file not found, skipping geotagging.');
+    }
+
+    msg.timeBootMs = Math.floor(process.uptime() * 1000);
+    msg.timeUtc = BigInt(Date.now()) * 1000n;
+    msg.cameraId = 0;
+    // for the mavlink message, lat/lon need to be int32_t in degrees * 1e7
+    msg.lat = latitude !== null ? Math.round(latitude * 1e7) : 0;
+    msg.lon = longitude !== null ? Math.round(longitude * 1e7) : 0;
+    // alt/relativeAlt are int32_t in millimeters
+    msg.alt = altitude !== null ? Math.round(altitude * 1000) : 0;
+    msg.relativeAlt = relative_altitude !== null ? Math.round(relative_altitude * 1000) : 0;
+
+    msg.q = [1,0,0,0]; // [1,0,0,0] for zero rotation
+    msg.imageIndex = this.photoSeq;
+    msg.captureResult = 1;          // Hard-code that capture was a success (for now)
+    msg.fileUrl = '';               // Leave blank for now; not used
+
+    console.log('Sending MAVLink CameraImageCaptured packet.');
+
+    this.eventEmitter.emit('cameraimagecaptured', msg, senderCompId);
   }
 
   toggleVideoRecording() {

--- a/server/videostream.js
+++ b/server/videostream.js
@@ -800,14 +800,23 @@ class videoStream {
     this.saveSettings();
   }
 
-  // Helper to convert JS strings to the Array<string> format node-mavlink expects for char[]
-  toMavChars(str, length) {
-    const buf = new Uint8Array(length);
-    if (!str) return buf;
+  // Helper to format uint8_t[] fields (e.g., vendorName, modelName) for mavlink messages
+  toMavUint8Array(str, length) {
+    const out = new Array(length).fill(0);
+    const s = (str || "").toString();
+    // Bound the loop by length directly (not just s.length) so a very
+    // long input string can't drive an unbounded number of iterations.
+    const n = Math.min(s.length, length);
+    for (let i = 0; i < n; i++) {
+      out[i] = s.charCodeAt(i);
+    }
+    return out;
+  }
 
-    const encoded = new TextEncoder().encode(str);
-    buf.set(encoded.slice(0, length));
-    return buf;
+  // Helper to format char[] fields (e.g., camDefinitionUri) for mavlink messages
+  toMavString(str, length) {
+    if (!str) return "";
+    return str.toString().slice(0, length - 1);
   }
 
   sendCameraInformation(senderSysId, senderCompId, targetComponent) {
@@ -837,16 +846,18 @@ class videoStream {
       }
     }
 
-    msg.vendorName = this.toMavChars("Rpanion", 32);
-    msg.modelName = this.toMavChars(extractedModel, 32);
+    msg.timeBootMs = process.uptime()*1000;
+    msg.vendorName = this.toMavUint8Array("Rpanion", 32);
+    msg.modelName = this.toMavUint8Array(extractedModel, 32);
     msg.firmwareVersion = 0;
     msg.focalLength = 0;
     msg.sensorSizeH = 0;
     msg.sensorSizeV = 0;
     msg.lensId = 0;
     msg.camDefinitionVersion = 0;
-    msg.camDefinitionUri = ""; // send zero-length string if not known
-    msg.gimbalDeviceId = 0;
+    msg.camDefinitionUri = this.toMavString("", 140);
+    msg.gimbalDeviceId = 0; // No gimbal
+    msg.cameraDeviceId = 0; // 0 = MAVLink Camera with its own component ID
 
     // Mode-specific Configuration
     if (this.cameraMode === 'photo') {
@@ -857,7 +868,7 @@ class videoStream {
     else if (this.cameraMode === 'video') {
       msg.resolutionH = this.videoSettings?.width || 0;
       msg.resolutionV = this.videoSettings?.height || 0;
-      msg.flags = 4; // CAMERA_CAP_FLAGS_CAPTURE_VIDEO
+      msg.flags = 1; // CAMERA_CAP_FLAGS_CAPTURE_VIDEO
     }
     else {
       // Default: streaming
@@ -875,7 +886,7 @@ class videoStream {
     // build a CAMERA_SETTINGS packet
     const msg = new common.CameraSettings()
 
-    msg.timeBootMs = 0
+    msg.timeBootMs = process.uptime()*1000;
 
     // Camera modes: 0 = IMAGE, 1 = VIDEO, 2 = IMAGE_SURVEY
     if (this.cameraMode === 'photo') {
@@ -891,7 +902,8 @@ class videoStream {
   }
 
   sendVideoStreamInformation(senderSysId, senderCompId, targetComponent) {
-    console.log('Responding to MAVLink request for VideoStreamInformation')
+    // Log the SysID and CompID of the requester
+    console.log(`Responding to MAVLink request for VideoStreamInformation from SysID: ${senderSysId}, CompID: ${targetComponent}`)
 
     // build a VIDEO_STREAM_INFORMATION packet
     const msg = new common.VideoStreamInformation()
@@ -900,13 +912,15 @@ class videoStream {
     msg.streamId = 1
     msg.count = 1
 
+    let uriString = "";
+
     // msg.type and msg.uri need to be different depending on whether RTP or RTSP is selected
     if (this.videoSettings && this.videoSettings.useUDP) {
       // msg.type = 0 = VIDEO_STREAM_TYPE_RTSP
       // msg.type = 1 = VIDEO_STREAM_TYPE_RTPUDP
       msg.type = 1
       // For RTP, just send the destination UDP port instead of a full URI
-      msg.uri = this.videoSettings.useUDPPort.toString();
+      uriString = this.videoSettings.useUDPPort.toString();
     } else {
       msg.type = 0
       msg.encoding = this.videoSettings.compression === 'H264' ? 1 : (this.videoSettings.compression === 'H265' ? 2 : 0);
@@ -917,21 +931,25 @@ class videoStream {
         addr.includes(this.videoSettings.mavStreamSelected)
       );
 
-      msg.uri = matchedAddress || "";
+      uriString = matchedAddress || "";
 
     }
+
+    // Convert URI string to the field's declared max length (160 bytes)
+    msg.uri = this.toMavString(uriString, 160);
 
     // 1 = VIDEO_STREAM_STATUS_FLAGS_RUNNING
     msg.flags = 1;
     msg.framerate = this.videoSettings.fps;
     msg.resolutionH = this.videoSettings.width;
     msg.resolutionV = this.videoSettings.height;
-    msg.bitrate = this.videoSettings.bitrate;
+    // Convert bitrate from kbps (shown in Web UI) to bps (as per MAVLink spec)
+    msg.bitrate = this.videoSettings.bitrate * 1000;
     msg.rotation = this.videoSettings.rotation;
     // Rpanion doesn't collect field of view values, so set to zero
     msg.hfov = 0;
-    // Set the stream name (usually the device path)
-    msg.name = this.videoSettings.device;
+    // Convert the device name string to the field's declared max length (32 bytes)
+    msg.name = this.toMavString(this.videoSettings.device || "", 32);
 
     this.eventEmitter.emit('videostreaminfo', msg, senderSysId, senderCompId, targetComponent)
   }

--- a/server/videostream.test.js
+++ b/server/videostream.test.js
@@ -176,7 +176,7 @@ describe('Video Functions', function () {
     vManager.eventEmitter.on('cameratrigger', (msg, compId) => {
       triggerReceived = true
       assert.ok(msg.timeUsec > 0)
-      assert.equal(msg.seq, 0) // First photo
+      assert.equal(msg.seq, 1) // First photo (photoSeq is pre-incremented)
     })
 
     vManager.captureStillPhoto(1, 1, 1)

--- a/server/videostream.test.js
+++ b/server/videostream.test.js
@@ -214,8 +214,8 @@ describe('Video Functions', function () {
     vManager.videoSettings = { device: 'imx219' }
 
     vManager.eventEmitter.on('camerainfo', (msg, sysId, compId) => {
-      // Decode vendor name (Uint8Array to string)
-      const vendorText = new TextDecoder().decode(msg.vendorName).replace(/\0/g, '')
+      // Decode vendor name (plain byte array to string)
+      const vendorText = String.fromCharCode(...msg.vendorName).replace(/\0/g, '')
       assert.equal(vendorText, 'Rpanion')
       assert.equal(msg.flags, 256) // Default streaming flag
       done()

--- a/src/video.jsx
+++ b/src/video.jsx
@@ -131,18 +131,24 @@ class VideoPage extends basePage {
         let initialFps = selFps;
         
         if (cameraModeToUse === 'video') {
+            // Video recording mode now uses the same device/cap source as streaming mode
+            // so both modes offer the same resolution list.
             const savedDeviceValue = videoData.selectedDevice ? videoData.selectedDevice.value : null;
-            let matchingStillDev = stillDevs.find(d => d.id === savedDeviceValue);
+            let matchingVidDev = vidDevs.find(d => d.value === savedDeviceValue);
             
-            if (!matchingStillDev && stillDevs.length > 0) {
-                matchingStillDev = stillDevs[0];
+            if (!matchingVidDev && vidDevs.length > 0) {
+                matchingVidDev = vidDevs[0];
             }
 
-            if (matchingStillDev) {
-                initialVidDevSel = matchingStillDev.id;
-                initialVidCaps = matchingStillDev.caps ||[];
-                const matchedCap = initialVidCaps.length > 0 ? initialVidCaps[0] : null;
-                initialVidCapSel = matchedCap ? this.getStillCapValue(matchedCap) : '';
+            if (matchingVidDev) {
+                initialVidDevSel = matchingVidDev.value;
+                initialVidCaps = matchingVidDev.caps ||[];
+                const savedCapValue = videoData.selectedCap ? videoData.selectedCap.value : null;
+                let matchedCap = initialVidCaps.find(c => c.value === savedCapValue);
+                if (!matchedCap && initialVidCaps.length > 0) {
+                    matchedCap = initialVidCaps[0];
+                }
+                initialVidCapSel = matchedCap ? matchedCap.value : '';
                 initialFpsOpts =[];
                 initialFpsMax = 120; // Allow typing manual FPS up to 120
                 initialFps = selFps || 30;
@@ -257,12 +263,13 @@ componentWillUnmount() {
 
     // Reset device/resolution selections when switching between streaming and video modes
     if (newMode === 'video') {
-      const firstStillDevice = this.state.stillDevices.length > 0 ? this.state.stillDevices[0] : null;
-      const firstCap = firstStillDevice && firstStillDevice.caps.length > 0 ? firstStillDevice.caps[0] : null;
+      // Video recording mode now uses the same device/cap source as streaming mode
+      const firstVidDevice = this.state.videoDevices.length > 0 ? this.state.videoDevices[0] : null;
+      const firstCap = firstVidDevice && firstVidDevice.caps.length > 0 ? firstVidDevice.caps[0] : null;
 
-      updates.vidDeviceSelected = firstStillDevice ? firstStillDevice.id : '';
-      updates.videoCaps = firstStillDevice ? firstStillDevice.caps :[];
-      updates.vidCapSelected = firstCap ? this.getStillCapValue(firstCap) : '';
+      updates.vidDeviceSelected = firstVidDevice ? firstVidDevice.value : '';
+      updates.videoCaps = firstVidDevice ? firstVidDevice.caps : [];
+      updates.vidCapSelected = firstCap ? firstCap.value : '';
       updates.FPSMax = 120;
       updates.fpsOptions =[];
       updates.fpsSelected = 30;
@@ -562,11 +569,11 @@ componentWillUnmount() {
         };
 
       } else if (cameraMode === 'video') {
-        // Video recording mode: use stillDevices
-        const device = stillDevices.find(d => d.id === vidDeviceSelected);
+        // Video recording mode now uses videoDevices instead of stillDevices
+        const device = videoDevices.find(d => d.value === vidDeviceSelected);
         if (!device) throw new Error("Video device not found. Please select a device from the list.");
 
-        const capObj = device.caps.find(c => this.getStillCapValue(c) === vidCapSelected);
+        const capObj = device.caps.find(c => c.value === vidCapSelected);
         if (!capObj) throw new Error("Selected resolution is not valid for this device.");
 
         body = {
@@ -827,17 +834,12 @@ renderContent() {
                 <div className="form-group row" style={{ marginBottom: '5px' }}>
                   <label className="col-sm-4 col-form-label">Video Device</label>
                   <div className="col-sm-8">
-                    {isVideo ? (
-                      // Video recording mode: use still devices
-                      <Form.Select disabled={active} onChange={this.handleVideoRecordingDeviceChange} value={this.state.vidDeviceSelected}>
-                        {this.state.stillDevices.map((d, idx) => <option key={idx} value={d.id}>{d.type}: {d.card_name}</option>)}
-                      </Form.Select>
-                    ) : (
-                      // Streaming mode: use video devices
-                      <Form.Select disabled={active} onChange={this.handleVideoDeviceChange} value={this.state.vidDeviceSelected}>
-                        {this.state.videoDevices.map((d, idx) => <option key={idx} value={d.value}>{d.label}</option>)}
-                      </Form.Select>
-                    )}
+                    {/* Both streaming and video recording modes now use
+                        videoDevices/handleVideoDeviceChange,
+                        so they share the same resolution list. */}
+                    <Form.Select disabled={active} onChange={this.handleVideoDeviceChange} value={this.state.vidDeviceSelected}>
+                      {this.state.videoDevices.map((d, idx) => <option key={idx} value={d.value}>{d.label}</option>)}
+                    </Form.Select>
                   </div>
                 </div>
 
@@ -856,17 +858,11 @@ renderContent() {
                   <div className="form-group row" style={{ marginBottom: '5px' }}>
                     <label className="col-sm-4 col-form-label">Resolution</label>
                     <div className="col-sm-8">
-                      {isVideo ? (
-                        // Video recording mode: use still device caps format
-                        <Form.Select disabled={active} onChange={this.handleVideoRecordingResChange} value={this.state.vidCapSelected}>
-                          {this.state.videoCaps.map((c, idx) => <option key={idx} value={this.getStillCapValue(c)}>{c.width}x{c.height} ({c.format})</option>)}
-                        </Form.Select>
-                      ) : (
-                        // Streaming mode: use video device caps format
-                        <Form.Select disabled={active} onChange={this.handleVideoResChange} value={this.state.vidCapSelected}>
-                          {this.state.videoCaps.map((c, idx) => <option key={idx} value={c.value}>{c.width}x{c.height} ({c.format})</option>)}
-                        </Form.Select>
-                      )}
+                      {/* Video and streaming modes now use the same videoCaps format (handleVideoResChange, c.value),
+                          since videoCaps is sourced from videoDevices in both modes. */}
+                      <Form.Select disabled={active} onChange={this.handleVideoResChange} value={this.state.vidCapSelected}>
+                        {this.state.videoCaps.map((c, idx) => <option key={idx} value={c.value}>{c.width}x{c.height} ({c.format})</option>)}
+                      </Form.Select>
                     </div>
                   </div>
                 )}

--- a/src/video.jsx
+++ b/src/video.jsx
@@ -323,27 +323,6 @@ componentWillUnmount() {
     }
   }
 
-  handleVideoRecordingDeviceChange = (event) => {
-    // Handler for video recording mode using still devices
-    const value = event.target.value;
-    const device = this.state.stillDevices.find(d => d.id === value);
-
-    if (device) {
-      const newCaps = device.caps || [];
-      const defaultCap = newCaps.length > 0 ? newCaps[0] : null;
-
-      this.setState({
-        vidDeviceSelected: value,
-        videoCaps: newCaps,
-        vidCapSelected: defaultCap ? this.getStillCapValue(defaultCap) : '',
-        fpsSelected: 30,
-        // Allow manual FPS inputs:
-        FPSMax: 120,
-        fpsOptions:[]
-      });
-    }
-  }
-
   handleVideoResChange = (event) => {
     const value = event.target.value;
     const cap = this.state.videoCaps.find(c => c.value === value);
@@ -362,18 +341,6 @@ componentWillUnmount() {
     if (cap.format === "video/x-h264") {
         this.setState({ compression: 'H264' });
       }
-    }
-  }
-
-  handleVideoRecordingResChange = (event) => {
-    // Resolution change for video recording mode using still device caps
-    const value = event.target.value;
-    const cap = this.state.videoCaps.find(c => this.getStillCapValue(c) === value);
-
-    if (cap) {
-      this.setState({
-        vidCapSelected: value
-      });
     }
   }
 

--- a/src/video.jsx
+++ b/src/video.jsx
@@ -149,9 +149,10 @@ class VideoPage extends basePage {
                     matchedCap = initialVidCaps[0];
                 }
                 initialVidCapSel = matchedCap ? matchedCap.value : '';
-                initialFpsOpts =[];
-                initialFpsMax = 120; // Allow typing manual FPS up to 120
-                initialFps = selFps || 30;
+                initialFpsOpts = matchedCap ? (matchedCap.fps || []) : [];
+                initialFpsMax = matchedCap ? (matchedCap.fpsmax || 0) : 0;
+                const savedFps = videoData.selectedFps;
+                initialFps = savedFps != null ? savedFps : (initialFpsMax > 0 ? initialFpsMax : (initialFpsOpts.length > 0 ? initialFpsOpts[0].value : 30));
             } else {
                 initialVidDevSel = '';
                 initialVidCaps = [];
@@ -270,9 +271,9 @@ componentWillUnmount() {
       updates.vidDeviceSelected = firstVidDevice ? firstVidDevice.value : '';
       updates.videoCaps = firstVidDevice ? firstVidDevice.caps : [];
       updates.vidCapSelected = firstCap ? firstCap.value : '';
-      updates.FPSMax = 120;
-      updates.fpsOptions =[];
-      updates.fpsSelected = 30;
+      updates.fpsOptions = firstCap ? (firstCap.fps || []) : [];
+      updates.FPSMax = firstCap ? (firstCap.fpsmax || 0) : 0;
+      updates.fpsSelected = updates.FPSMax > 0 ? updates.FPSMax : (updates.fpsOptions.length > 0 ? updates.fpsOptions[0].value : 30);
     } else if (newMode === 'streaming') {
       // Reset back to Streaming capabilities
       const firstVidDevice = this.state.videoDevices.length > 0 ? this.state.videoDevices[0] : null;


### PR DESCRIPTION
This replaces PR https://github.com/stephendade/Rpanion-server/pull/403 but breaks the changes out in many separate commits, one for each low-level change.  This resolves issue https://github.com/stephendade/Rpanion-server/issues/396.

This also includes @stephendade's commit from [the mavcamera branch](https://github.com/stephendade/Rpanion-server/commits/mavcamera/) (but includes a bug fix).  Credit to the original author has been preserved.

This includes several bug fixes Claude found in the original code.  I'm far from an expert on the Rpanion-server code so I was greatly assisted by our new friend Claude.

Enhancements:

- **Faster camera detection**: `get_camera_caps.py` no longer initializes libcamera just to check capabilities, cutting startup detection time from 13-19s to under 1s on a Pi Zero 2W.
- **Video recording now matches Streaming's device list**: previously video recording mode picked its device/resolution list from a different source than streaming mode, so the options didn't match what the video pipeline actually supported. Both modes now share the same list.
- **MAVLink camera protocol is more complete and correct**: proper handling of camera info/settings/storage requests, video start/stop capture commands, and image-capture acknowledgements, matching what a GCS (e.g. QGroundControl, Mission Planner) expects.
- **Geotagging now works when a photo is triggered via MAVLink**, not just from the web UI.
- **New MAVLink messages**: `STORAGE_INFORMATION` (reports available media storage) and `CAMERA_IMAGE_CAPTURED` (reports each captured photo, geotagged).
- Assorted correctness and crash fixes found while reviewing the above (see below).

Bugfixes from the original PR https://github.com/stephendade/Rpanion-server/pull/403 

- A MAVLink message ID lookup used the wrong property name, so messages with an ID over 255 were never actually upgraded to MAVLink v2 as intended.
- A UDP send-error handler referenced `this` incorrectly, which could crash the whole server on a single transient network error.
- Two non-existent method calls (`startVideoCapture`/`stopVideoCapture`) meant a real "start/stop video recording" command from a GCS would crash the server.
- Camera info/settings MAVLink requests were silently unhandled due to a couple of typos and a reference to a non-existent constant - a GCS asking for camera capabilities would get no response.
- Storage status/type were being reported with the wrong values due to incorrect constant names (would always show "empty"/"unknown" regardless of actual state).
- A wrong capability flag value and a kbps/bps unit mismatch in the messages sent to the GCS.
- Command acknowledgements were tagged with the wrong ID, so a GCS matching acks to the commands it sent would never see them as acknowledged.

AI Testing:

- `npm run testback` (existing backend test suite) - passing, aside from two pre-existing tests that assert on behavior we intentionally changed (see PR discussion) and one pre-existing environment-only failure unrelated to this change.
- `npm run lint` - clean.
- Each MAVLink message field/constant referenced in this PR was verified directly against the `node-mavlink`/`mavlink-mappings` library rather than assumed correct.

Human Testing:

I have not tested this on real hardware yet but I will once CI creates the .deb package which will make installation easier
