### PR TITLE
Video: numerous small enhancements and fixes

### DIFF
--- a/python/get_camera_caps.py
+++ b/python/get_camera_caps.py
@@ -167,6 +167,12 @@ for dev_path in get_video_device_paths():
             'caps': caps
         })
 
+# Sort each device's resolutions largest-to-smallest, same as gstcaps.py -
+# the order caps are discovered in has no relation to resolution size, so
+# without this the Resolution dropdown shows options in an arbitrary order.
+for dev in devices:
+    dev['caps'].sort(key=lambda c: (c['width'], c['height']), reverse=True)
+
 output = {
     'devices': devices,
     'capabilities': get_capabilities()

--- a/python/gstcaps.py
+++ b/python/gstcaps.py
@@ -261,4 +261,11 @@ capsTest.append({'value': "640x480xx-raw", 'label': "640x480", 'height': 480, 'w
                  'format': 'video/x-raw', 'fpsmax': '30', 'fps': []})
 retDevices.append({'value': "testsrc", 'label': "Test Source", 'caps': capsTest})
 
+# Sort each device's resolutions largest-to-smallest. The caps lists above are
+# built in whichever order the camera's native sensor modes were enumerated,
+# which has no relation to resolution size - so without this, the Resolution
+# dropdown in the UI shows options in a fairly arbitrary order.
+for dev in retDevices:
+    dev['caps'].sort(key=lambda c: (c['width'], c['height']), reverse=True)
+
 print(json.dumps(retDevices))

--- a/python/photovideo.py
+++ b/python/photovideo.py
@@ -2,6 +2,7 @@
 # -*- coding:utf-8 vi:ts=4:noexpandtab
 
 import argparse
+import inspect
 import time, signal, os, sys, shutil, traceback
 import json
 
@@ -244,16 +245,43 @@ elif captureMode == "video":
             print(f"Mapping format '{args.vidFormat}' to 'YUV420' for Picamera2", flush=True)
             args.vidFormat = "YUV420"
             
+        # FrameRate alone only requests a nominal rate - auto-exposure can still
+        # stretch each frame's actual duration in low light, so the real
+        # capture rate can drift below what was requested. Pinning
+        # FrameDurationLimits to a fixed value prevents that drift.
+        video_controls = {"FrameRate": args.vidFps}
+        if args.vidFps > 0:
+            frame_duration_us = int(1_000_000 / args.vidFps)
+            video_controls["FrameDurationLimits"] = (frame_duration_us, frame_duration_us)
+
         picam2_vid = Picamera2()
         video_config = picam2_vid.create_video_configuration(
             main={
                 "size": (args.vidWidth, args.vidHeight),
                 "format": args.vidFormat},
-                controls={"FrameRate": args.vidFps},
+                controls=video_controls,
                 transform=Transform(rotation=args.imageRotation)
             )
         picam2_vid.configure(video_config)
-        encoder = H264Encoder(bitrate=args.vidBitrate)
+        # The recording is a raw elementary .h264 stream (no container/
+        # timestamps), so a player has no way to know the real playback rate
+        # unless it's embedded in-band. enable_sps_framerate writes the actual
+        # (now-fixed) framerate into the stream's SPS/VUI metadata.
+        #
+        # H264Encoder() picks its actual implementation based on hardware:
+        # boards with a hardware H264 block (e.g. Pi4/CM4) get the hardware
+        # encoder, but boards without one (e.g. Pi5/CM5) transparently get
+        # LibavH264Encoder instead - a different class that doesn't accept
+        # enable_sps_framerate. Only pass it if this build's encoder actually
+        # supports it, rather than assuming a specific backend.
+        encoder_kwargs = {"bitrate": args.vidBitrate, "framerate": args.vidFps}
+        if "enable_sps_framerate" in inspect.signature(H264Encoder.__init__).parameters:
+            encoder_kwargs["enable_sps_framerate"] = True
+        else:
+            print("H264 encoder backend doesn't support enable_sps_framerate - recorded video's "
+                  "framerate won't be embedded in-band (playback speed may still be affected on "
+                  "players that can't infer it from FrameDurationLimits alone).", flush=True)
+        encoder = H264Encoder(**encoder_kwargs)
         picam2_vid.start()
         print(f"Camera is ready in Picamera2 video mode. Capturing {args.vidWidth}x{args.vidHeight} {args.vidFormat} @ {args.vidFps} fps, {args.imageRotation}° rotation")
     else:

--- a/server/index.js
+++ b/server/index.js
@@ -1320,11 +1320,13 @@ app.post('/api/camera/start', authenticateToken, [
       
     }
 
-  // Map incoming request to the internal settings objects used by videostream.js
-  if (mode === 'streaming' || mode === 'video') {
+  // Map incoming request to the internal settings objects used by videostream.js.
+  // Streaming and Video Recording are independent pipelines/settings objects
+  // (video-server.py/GStreamer vs photovideo.py/Picamera2), so a save in one
+  // mode must not overwrite the other's saved device/resolution/fps/etc.
+  if (mode === 'streaming') {
     vManager.videoSettings = {
       device: req.body.videoDevice,
-      isRecording: req.body.isRecording === false || req.body.isRecording === 'false',
       height: parseInt(req.body.height, 10),
       width: parseInt(req.body.width, 10),
       format: req.body.format,
@@ -1337,6 +1339,18 @@ app.post('/api/camera/start', authenticateToken, [
       useTimestamp: req.body.useTimestamp === true || req.body.useTimestamp === 'true',
       mavStreamSelected: req.body.mavStreamSelected,
       compression: req.body.compression,
+      mediaDestination: safeMediaDestination
+    };
+  } else if (mode === 'video') {
+    vManager.videoRecordSettings = {
+      device: req.body.videoDevice,
+      isRecording: req.body.isRecording === false || req.body.isRecording === 'false',
+      height: parseInt(req.body.height, 10),
+      width: parseInt(req.body.width, 10),
+      format: req.body.format,
+      bitrate: parseInt(req.body.bitrate, 10),
+      fps: parseInt(req.body.fps, 10),
+      rotation: parseInt(req.body.rotation, 10),
       mediaDestination: safeMediaDestination
     };
   } else if (mode === 'photo') {

--- a/server/videostream.js
+++ b/server/videostream.js
@@ -296,7 +296,7 @@ class videoStream {
         };
 
         // 3. Map simple values
-        responseData.selectedisRecording = this.videoRecordSettings?.isRecording || false;
+        responseData.selectedIsRecording = this.videoRecordSettings?.isRecording || false;
         responseData.selectedBitrate = activeSettings.bitrate || 1100;
         responseData.selectedFps = activeSettings.fps || 30;
         responseData.selectedUseUDP = this.videoSettings?.useUDP || false;

--- a/server/videostream.js
+++ b/server/videostream.js
@@ -1010,22 +1010,24 @@ class videoStream {
     msg.gimbalDeviceId = 0; // No gimbal
     msg.cameraDeviceId = 0; // 0 = MAVLink Camera with its own component ID
 
+    // Rpanion can auto-switch modes to service any of these requests, so
+    // advertise the full combined capability set regardless of the mode
+    // it currently happens to be in. Autopilots (e.g. ArduPilot's
+    // AP_Camera_MAVLinkCamV2) gate whether they even send commands like
+    // MAV_CMD_IMAGE_START_CAPTURE on these flags, so reporting only the
+    // current mode's capability would prevent them from ever requesting
+    // a mode switch in the first place.
+    msg.flags = common.CameraCapFlags.CAPTURE_IMAGE | common.CameraCapFlags.CAPTURE_VIDEO | common.CameraCapFlags.HAS_VIDEO_STREAM;
+
     // Mode-specific Configuration
     if (this.cameraMode === 'photo') {
       msg.resolutionH = this.stillSettings?.width || 0;
       msg.resolutionV = this.stillSettings?.height || 0;
-      msg.flags = 2; // CAMERA_CAP_FLAGS_CAPTURE_IMAGE
-    }
-    else if (this.cameraMode === 'video') {
-      msg.resolutionH = this.videoSettings?.width || 0;
-      msg.resolutionV = this.videoSettings?.height || 0;
-      msg.flags = 1; // CAMERA_CAP_FLAGS_CAPTURE_VIDEO
     }
     else {
-      // Default: streaming
+      // video or streaming
       msg.resolutionH = this.videoSettings?.width || 0;
       msg.resolutionV = this.videoSettings?.height || 0;
-      msg.flags = 256; // CAMERA_CAP_FLAGS_HAS_VIDEO_STREAM
     }
 
     this.eventEmitter.emit('camerainfo', msg, senderSysId, senderCompId, targetComponent);

--- a/server/videostream.js
+++ b/server/videostream.js
@@ -1000,9 +1000,19 @@ class videoStream {
 
       // Find the address in the list that matches the selected MAVLink interface IP
       // This uses the array populated in populateAddresses() to ensure 1:1 consistency with Web UI
-      const matchedAddress = this.deviceAddresses.find(addr =>
+      let matchedAddress = this.deviceAddresses.find(addr =>
         addr.includes(this.videoSettings.mavStreamSelected)
       );
+
+      // Loopback is never reachable by a remote GCS. If that's what matched
+      // (or nothing matched at all), prefer the first non-loopback address
+      // instead of advertising something guaranteed to be useless.
+      if (!matchedAddress || /:\/\/127\./.test(matchedAddress)) {
+        const nonLoopback = this.deviceAddresses.find(addr => !/:\/\/127\./.test(addr));
+        if (nonLoopback) {
+          matchedAddress = nonLoopback;
+        }
+      }
 
       uriString = matchedAddress || "";
 

--- a/server/videostream.js
+++ b/server/videostream.js
@@ -974,53 +974,9 @@ class videoStream {
     this.eventEmitter.emit('camerasettings', msg, senderSysId, senderCompId, targetComponent)
   }
 
-  sendVideoStreamInformation(senderSysId, senderCompId, targetComponent) {
-    // Log the SysID and CompID of the requester
-    console.log(`Responding to MAVLink request for VideoStreamInformation from SysID: ${senderSysId}, CompID: ${targetComponent}`)
-
-    // build a VIDEO_STREAM_INFORMATION packet
-    const msg = new common.VideoStreamInformation()
-
-    // rpanion only supports a single stream, so streamId and count will always be 1
-    msg.streamId = 1
-    msg.count = 1
-
-    let uriString = "";
-
-    // msg.type and msg.uri need to be different depending on whether RTP or RTSP is selected
-    if (this.videoSettings && this.videoSettings.useUDP) {
-      // msg.type = 0 = VIDEO_STREAM_TYPE_RTSP
-      // msg.type = 1 = VIDEO_STREAM_TYPE_RTPUDP
-      msg.type = 1
-      // For RTP, just send the destination UDP port instead of a full URI
-      uriString = this.videoSettings.useUDPPort.toString();
-    } else {
-      msg.type = 0
-      msg.encoding = this.videoSettings.compression === 'H264' ? 1 : (this.videoSettings.compression === 'H265' ? 2 : 0);
-
-      // Find the address in the list that matches the selected MAVLink interface IP
-      // This uses the array populated in populateAddresses() to ensure 1:1 consistency with Web UI
-      let matchedAddress = this.deviceAddresses.find(addr =>
-        addr.includes(this.videoSettings.mavStreamSelected)
-      );
-
-      // Loopback is never reachable by a remote GCS. If that's what matched
-      // (or nothing matched at all), prefer the first non-loopback address
-      // instead of advertising something guaranteed to be useless.
-      if (!matchedAddress || /:\/\/127\./.test(matchedAddress)) {
-        const nonLoopback = this.deviceAddresses.find(addr => !/:\/\/127\./.test(addr));
-        if (nonLoopback) {
-          matchedAddress = nonLoopback;
-        }
-      }
-
-      uriString = matchedAddress || "";
-
-    }
-
-    // Convert URI string to the field's declared max length (160 bytes)
-    msg.uri = this.toMavString(uriString, 160);
-
+  // Fields shared by every VIDEO_STREAM_INFORMATION message for the current stream,
+  // regardless of which address/stream_id it's advertised under.
+  populateVideoStreamCommonFields(msg) {
     // 1 = VIDEO_STREAM_STATUS_FLAGS_RUNNING
     msg.flags = 1;
     msg.framerate = this.videoSettings.fps;
@@ -1033,8 +989,65 @@ class videoStream {
     msg.hfov = 0;
     // Convert the device name string to the field's declared max length (32 bytes)
     msg.name = this.toMavString(this.videoSettings.device || "", 32);
+  }
 
-    this.eventEmitter.emit('videostreaminfo', msg, senderSysId, senderCompId, targetComponent)
+  sendVideoStreamInformation(senderSysId, senderCompId, targetComponent) {
+    // Log the SysID and CompID of the requester
+    console.log(`Responding to MAVLink request for VideoStreamInformation from SysID: ${senderSysId}, CompID: ${targetComponent}`)
+
+    // RTP push mode has exactly one meaningful destination (useUDPIP), so there's
+    // only ever a single stream to advertise - unlike RTSP, a GCS can't just try
+    // a different address, since Rpanion is the one pushing to a fixed destination.
+    if (this.videoSettings && this.videoSettings.useUDP) {
+      const msg = new common.VideoStreamInformation()
+      msg.streamId = 1
+      msg.count = 1
+      msg.type = 1
+      // For RTP, just send the destination UDP port instead of a full URI
+      msg.uri = this.toMavString(this.videoSettings.useUDPPort.toString(), 160);
+      this.populateVideoStreamCommonFields(msg);
+      this.eventEmitter.emit('videostreaminfo', msg, senderSysId, senderCompId, targetComponent)
+      return
+    }
+
+    // RTSP: the same stream is reachable via every address this device has, so
+    // advertise all of them as separate stream_ids instead of just the one
+    // configured as the "MAVLink video source IP" - a GCS on a different
+    // interface can still find a working URI this way.
+    const isLoopback = (addr) => /:\/\/127\./.test(addr);
+    const matchedAddress = this.deviceAddresses.find(addr =>
+      addr.includes(this.videoSettings.mavStreamSelected)
+    );
+
+    // Order: the explicitly-selected address first (if non-loopback), then any
+    // other non-loopback addresses, then loopback last as a final fallback.
+    const addresses = [];
+    if (matchedAddress && !isLoopback(matchedAddress)) {
+      addresses.push(matchedAddress);
+    }
+    for (const addr of this.deviceAddresses) {
+      if (!isLoopback(addr) && !addresses.includes(addr)) addresses.push(addr);
+    }
+    for (const addr of this.deviceAddresses) {
+      if (!addresses.includes(addr)) addresses.push(addr);
+    }
+    if (addresses.length === 0) {
+      addresses.push(matchedAddress || "");
+    }
+
+    const encoding = this.videoSettings.compression === 'H264' ? 1 : (this.videoSettings.compression === 'H265' ? 2 : 0);
+
+    addresses.forEach((addr, idx) => {
+      const msg = new common.VideoStreamInformation()
+      msg.streamId = idx + 1
+      msg.count = addresses.length
+      msg.type = 0
+      msg.encoding = encoding
+      // Convert URI string to the field's declared max length (160 bytes)
+      msg.uri = this.toMavString(addr, 160);
+      this.populateVideoStreamCommonFields(msg);
+      this.eventEmitter.emit('videostreaminfo', msg, senderSysId, senderCompId, targetComponent)
+    });
   }
 
   // Find how much media space there is in total, and how much is available

--- a/server/videostream.js
+++ b/server/videostream.js
@@ -580,6 +580,12 @@ class videoStream {
       // Send one immediate heartbeat before starting the timer
       this.eventEmitter.emit('cameraheartbeat', minimal.MavType.CAMERA, minimal.MavAutopilot.INVALID, minimal.MavComponent.CAMERA);
       this.startHeartbeatInterval();
+      // Proactively announce capabilities/settings on start, same as Photo and
+      // Video Recording modes - otherwise a GCS/autopilot that doesn't
+      // explicitly re-request CAMERA_INFORMATION never sees it while
+      // Streaming (Rpanion's default mode) is active.
+      this.sendCameraInformation(null, minimal.MavComponent.CAMERA, null);
+      this.sendCameraSettings(null, minimal.MavComponent.CAMERA, null);
       this.sendVideoStreamInformation(null, minimal.MavComponent.CAMERA, null);
     }
   }

--- a/server/videostream.js
+++ b/server/videostream.js
@@ -888,36 +888,36 @@ class videoStream {
     return ((dev & 0xff) << 24) | ((patch & 0xff) << 16) | ((minor & 0xff) << 8) | (major & 0xff);
   }
 
+  // Extract a clean, short model name from a device/still-image ID string, e.g.
+  // /base/soc/i2c0mux/i2c@1/imx415@1a -> imx415, CSI-imx415 -> imx415 (the
+  // latter is a synthetic still-device ID from get_camera_caps.py).
+  extractModelName(devicePath) {
+    if (!devicePath) return "Unknown";
+    if (devicePath.includes('rtspsource')) {
+      return "RTSP Source";
+    } else if (devicePath.includes('/')) {
+      const parts = devicePath.split('/');
+      const leaf = parts[parts.length - 1];
+      return leaf.split('@')[0];
+    } else if (devicePath.startsWith('CSI-')) {
+      return devicePath.slice('CSI-'.length);
+    }
+    return devicePath;
+  }
+
   sendCameraInformation(senderSysId, senderCompId, targetComponent) {
     console.log('Sending MAVLink CameraInformation packet')
 
     const msg = new common.CameraInformation();
 
     // Get the camera model name, and handle cases where settings might be null
-    let devicePath = "Unknown";
+    let devicePath = null;
     if (this.cameraMode === 'photo' && this.stillSettings && this.stillSettings.device) {
       devicePath = this.stillSettings.device;
     } else if (this.videoSettings && this.videoSettings.device) {
       devicePath = this.videoSettings.device;
     }
-
-    let extractedModel = "Unknown";
-    if (devicePath !== "Unknown") {
-      if (devicePath.includes('rtspsource')) {
-        extractedModel = "RTSP Source";
-      } else if (devicePath.includes('/')) {
-        // e.g. /base/soc/i2c0mux/i2c@1/imx219@10 -> imx219
-        const parts = devicePath.split('/');
-        const leaf = parts[parts.length - 1];
-        extractedModel = leaf.split('@')[0];
-      } else if (devicePath.startsWith('CSI-')) {
-        // Still-photo device IDs are synthetic, from get_camera_caps.py:
-        // e.g. CSI-imx415 -> imx415
-        extractedModel = devicePath.slice('CSI-'.length);
-      } else {
-        extractedModel = devicePath;
-      }
-    }
+    const extractedModel = this.extractModelName(devicePath);
 
     msg.timeBootMs = process.uptime()*1000;
     msg.vendorName = this.toMavUint8Array("Rpanion", 32);
@@ -975,7 +975,9 @@ class videoStream {
   }
 
   // Fields shared by every VIDEO_STREAM_INFORMATION message for the current stream,
-  // regardless of which address/stream_id it's advertised under.
+  // regardless of which address/stream_id it's advertised under. Does NOT include
+  // `name` - when advertising multiple addresses, each needs its own distinguishing
+  // name so a GCS's stream picker doesn't show several identical-looking entries.
   populateVideoStreamCommonFields(msg) {
     // 1 = VIDEO_STREAM_STATUS_FLAGS_RUNNING
     msg.flags = 1;
@@ -987,13 +989,13 @@ class videoStream {
     msg.rotation = this.videoSettings.rotation;
     // Rpanion doesn't collect field of view values, so set to zero
     msg.hfov = 0;
-    // Convert the device name string to the field's declared max length (32 bytes)
-    msg.name = this.toMavString(this.videoSettings.device || "", 32);
   }
 
   sendVideoStreamInformation(senderSysId, senderCompId, targetComponent) {
     // Log the SysID and CompID of the requester
     console.log(`Responding to MAVLink request for VideoStreamInformation from SysID: ${senderSysId}, CompID: ${targetComponent}`)
+
+    const modelName = this.extractModelName(this.videoSettings && this.videoSettings.device);
 
     // RTP push mode has exactly one meaningful destination (useUDPIP), so there's
     // only ever a single stream to advertise - unlike RTSP, a GCS can't just try
@@ -1006,6 +1008,7 @@ class videoStream {
       // For RTP, just send the destination UDP port instead of a full URI
       msg.uri = this.toMavString(this.videoSettings.useUDPPort.toString(), 160);
       this.populateVideoStreamCommonFields(msg);
+      msg.name = this.toMavString(modelName, 32);
       this.eventEmitter.emit('videostreaminfo', msg, senderSysId, senderCompId, targetComponent)
       return
     }
@@ -1046,6 +1049,10 @@ class videoStream {
       // Convert URI string to the field's declared max length (160 bytes)
       msg.uri = this.toMavString(addr, 160);
       this.populateVideoStreamCommonFields(msg);
+      // Distinguish each stream by its address, e.g. "imx415 (10.0.2.100)" -
+      // otherwise every entry would show the same name in a GCS's stream picker.
+      const ip = (addr.match(/^rtsp:\/\/([^:]+):/) || [])[1];
+      msg.name = this.toMavString(ip ? `${modelName} (${ip})` : modelName, 32);
       this.eventEmitter.emit('videostreaminfo', msg, senderSysId, senderCompId, targetComponent)
     });
   }

--- a/server/videostream.js
+++ b/server/videostream.js
@@ -18,6 +18,7 @@ class videoStream {
     this.deviceAddresses = []
     this.cameraMode = null; // 'streaming', 'photo', or 'video'
     this.photoSeq = 0;
+    this.modeSwitchInProgress = false; // true while switchCameraModeAndTakeAction() is mid-switch
 
     // Interval to send camera heartbeat events
     this.intervalObj = null;
@@ -437,6 +438,50 @@ class videoStream {
     }
   }
 
+  // Switch to targetMode (stopping whatever's currently running and starting
+  // targetMode's process) if not already there, then call action(). Used so a
+  // MAVLink command (e.g. take a photo) can be serviced regardless of which
+  // mode the camera happens to be in when it arrives, rather than rejecting it.
+  //
+  // Starting a new mode's process can take a while (spawning
+  // photovideo.py/video-server.py, camera library init, etc.), so a
+  // MAV_RESULT_IN_PROGRESS ack is sent immediately if a switch is actually
+  // needed, to avoid the GCS timing out while it waits - followed by a final
+  // MAV_RESULT_FAILED ack if the switch itself fails. On success, action() is
+  // called and is responsible for its own ack.
+  switchCameraModeAndTakeAction(targetMode, commandId, senderSysId, senderCompId, targetComponent, action) {
+    if (this.active && this.cameraMode === targetMode) {
+      action();
+      return;
+    }
+
+    if (this.modeSwitchInProgress) {
+      console.log(`Cannot switch to '${targetMode}' mode - another mode switch is already in progress`)
+      // 1 = MAV_RESULT_TEMPORARILY_REJECTED
+      this.eventEmitter.emit('camera_command_ack', commandId, senderSysId, senderCompId, targetComponent, 1)
+      return
+    }
+
+    console.log(`Switching camera mode from '${this.cameraMode}' to '${targetMode}' to service command ${commandId}`)
+    this.modeSwitchInProgress = true
+    // 5 = MAV_RESULT_IN_PROGRESS
+    this.eventEmitter.emit('camera_command_ack', commandId, senderSysId, senderCompId, targetComponent, 5)
+
+    this.stopCamera(() => {
+      this.cameraMode = targetMode
+      this.startCamera((err) => {
+        this.modeSwitchInProgress = false
+        if (err) {
+          console.log(`Failed to switch to '${targetMode}' mode:`, err)
+          // 4 = MAV_RESULT_FAILED
+          this.eventEmitter.emit('camera_command_ack', commandId, senderSysId, senderCompId, targetComponent, 4)
+          return
+        }
+        action()
+      })
+    })
+  }
+
   async startVideoStreaming(callback) {
     if (!this.videoSettings) return callback(new Error('No video settings provided'));
 
@@ -563,6 +608,13 @@ class videoStream {
   }
 
   setupStreamEvents(modeName, callback) {
+    // Capture the specific process this setup call is for. A process killed
+    // during a mode switch (stopCamera() followed immediately by
+    // startCamera()) doesn't exit instantly - its listeners can still fire
+    // well after a newer process has already started and been marked active.
+    // Guard every shared-state mutation below with `this.deviceStream === proc`
+    // so a stale, superseded process can't clobber the current mode's state.
+    const proc = this.deviceStream;
     let callbackCalled = false;
     let stdoutBuffer = ''; // Buffer for accumulating data chunks
 
@@ -573,13 +625,15 @@ class videoStream {
       if (!callbackCalled) {
         callbackCalled = true;
         console.log(`${modeName}: No response from script after 90s, assuming start.`);
-        this.active = true;
-        this.saveSettings();
+        if (this.deviceStream === proc) {
+          this.active = true;
+          this.saveSettings();
+        }
         callback(null, { active: true, addresses: this.deviceAddresses });
       }
     }, 90000);
 
-    this.deviceStream.on('error', (err) => {
+    proc.on('error', (err) => {
       clearTimeout(timeout);
       console.error(`Failed to spawn ${modeName}:`, err);
       if (!callbackCalled) {
@@ -590,30 +644,33 @@ class videoStream {
 
     // Listen continuously until we hear "Camera is ready"
     // or in streaming mode
-    this.deviceStream.stdout.on('data', (data) => {
+    proc.stdout.on('data', (data) => {
 
       const chunk = data.toString();
       stdoutBuffer += chunk;
 
-      // Detect the video recording start/stop messages from photovideo.py and update the recording flag
-      const lower = chunk.toLowerCase();
-      // start patterns printed by photovideo.py:
-      // "Picamera2 recording started to <path>"
-      // "V4L2 recording started to <path>"
-      // also generic "recording started"
-      if (lower.includes('recording started') || lower.includes('recording started to')) {
-        this.setRecordingFlag(true);
-        this.saveSettings();
-        console.log('Detected recorder START; isRecording=true');
-      }
-      // stop patterns printed by photovideo.py:
-      // "Picamera2 recording stopped."
-      // "V4L2 recording stopped."
-      // also generic "recording stopped"
-      if (lower.includes('recording stopped')) {
-        this.setRecordingFlag(false);
-        this.saveSettings();
-        console.log('Detected recorder STOP; isRecording=false');
+      // Detect the video recording start/stop messages from photovideo.py and
+      // update the recording flag - only if this is still the current process.
+      if (this.deviceStream === proc) {
+        const lower = chunk.toLowerCase();
+        // start patterns printed by photovideo.py:
+        // "Picamera2 recording started to <path>"
+        // "V4L2 recording started to <path>"
+        // also generic "recording started"
+        if (lower.includes('recording started') || lower.includes('recording started to')) {
+          this.setRecordingFlag(true);
+          this.saveSettings();
+          console.log('Detected recorder START; isRecording=true');
+        }
+        // stop patterns printed by photovideo.py:
+        // "Picamera2 recording stopped."
+        // "V4L2 recording stopped."
+        // also generic "recording stopped"
+        if (lower.includes('recording stopped')) {
+          this.setRecordingFlag(false);
+          this.saveSettings();
+          console.log('Detected recorder STOP; isRecording=false');
+        }
       }
 
       // find file paths printed by photovideo.py
@@ -648,27 +705,34 @@ class videoStream {
         if (isReady) {
           clearTimeout(timeout);
           console.log(`${modeName} process is fully initialized.`);
-          this.active = true;
-          this.saveSettings();
+          if (this.deviceStream === proc) {
+            this.active = true;
+            this.saveSettings();
+          }
           callbackCalled = true;
           callback(null, { active: true, addresses: this.deviceAddresses });
         }
       }
     });
 
-    this.deviceStream.stderr.on('data', (data) => {
+    proc.stderr.on('data', (data) => {
       const msg = data.toString().trim();
       if (msg) console.error(`${modeName} error: ${msg}`);
     });
 
-    this.deviceStream.on('close', (code) => {
+    proc.on('close', (code) => {
       clearTimeout(timeout);
       console.log(`${modeName} exited with code ${code}`);
-      this.active = false;
-      // Clear the video recording flag
-      if (this.videoSettings) {
-        this.setRecordingFlag(false);
-        this.saveSettings();
+      // Only update shared state if this is still the current process - a
+      // stale, already-superseded process exiting late must not clobber the
+      // new mode's state (see comment at the top of this method).
+      if (this.deviceStream === proc) {
+        this.active = false;
+        // Clear the video recording flag
+        if (this.videoSettings) {
+          this.setRecordingFlag(false);
+          this.saveSettings();
+        }
       }
       if (!callbackCalled) {
         callbackCalled = true;
@@ -1159,7 +1223,9 @@ class videoStream {
       }
       else if (data.command === common.MavCmd['IMAGE_START_CAPTURE']) {
         console.log('Received MAVLink command to start image capture')
-        this.captureStillPhoto(packet.header.sysid, minimal.MavComponent.CAMERA, packet.header.compid, currentPosition, common.MavCmd['IMAGE_START_CAPTURE'])
+        this.switchCameraModeAndTakeAction('photo', common.MavCmd['IMAGE_START_CAPTURE'], packet.header.sysid, minimal.MavComponent.CAMERA, packet.header.compid, () => {
+          this.captureStillPhoto(packet.header.sysid, minimal.MavComponent.CAMERA, packet.header.compid, currentPosition, common.MavCmd['IMAGE_START_CAPTURE'])
+        })
       }
       else if (data.command === common.MavCmd['IMAGE_STOP_CAPTURE']) {
         console.log('Received IMAGE_STOP_CAPTURE command')
@@ -1167,30 +1233,58 @@ class videoStream {
       }
       else if (data.command === common.MavCmd['VIDEO_START_CAPTURE']) {
         console.log('Received MAVLink command to start video capture')
-        if (this.cameraMode !== 'video') {
-          console.log(`Cannot start video capture - camera is in '${this.cameraMode}' mode, not 'video'`)
-          // 1 = MAV_RESULT_TEMPORARILY_REJECTED
-          this.eventEmitter.emit('camera_command_ack', common.MavCmd['VIDEO_START_CAPTURE'], packet.header.sysid, minimal.MavComponent.CAMERA, packet.header.compid, 1)
-        } else {
+        this.switchCameraModeAndTakeAction('video', common.MavCmd['VIDEO_START_CAPTURE'], packet.header.sysid, minimal.MavComponent.CAMERA, packet.header.compid, () => {
           if (!this.videoSettings.isRecording) {
             this.toggleVideoRecording()
           }
           // Already recording, or just started - either way the requested state now holds
           this.eventEmitter.emit('camera_command_ack', common.MavCmd['VIDEO_START_CAPTURE'], packet.header.sysid, minimal.MavComponent.CAMERA, packet.header.compid)
-        }
+        })
       }
       else if (data.command === common.MavCmd['VIDEO_STOP_CAPTURE']) {
         console.log('Received MAVLink command to stop video capture')
-        if (this.cameraMode !== 'video') {
-          console.log(`Cannot stop video capture - camera is in '${this.cameraMode}' mode, not 'video'`)
-          // 1 = MAV_RESULT_TEMPORARILY_REJECTED
-          this.eventEmitter.emit('camera_command_ack', common.MavCmd['VIDEO_STOP_CAPTURE'], packet.header.sysid, minimal.MavComponent.CAMERA, packet.header.compid, 1)
+        if (this.cameraMode === 'video' && this.videoSettings.isRecording) {
+          this.toggleVideoRecording()
+        }
+        // Not recording (whether because we were never in video mode, or
+        // already stopped) - the requested state already holds either way.
+        // Unlike START, there's nothing sensible to auto-switch mode for here.
+        this.eventEmitter.emit('camera_command_ack', common.MavCmd['VIDEO_STOP_CAPTURE'], packet.header.sysid, minimal.MavComponent.CAMERA, packet.header.compid)
+      }
+      else if (data.command === common.MavCmd['VIDEO_START_STREAMING']) {
+        console.log('Received MAVLink command to start video streaming')
+        this.switchCameraModeAndTakeAction('streaming', common.MavCmd['VIDEO_START_STREAMING'], packet.header.sysid, minimal.MavComponent.CAMERA, packet.header.compid, () => {
+          this.eventEmitter.emit('camera_command_ack', common.MavCmd['VIDEO_START_STREAMING'], packet.header.sysid, minimal.MavComponent.CAMERA, packet.header.compid)
+        })
+      }
+      else if (data.command === common.MavCmd['VIDEO_STOP_STREAMING']) {
+        console.log('Received MAVLink command to stop video streaming')
+        if (this.cameraMode === 'streaming' && this.active) {
+          this.stopCamera(() => {
+            this.eventEmitter.emit('camera_command_ack', common.MavCmd['VIDEO_STOP_STREAMING'], packet.header.sysid, minimal.MavComponent.CAMERA, packet.header.compid)
+          })
         } else {
-          if (this.videoSettings.isRecording) {
-            this.toggleVideoRecording()
-          }
-          // Already stopped, or just stopped - either way the requested state now holds
-          this.eventEmitter.emit('camera_command_ack', common.MavCmd['VIDEO_STOP_CAPTURE'], packet.header.sysid, minimal.MavComponent.CAMERA, packet.header.compid)
+          // Not streaming - the requested state already holds
+          this.eventEmitter.emit('camera_command_ack', common.MavCmd['VIDEO_STOP_STREAMING'], packet.header.sysid, minimal.MavComponent.CAMERA, packet.header.compid)
+        }
+      }
+      else if (data.command === common.MavCmd['SET_CAMERA_MODE']) {
+        console.log('Received MAVLink command to set camera mode')
+        const requestedMode = data._param2;
+        let targetMode = null;
+        if (requestedMode === common.CameraMode.IMAGE) {
+          targetMode = 'photo';
+        } else if (requestedMode === common.CameraMode.VIDEO) {
+          targetMode = 'video';
+        }
+        // No Rpanion equivalent for IMAGE_SURVEY. Streaming isn't reachable
+        // via this command - see VIDEO_START_STREAMING/VIDEO_STOP_STREAMING.
+        if (targetMode === null) {
+          this.sendUnsupportedAck(common.MavCmd['SET_CAMERA_MODE'], packet.header.sysid, packet.header.compid)
+        } else {
+          this.switchCameraModeAndTakeAction(targetMode, common.MavCmd['SET_CAMERA_MODE'], packet.header.sysid, minimal.MavComponent.CAMERA, packet.header.compid, () => {
+            this.eventEmitter.emit('camera_command_ack', common.MavCmd['SET_CAMERA_MODE'], packet.header.sysid, minimal.MavComponent.CAMERA, packet.header.compid)
+          })
         }
       }
       // MAVProxy: responds to DO_DIGICAM_CONFIGURE by requesting our capabilities
@@ -1200,7 +1294,9 @@ class videoStream {
       }
       else if (data.command === common.MavCmd['DO_DIGICAM_CONTROL']) {
         console.log('Received MAV_CMD_DO_DIGICAM_CONTROL command')
-        this.captureStillPhoto(packet.header.sysid, minimal.MavComponent.CAMERA, packet.header.compid, currentPosition, common.MavCmd['DO_DIGICAM_CONTROL'])
+        this.switchCameraModeAndTakeAction('photo', common.MavCmd['DO_DIGICAM_CONTROL'], packet.header.sysid, minimal.MavComponent.CAMERA, packet.header.compid, () => {
+          this.captureStillPhoto(packet.header.sysid, minimal.MavComponent.CAMERA, packet.header.compid, currentPosition, common.MavCmd['DO_DIGICAM_CONTROL'])
+        })
       }
       else {
         this.sendUnsupportedAck(data.command, packet.header.sysid, packet.header.compid)

--- a/server/videostream.js
+++ b/server/videostream.js
@@ -528,6 +528,7 @@ class videoStream {
 
     this.stopCamera(() => {
       this.cameraMode = targetMode
+      this.ensureDefaultSettingsForMode(targetMode)
       this.startCamera((err) => {
         this.modeSwitchInProgress = false
         if (err) {
@@ -539,6 +540,78 @@ class videoStream {
         action()
       })
     })
+  }
+
+  // gstcaps.py's fallback resolution tables inconsistently emit fpsmax as
+  // either a number or a numeric string, unlike the normal UI-driven save
+  // path (index.js's /api/camera/start), which always parseInt()s fps before
+  // it reaches here - so explicitly coerce to a real number.
+  defaultFpsFor(cap) {
+    return Number(cap.fpsmax) > 0 ? Number(cap.fpsmax) : Number(cap.fps?.[0]?.value || 30);
+  }
+
+  // If targetMode has never been configured via the web UI, populate it with
+  // reasonable defaults (first available device/capability) so an
+  // autopilot-triggered auto-switch can still start it, rather than failing
+  // just because nobody has visited that mode's tab yet. Persists the result
+  // so it behaves like a normal saved configuration from here on.
+  ensureDefaultSettingsForMode(targetMode) {
+    if (targetMode === 'photo' && !this.stillSettings) {
+      const device = (this.stillDevices || []).find(d => d.caps && d.caps.length > 0);
+      if (!device) return;
+      const cap = device.caps[0];
+      this.stillSettings = {
+        device: device.id,
+        width: cap.width,
+        height: cap.height,
+        format: cap.format,
+        mediaDestination: ''
+      };
+      console.log('No saved Photo settings found - using defaults:', this.stillSettings);
+      this.saveSettings();
+    } else if (targetMode === 'video' && !this.videoRecordSettings) {
+      const device = (this.devices || []).find(d => d.caps && d.caps.length > 0);
+      if (!device) return;
+      const cap = device.caps[0];
+      this.videoRecordSettings = {
+        device: device.value,
+        isRecording: false,
+        width: cap.width,
+        height: cap.height,
+        format: cap.format,
+        bitrate: 1100,
+        fps: this.defaultFpsFor(cap),
+        rotation: 0,
+        mediaDestination: ''
+      };
+      console.log('No saved Video Recording settings found - using defaults:', this.videoRecordSettings);
+      this.saveSettings();
+    } else if (targetMode === 'streaming' && !this.videoSettings) {
+      const device = (this.devices || []).find(d => d.caps && d.caps.length > 0);
+      if (!device) return;
+      const cap = device.caps[0];
+      // Use a fresh scan rather than this.ifaces, which is only populated once
+      // Streaming has actually started (too late to help here, the first time).
+      const nonLoopbackIface = this.scanInterfaces().find(ip => ip !== '127.0.0.1') || '127.0.0.1';
+      this.videoSettings = {
+        device: device.value,
+        width: cap.width,
+        height: cap.height,
+        format: cap.format,
+        bitrate: 1100,
+        fps: this.defaultFpsFor(cap),
+        rotation: 0,
+        useUDP: false,
+        useUDPIP: '127.0.0.1',
+        useUDPPort: 5600,
+        useTimestamp: false,
+        mavStreamSelected: nonLoopbackIface,
+        compression: 'H264',
+        mediaDestination: null
+      };
+      console.log('No saved Streaming settings found - using defaults:', this.videoSettings);
+      this.saveSettings();
+    }
   }
 
   async startVideoStreaming(callback) {

--- a/server/videostream.js
+++ b/server/videostream.js
@@ -746,6 +746,20 @@ class videoStream {
     // Capture a single still photo
     console.log('Capturing still photo')
 
+    // deviceStream is whichever process is currently running for the active
+    // cameraMode - if that's not 'photo', sending SIGUSR1 to it either does
+    // nothing (streaming) or does something else entirely (SIGUSR1 toggles
+    // video recording when deviceStream is running photovideo.py --mode=video).
+    if (this.cameraMode !== 'photo') {
+      console.log(`Cannot capture photo - camera is in '${this.cameraMode}' mode, not 'photo'`)
+      if (commandId && senderSysId !== null) {
+        // 1 = MAV_RESULT_TEMPORARILY_REJECTED: valid command, but not right now -
+        // switch to photo mode (or retry once auto-switching exists) and it'll work.
+        this.eventEmitter.emit('camera_command_ack', commandId, senderSysId, senderCompId, targetComponent, 1)
+      }
+      return
+    }
+
     if (!this.active || !this.deviceStream) {
       console.log('Cannot capture photo - camera not active')
       console.log('Internal check failed: Cannot capture photo - camera not active or no deviceStream.');
@@ -1153,17 +1167,31 @@ class videoStream {
       }
       else if (data.command === common.MavCmd['VIDEO_START_CAPTURE']) {
         console.log('Received MAVLink command to start video capture')
-        if (this.cameraMode === 'video' && !this.videoSettings.isRecording) {
-          this.toggleVideoRecording()
+        if (this.cameraMode !== 'video') {
+          console.log(`Cannot start video capture - camera is in '${this.cameraMode}' mode, not 'video'`)
+          // 1 = MAV_RESULT_TEMPORARILY_REJECTED
+          this.eventEmitter.emit('camera_command_ack', common.MavCmd['VIDEO_START_CAPTURE'], packet.header.sysid, minimal.MavComponent.CAMERA, packet.header.compid, 1)
+        } else {
+          if (!this.videoSettings.isRecording) {
+            this.toggleVideoRecording()
+          }
+          // Already recording, or just started - either way the requested state now holds
+          this.eventEmitter.emit('camera_command_ack', common.MavCmd['VIDEO_START_CAPTURE'], packet.header.sysid, minimal.MavComponent.CAMERA, packet.header.compid)
         }
-        this.eventEmitter.emit('camera_command_ack', common.MavCmd['VIDEO_START_CAPTURE'], packet.header.sysid, minimal.MavComponent.CAMERA, packet.header.compid)
       }
       else if (data.command === common.MavCmd['VIDEO_STOP_CAPTURE']) {
         console.log('Received MAVLink command to stop video capture')
-        if (this.cameraMode === 'video' && this.videoSettings.isRecording) {
-          this.toggleVideoRecording()
+        if (this.cameraMode !== 'video') {
+          console.log(`Cannot stop video capture - camera is in '${this.cameraMode}' mode, not 'video'`)
+          // 1 = MAV_RESULT_TEMPORARILY_REJECTED
+          this.eventEmitter.emit('camera_command_ack', common.MavCmd['VIDEO_STOP_CAPTURE'], packet.header.sysid, minimal.MavComponent.CAMERA, packet.header.compid, 1)
+        } else {
+          if (this.videoSettings.isRecording) {
+            this.toggleVideoRecording()
+          }
+          // Already stopped, or just stopped - either way the requested state now holds
+          this.eventEmitter.emit('camera_command_ack', common.MavCmd['VIDEO_STOP_CAPTURE'], packet.header.sysid, minimal.MavComponent.CAMERA, packet.header.compid)
         }
-        this.eventEmitter.emit('camera_command_ack', common.MavCmd['VIDEO_STOP_CAPTURE'], packet.header.sysid, minimal.MavComponent.CAMERA, packet.header.compid)
       }
       // MAVProxy: responds to DO_DIGICAM_CONFIGURE by requesting our capabilities
       else if (data.command === common.MavCmd['DO_DIGICAM_CONFIGURE']) {

--- a/server/videostream.js
+++ b/server/videostream.js
@@ -6,6 +6,7 @@ const events = require('events')
 const { minimal, common } = require('node-mavlink')
 const logpaths = require('./paths.js')
 const fs = require('fs')
+const rpanionVersion = require('../package.json').version
 
 class videoStream {
   constructor (settings) {
@@ -872,6 +873,21 @@ class videoStream {
     return str.toString().slice(0, length - 1);
   }
 
+  // Encode Rpanion's own package.json version (e.g. "0.12.0") for
+  // CAMERA_INFORMATION.firmware_version, which per the MAVLink spec is packed
+  // as (Dev << 24) | (Patch << 16) | (Minor << 8) | Major - i.e. Major is the
+  // *least* significant byte. This is the opposite byte order to
+  // AUTOPILOT_VERSION.flight_sw_version (major is the most significant byte
+  // there), so don't reuse decodeFlightSwVersion()'s logic for this field.
+  encodeFirmwareVersion(versionStr) {
+    const parts = (versionStr || "").split('.').map(n => parseInt(n, 10) || 0);
+    const major = parts[0] || 0;
+    const minor = parts[1] || 0;
+    const patch = parts[2] || 0;
+    const dev = 0; // Not used/unspecified
+    return ((dev & 0xff) << 24) | ((patch & 0xff) << 16) | ((minor & 0xff) << 8) | (major & 0xff);
+  }
+
   sendCameraInformation(senderSysId, senderCompId, targetComponent) {
     console.log('Sending MAVLink CameraInformation packet')
 
@@ -906,7 +922,7 @@ class videoStream {
     msg.timeBootMs = process.uptime()*1000;
     msg.vendorName = this.toMavUint8Array("Rpanion", 32);
     msg.modelName = this.toMavUint8Array(extractedModel, 32);
-    msg.firmwareVersion = 0;
+    msg.firmwareVersion = this.encodeFirmwareVersion(rpanionVersion);
     msg.focalLength = 0;
     msg.sensorSizeH = 0;
     msg.sensorSizeV = 0;

--- a/server/videostream.js
+++ b/server/videostream.js
@@ -894,6 +894,10 @@ class videoStream {
         const parts = devicePath.split('/');
         const leaf = parts[parts.length - 1];
         extractedModel = leaf.split('@')[0];
+      } else if (devicePath.startsWith('CSI-')) {
+        // Still-photo device IDs are synthetic, from get_camera_caps.py:
+        // e.g. CSI-imx415 -> imx415
+        extractedModel = devicePath.slice('CSI-'.length);
       } else {
         extractedModel = devicePath;
       }

--- a/server/videostream.js
+++ b/server/videostream.js
@@ -27,7 +27,8 @@ class videoStream {
     // Mode-specific hardware lists/settings
     this.devices = null;      // Video devices
     this.stillDevices = null; // Still devices
-    this.videoSettings = null;
+    this.videoSettings = null;       // Streaming mode settings
+    this.videoRecordSettings = null; // Video Recording mode settings (independent of Streaming's)
     this.stillSettings = null;
     this.fcManager = null;    // Flight controller manager reference, set externally if available
 
@@ -36,8 +37,12 @@ class videoStream {
     this.cameraMode = this.settings.value('camera.mode', 'streaming');
     this.useCameraHeartbeat = this.settings.value('camera.useHeartbeat', false);
 
-    // Load specific settings based on mode
+    // Load specific settings based on mode. Streaming and Video Recording are
+    // separate pipelines (video-server.py/GStreamer vs photovideo.py/Picamera2)
+    // and are kept as independent settings objects so configuring one (e.g.
+    // resolution/fps) doesn't overwrite the other's saved values.
     this.videoSettings = this.settings.value('camera.videoSettings', null);
+    this.videoRecordSettings = this.settings.value('camera.videoRecordSettings', null);
     this.stillSettings = this.settings.value('camera.stillSettings', null);
 
     // if it's an active device, stop then start it up
@@ -203,6 +208,38 @@ class videoStream {
     ];
   }
 
+  // Build the {selectedDevice, selectedCap, selectedFps, selectedBitrate,
+  // selectedRotation, mediaDestination} shape describing a saved settings
+  // object (this.videoSettings for Streaming, this.videoRecordSettings for
+  // Video Recording) against a device list. Used so the frontend can
+  // pre-populate each mode's Resolution/FPS dropdowns independently, since
+  // the two modes no longer share a single settings object.
+  buildModeSelection(settingsObj, devices) {
+    const result = {
+      selectedDevice: null,
+      selectedCap: null,
+      selectedFps: null,
+      selectedBitrate: 1100,
+      selectedRotation: { label: '0°', value: 0 },
+      mediaDestination: ''
+    };
+    if (!settingsObj || !devices) return result;
+
+    result.selectedDevice = devices.find(d => d.value === settingsObj.device) || null;
+    if (result.selectedDevice) {
+      // Safeguard the format string against missing slashes for V4L2 raw modes
+      const formatStr = settingsObj.format || "";
+      const formatShort = formatStr.includes('/') ? formatStr.split('/')[1] : formatStr;
+      const capVal = `${settingsObj.width}x${settingsObj.height}x${formatShort}`;
+      result.selectedCap = result.selectedDevice.caps.find(cap => cap.value === capVal) || null;
+    }
+    result.selectedFps = settingsObj.fps ?? null;
+    result.selectedBitrate = settingsObj.bitrate || 1100;
+    result.selectedRotation = { label: (settingsObj.rotation || 0) + '°', value: (settingsObj.rotation || 0) };
+    result.mediaDestination = this.toRelativePath(settingsObj.mediaDestination || '');
+    return result;
+  }
+
   // video streaming
   getVideoDevices (callback) {
     // get all video device details
@@ -212,6 +249,10 @@ class videoStream {
     // Don't re-scan hardware if a stream is already running
     if (this.deviceStream !== null) {
       console.log("Camera active; returning cached hardware details.");
+
+      // Streaming and Video Recording have independent settings; use whichever
+      // one matches the mode that's actually running.
+      const activeSettings = this.cameraMode === 'video' ? this.videoRecordSettings : this.videoSettings;
 
       const responseData = {
         devices: this.devices || [],
@@ -227,13 +268,13 @@ class videoStream {
       };
 
       // 1. Find the device and capability currently being used
-      if (this.videoSettings && this.devices) {
-        responseData.selectedDevice = this.devices.find(d => d.value === this.videoSettings.device);
+      if (activeSettings && this.devices) {
+        responseData.selectedDevice = this.devices.find(d => d.value === activeSettings.device);
         if (responseData.selectedDevice) {
           // Safeguard the format string against missing slashes for V4L2 raw modes
-          const formatStr = this.videoSettings.format || "";
+          const formatStr = activeSettings.format || "";
           const formatShort = formatStr.includes('/') ? formatStr.split('/')[1] : formatStr;
-          const capVal = `${this.videoSettings.width}x${this.videoSettings.height}x${formatShort}`;
+          const capVal = `${activeSettings.width}x${activeSettings.height}x${formatShort}`;
 
           responseData.selectedCap = responseData.selectedDevice.caps.find(cap => cap.value === capVal);
           responseData.resolutionCaps = responseData.selectedDevice.caps;
@@ -243,27 +284,36 @@ class videoStream {
 
         // 2. Map raw numbers back to the UI's Object format
         responseData.selectedRotation = {
-          label: (this.videoSettings.rotation || 0) + '°',
-          value: (this.videoSettings.rotation || 0)
+          label: (activeSettings.rotation || 0) + '°',
+          value: (activeSettings.rotation || 0)
         };
+        // Transport (RTSP/RTP) fields only exist on Streaming's settings object -
+        // Video Recording has no analogous concept, so always read these from
+        // this.videoSettings regardless of which mode is currently active.
         responseData.selectedMavStreamURI = {
-          label: this.videoSettings.mavStreamSelected?.toString() || '127.0.0.1',
-          value: this.videoSettings.mavStreamSelected || '127.0.0.1'
+          label: this.videoSettings?.mavStreamSelected?.toString() || '127.0.0.1',
+          value: this.videoSettings?.mavStreamSelected || '127.0.0.1'
         };
 
         // 3. Map simple values
-        responseData.selectedisRecording = this.videoSettings.isRecording || false;
-        responseData.selectedBitrate = this.videoSettings.bitrate || 1100;
-        responseData.selectedFps = this.videoSettings.fps || 30;
-        responseData.selectedUseUDP = this.videoSettings.useUDP || false;
-        responseData.selectedUseUDPIP = this.videoSettings.useUDPIP || '127.0.0.1';
-        responseData.selectedUseUDPPort = this.videoSettings.useUDPPort || 5600;
-        responseData.selectedUseTimestamp = this.videoSettings.useTimestamp || false;
+        responseData.selectedisRecording = this.videoRecordSettings?.isRecording || false;
+        responseData.selectedBitrate = activeSettings.bitrate || 1100;
+        responseData.selectedFps = activeSettings.fps || 30;
+        responseData.selectedUseUDP = this.videoSettings?.useUDP || false;
+        responseData.selectedUseUDPIP = this.videoSettings?.useUDPIP || '127.0.0.1';
+        responseData.selectedUseUDPPort = this.videoSettings?.useUDPPort || 5600;
+        responseData.selectedUseTimestamp = this.videoSettings?.useTimestamp || false;
         responseData.selectedUseCameraHeartbeat = this.useCameraHeartbeat || false;
 
         // Return an empty string if no media destination is given.
-        responseData.videoMediaDestination = this.toRelativePath(this.videoSettings?.mediaDestination || '');
+        responseData.videoMediaDestination = this.toRelativePath(activeSettings?.mediaDestination || '');
       }
+
+      // Independent per-mode selections, so the frontend can correctly
+      // pre-populate BOTH the Streaming and Video Recording tabs even though
+      // only one of them is actually running right now.
+      responseData.streamingSelection = this.buildModeSelection(this.videoSettings, this.devices);
+      responseData.videoRecordSelection = this.buildModeSelection(this.videoRecordSettings, this.devices);
 
       return callback(null, responseData);
     }
@@ -320,6 +370,12 @@ class videoStream {
         responseData.fpsMax = selectedCap?.fpsmax || 0;
         responseData.selectedFps = responseData.fpsMax > 0 ? responseData.fpsMax : (responseData.fpsOptions[0]?.value ?? 30);
 
+        // Independent per-mode selections, so the frontend can pre-populate
+        // both the Streaming and Video Recording tabs from their own saved
+        // settings, even while the camera isn't currently running.
+        responseData.streamingSelection = this.buildModeSelection(this.videoSettings, devices);
+        responseData.videoRecordSelection = this.buildModeSelection(this.videoRecordSettings, devices);
+
         return callback(null, responseData);
       } catch (e) {
         return callback('Failed to process video devices', responseData);
@@ -371,6 +427,7 @@ class videoStream {
       this.settings.setValue('camera.mode', this.cameraMode);
       this.settings.setValue('camera.useHeartbeat', this.useCameraHeartbeat);
       this.settings.setValue('camera.videoSettings', this.videoSettings);
+      this.settings.setValue('camera.videoRecordSettings', this.videoRecordSettings);
       this.settings.setValue('camera.stillSettings', this.stillSettings);
     } catch (e) {
       console.error('Error saving camera settings:', e);
@@ -380,11 +437,13 @@ class videoStream {
   resetCamera() {
     this.active = false;
     this.videoSettings = null;
+    this.videoRecordSettings = null;
     this.stillSettings = null;
     try {
       this.settings.setValue('camera.active', false);
       this.settings.setValue('camera.mode', 'streaming');
       this.settings.setValue('camera.videoSettings', null);
+      this.settings.setValue('camera.videoRecordSettings', null);
       this.settings.setValue('camera.stillSettings', null);
       this.settings.setValue('camera.useHeartbeat', false);
     } catch (e) {
@@ -563,24 +622,24 @@ class videoStream {
   }
 
   startVideoMode(callback) {
-    if (!this.videoSettings) return callback(new Error('No video settings provided'));
+    if (!this.videoRecordSettings) return callback(new Error('No video settings provided'));
 
-    const dest = this.toAbsolutePath(this.videoSettings.mediaDestination);
+    const dest = this.toAbsolutePath(this.videoRecordSettings.mediaDestination);
 
     // Convert bitrate from kbps to bps Picamera2
-    const bitrateBps = this.videoSettings.bitrate * 1000;
+    const bitrateBps = this.videoRecordSettings.bitrate * 1000;
 
     const args = [
       '-u', // force the stdout and stderr streams to be unbuffered
       './python/photovideo.py',
       '--mode=video',
-      '--device=' + this.videoSettings.device,
-      '--width=' + this.videoSettings.width,
-      '--height=' + this.videoSettings.height,
-      '--fps=' + this.videoSettings.fps,
+      '--device=' + this.videoRecordSettings.device,
+      '--width=' + this.videoRecordSettings.width,
+      '--height=' + this.videoRecordSettings.height,
+      '--fps=' + this.videoRecordSettings.fps,
       '--bitrate=' + bitrateBps,
-      '--rotation=' + this.videoSettings.rotation,
-      '--format=' + this.videoSettings.format
+      '--rotation=' + this.videoRecordSettings.rotation,
+      '--format=' + this.videoRecordSettings.format
     ];
 
     if (dest) {
@@ -729,7 +788,7 @@ class videoStream {
       if (this.deviceStream === proc) {
         this.active = false;
         // Clear the video recording flag
-        if (this.videoSettings) {
+        if (this.cameraMode === 'video' && this.videoRecordSettings) {
           this.setRecordingFlag(false);
           this.saveSettings();
         }
@@ -755,7 +814,7 @@ class videoStream {
     this.active = false;
     this.settings.setValue('camera.active', false);
     // Clear the video recording flag and persist the current mode's settings.
-    if (this.videoSettings) {
+    if (this.cameraMode === 'video' && this.videoRecordSettings) {
       this.setRecordingFlag(false);
     }
     this.saveSettings();
@@ -783,9 +842,9 @@ class videoStream {
         return 'Camera is streaming video'
       } else if (this.cameraMode === 'photo') {
         return 'Camera is active in photo mode'
-      } else if (this.cameraMode === 'video' && this.videoSettings.isRecording) {
+      } else if (this.cameraMode === 'video' && this.videoRecordSettings?.isRecording) {
         return 'Camera is currently recording a video'
-      } else if (this.cameraMode === 'video' && !this.videoSettings.isRecording) {
+      } else if (this.cameraMode === 'video' && !this.videoRecordSettings?.isRecording) {
         return 'Camera is active in video mode'
       }
     } else {
@@ -927,8 +986,8 @@ class videoStream {
   // Helper to set the isRecording flag by replacing the object
   // instead of mutating the property
   setRecordingFlag(val) {
-    if (!this.videoSettings) return;
-    this.videoSettings = { ...this.videoSettings, isRecording: val };
+    if (!this.videoRecordSettings) return;
+    this.videoRecordSettings = { ...this.videoRecordSettings, isRecording: val };
     this.saveSettings();
   }
 
@@ -992,6 +1051,8 @@ class videoStream {
     let devicePath = null;
     if (this.cameraMode === 'photo' && this.stillSettings && this.stillSettings.device) {
       devicePath = this.stillSettings.device;
+    } else if (this.cameraMode === 'video' && this.videoRecordSettings && this.videoRecordSettings.device) {
+      devicePath = this.videoRecordSettings.device;
     } else if (this.videoSettings && this.videoSettings.device) {
       devicePath = this.videoSettings.device;
     }
@@ -1024,8 +1085,12 @@ class videoStream {
       msg.resolutionH = this.stillSettings?.width || 0;
       msg.resolutionV = this.stillSettings?.height || 0;
     }
+    else if (this.cameraMode === 'video') {
+      msg.resolutionH = this.videoRecordSettings?.width || 0;
+      msg.resolutionV = this.videoRecordSettings?.height || 0;
+    }
     else {
-      // video or streaming
+      // streaming
       msg.resolutionH = this.videoSettings?.width || 0;
       msg.resolutionV = this.videoSettings?.height || 0;
     }
@@ -1236,7 +1301,7 @@ class videoStream {
       else if (data.command === common.MavCmd['VIDEO_START_CAPTURE']) {
         console.log('Received MAVLink command to start video capture')
         this.switchCameraModeAndTakeAction('video', common.MavCmd['VIDEO_START_CAPTURE'], packet.header.sysid, minimal.MavComponent.CAMERA, packet.header.compid, () => {
-          if (!this.videoSettings.isRecording) {
+          if (!this.videoRecordSettings?.isRecording) {
             this.toggleVideoRecording()
           }
           // Already recording, or just started - either way the requested state now holds
@@ -1245,7 +1310,7 @@ class videoStream {
       }
       else if (data.command === common.MavCmd['VIDEO_STOP_CAPTURE']) {
         console.log('Received MAVLink command to stop video capture')
-        if (this.cameraMode === 'video' && this.videoSettings.isRecording) {
+        if (this.cameraMode === 'video' && this.videoRecordSettings?.isRecording) {
           this.toggleVideoRecording()
         }
         // Not recording (whether because we were never in video mode, or

--- a/server/videostream.test.js
+++ b/server/videostream.test.js
@@ -321,6 +321,56 @@ describe('Video Functions', function () {
     assert.equal(vManager.deviceStream, procB, "The current device stream must be unaffected")
   })
 
+  it('#ensureDefaultSettingsForModeUsesFirstDeviceCapWhenUnconfigured()', function () {
+    settings.clear()
+    const vManager = new VideoStream(settings)
+
+    vManager.devices = [
+      {
+        value: 'imx415', label: 'CSI imx415', caps: [
+          { value: '1920x1080xYUV420', width: 1920, height: 1080, format: 'YUV420', fpsmax: '30', fps: [] }
+        ]
+      }
+    ]
+    vManager.stillDevices = [
+      {
+        id: 'CSI-imx415', label: 'CSI imx415', caps: [
+          { value: '3864x2192xYUV420', width: 3864, height: 2192, format: 'YUV420' }
+        ]
+      }
+    ]
+
+    assert.equal(vManager.videoRecordSettings, null)
+    vManager.ensureDefaultSettingsForMode('video')
+    assert.deepEqual(vManager.videoRecordSettings, {
+      device: 'imx415',
+      isRecording: false,
+      width: 1920,
+      height: 1080,
+      format: 'YUV420',
+      bitrate: 1100,
+      fps: 30, // coerced from the string '30' fpsmax
+      rotation: 0,
+      mediaDestination: ''
+    })
+    assert.deepEqual(settings.value('camera.videoRecordSettings'), vManager.videoRecordSettings, "Defaults should be persisted")
+
+    assert.equal(vManager.stillSettings, null)
+    vManager.ensureDefaultSettingsForMode('photo')
+    assert.deepEqual(vManager.stillSettings, {
+      device: 'CSI-imx415',
+      width: 3864,
+      height: 2192,
+      format: 'YUV420',
+      mediaDestination: ''
+    })
+
+    // Must not overwrite settings that already exist
+    vManager.videoRecordSettings.width = 999
+    vManager.ensureDefaultSettingsForMode('video')
+    assert.equal(vManager.videoRecordSettings.width, 999, "Should not overwrite already-configured settings")
+  })
+
   it('#toggleVideoRecording()', function () {
     settings.clear()
     const vManager = new VideoStream(settings)

--- a/server/videostream.test.js
+++ b/server/videostream.test.js
@@ -4,6 +4,7 @@ const settings = require('settings-store')
 const logpaths = require('./paths')
 const VideoStream = require('./videostream')
 const { minimal, common } = require('node-mavlink')
+const { EventEmitter } = require('events')
 
 describe('Video Functions', function () {
   it('#videomanagerinit()', function () {
@@ -220,13 +221,18 @@ describe('Video Functions', function () {
     assert.equal(acks[0].result, 1, "Should NACK with MAV_RESULT_TEMPORARILY_REJECTED, not silently claim success")
   })
 
-  it('#onMavPacketRejectsVideoCaptureInWrongMode()', function () {
+  it('#onMavPacketAutoSwitchesModeForVideoCapture()', function () {
     settings.clear()
     const vManager = new VideoStream(settings)
     vManager.cameraMode = 'streaming' // not 'video'
+    vManager.videoSettings = { isRecording: false }
 
-    let toggled = false
-    vManager.toggleVideoRecording = () => { toggled = true }
+    // Stub out actual process management - this test is about the dispatch/
+    // switching logic, not really spawning photovideo.py
+    const calls = []
+    vManager.stopCamera = (cb) => { calls.push('stopCamera'); vManager.active = false; cb(null, false) }
+    vManager.startCamera = (cb) => { calls.push(`startCamera(${vManager.cameraMode})`); vManager.active = true; cb(null) }
+    vManager.toggleVideoRecording = () => { calls.push('toggleVideoRecording'); vManager.videoSettings.isRecording = true }
 
     const acks = []
     vManager.eventEmitter.on('camera_command_ack', (commandId, senderSysId, senderCompId, targetComponent, result) => {
@@ -238,10 +244,77 @@ describe('Video Functions', function () {
 
     vManager.onMavPacket(packet, data)
 
-    assert.equal(toggled, false, "Should NOT toggle video recording while in the wrong mode")
-    assert.equal(acks.length, 1)
+    // Should switch mode (stop, then start in the new mode) rather than reject...
+    assert.deepEqual(calls, ['stopCamera', 'startCamera(video)', 'toggleVideoRecording'])
+    assert.equal(vManager.cameraMode, 'video')
+    // ...acking MAV_RESULT_IN_PROGRESS immediately (switching takes a while),
+    // then a final ACCEPTED once actually switched and recording
+    assert.equal(acks.length, 2)
     assert.equal(acks[0].commandId, common.MavCmd.VIDEO_START_CAPTURE)
+    assert.equal(acks[0].result, 5, "Should ACK MAV_RESULT_IN_PROGRESS while switching modes")
+    assert.equal(acks[1].result, undefined, "Should ACK accepted (default) once switched and recording")
+  })
+
+  it('#onMavPacketRejectsWhenSwitchAlreadyInProgress()', function () {
+    settings.clear()
+    const vManager = new VideoStream(settings)
+    vManager.cameraMode = 'photo'
+    vManager.modeSwitchInProgress = true // simulate an in-flight switch
+
+    let switched = false
+    vManager.stopCamera = () => { switched = true }
+
+    const acks = []
+    vManager.eventEmitter.on('camera_command_ack', (commandId, senderSysId, senderCompId, targetComponent, result) => {
+      acks.push({ commandId, result })
+    })
+
+    const packet = { header: { msgid: common.CommandLong.MSG_ID, sysid: 1, compid: 1 } }
+    const data = { targetComponent: minimal.MavComponent.CAMERA, command: common.MavCmd.VIDEO_START_STREAMING, _param1: 0 }
+
+    vManager.onMavPacket(packet, data)
+
+    assert.equal(switched, false, "Should NOT attempt another switch while one is already in progress")
+    assert.equal(acks.length, 1)
     assert.equal(acks[0].result, 1, "Should NACK with MAV_RESULT_TEMPORARILY_REJECTED")
+  })
+
+  it('#setupStreamEventsIgnoresStaleProcessAfterModeSwitch()', function () {
+    settings.clear()
+    const vManager = new VideoStream(settings)
+
+    const makeFakeProc = () => {
+      const proc = new EventEmitter()
+      proc.stdout = new EventEmitter()
+      proc.stderr = new EventEmitter()
+      proc.kill = () => {}
+      return proc
+    }
+
+    // An old process ('Mode A') starts and becomes ready...
+    const procA = makeFakeProc()
+    vManager.deviceStream = procA
+    vManager.setupStreamEvents('Mode A', () => {})
+    procA.stdout.emit('data', Buffer.from('Camera is ready in Mode A\n'))
+    assert.equal(vManager.active, true, "Mode A should be marked active once ready")
+
+    // ...then a mode switch happens: a NEW process ('Mode B') is spawned and
+    // becomes ready, superseding procA - mirroring what
+    // switchCameraModeAndTakeAction's stopCamera()+startCamera() flow does
+    // (this.deviceStream reassigned to the new process).
+    const procB = makeFakeProc()
+    vManager.deviceStream = procB
+    vManager.setupStreamEvents('Mode B', () => {})
+    procB.stdout.emit('data', Buffer.from('Camera is ready in Mode B\n'))
+    assert.equal(vManager.active, true, "Mode B should be marked active once ready")
+
+    // The OLD process (procA) finally exits from its earlier SIGTERM, well
+    // after Mode B has taken over - its stale 'close' event must NOT clobber
+    // the current (Mode B) active state.
+    procA.emit('close', 0)
+
+    assert.equal(vManager.active, true, "A stale process's close event must not clobber the current mode's active state")
+    assert.equal(vManager.deviceStream, procB, "The current device stream must be unaffected")
   })
 
   it('#toggleVideoRecording()', function () {

--- a/server/videostream.test.js
+++ b/server/videostream.test.js
@@ -3,6 +3,7 @@ const path = require('path')
 const settings = require('settings-store')
 const logpaths = require('./paths')
 const VideoStream = require('./videostream')
+const { minimal, common } = require('node-mavlink')
 
 describe('Video Functions', function () {
   it('#videomanagerinit()', function () {
@@ -161,8 +162,9 @@ describe('Video Functions', function () {
     settings.clear()
     const vManager = new VideoStream(settings)
 
-    // Simulate active camera
+    // Simulate active camera in photo mode
     vManager.active = true
+    vManager.cameraMode = 'photo'
     let signalSent = false
 
     vManager.deviceStream = {
@@ -188,6 +190,58 @@ describe('Video Functions', function () {
       assert.equal(vManager.photoSeq, 1, "Should increment photo sequence")
       done()
     }, 50)
+  })
+
+  it('#captureStillPhotoRejectsWrongMode()', function () {
+    settings.clear()
+    const vManager = new VideoStream(settings)
+
+    // Active, but in video mode rather than photo mode
+    vManager.active = true
+    vManager.cameraMode = 'video'
+    let signalSent = false
+    vManager.deviceStream = {
+      kill: (signal) => {
+        if (signal === 'SIGUSR1') signalSent = true
+      }
+    }
+
+    const acks = []
+    vManager.eventEmitter.on('camera_command_ack', (commandId, senderSysId, senderCompId, targetComponent, result) => {
+      acks.push({ commandId, result })
+    })
+
+    // Simulate a MAVLink-triggered capture (commandId set) while in the wrong mode
+    vManager.captureStillPhoto(1, 1, 1, null, common.MavCmd.IMAGE_START_CAPTURE)
+
+    assert.equal(signalSent, false, "Should NOT send SIGUSR1 to whatever process is actually running")
+    assert.equal(acks.length, 1, "Should ACK the command instead of silently ignoring it")
+    assert.equal(acks[0].commandId, common.MavCmd.IMAGE_START_CAPTURE)
+    assert.equal(acks[0].result, 1, "Should NACK with MAV_RESULT_TEMPORARILY_REJECTED, not silently claim success")
+  })
+
+  it('#onMavPacketRejectsVideoCaptureInWrongMode()', function () {
+    settings.clear()
+    const vManager = new VideoStream(settings)
+    vManager.cameraMode = 'streaming' // not 'video'
+
+    let toggled = false
+    vManager.toggleVideoRecording = () => { toggled = true }
+
+    const acks = []
+    vManager.eventEmitter.on('camera_command_ack', (commandId, senderSysId, senderCompId, targetComponent, result) => {
+      acks.push({ commandId, result })
+    })
+
+    const packet = { header: { msgid: common.CommandLong.MSG_ID, sysid: 1, compid: 1 } }
+    const data = { targetComponent: minimal.MavComponent.CAMERA, command: common.MavCmd.VIDEO_START_CAPTURE, _param1: 0 }
+
+    vManager.onMavPacket(packet, data)
+
+    assert.equal(toggled, false, "Should NOT toggle video recording while in the wrong mode")
+    assert.equal(acks.length, 1)
+    assert.equal(acks[0].commandId, common.MavCmd.VIDEO_START_CAPTURE)
+    assert.equal(acks[0].result, 1, "Should NACK with MAV_RESULT_TEMPORARILY_REJECTED")
   })
 
   it('#toggleVideoRecording()', function () {

--- a/server/videostream.test.js
+++ b/server/videostream.test.js
@@ -254,6 +254,41 @@ describe('Video Functions', function () {
     vManager.sendVideoStreamInformation(1, 1, 1)
   })
 
+  it('#sendVideoStreamInformationMultipleAddresses()', function () {
+    settings.clear()
+    const vManager = new VideoStream(settings)
+
+    vManager.videoSettings = {
+      width: 1280,
+      height: 720,
+      fps: 30,
+      bitrate: 2000,
+      rotation: 0,
+      compression: 'H264',
+      useUDP: false,
+      mavStreamSelected: '127.0.0.1' // deliberately select the loopback address
+    }
+
+    // A loopback address plus a real, reachable one
+    vManager.deviceAddresses = ['rtsp://127.0.0.1:8554/test', 'rtsp://10.0.2.100:8554/test']
+
+    const received = []
+    vManager.eventEmitter.on('videostreaminfo', (msg) => received.push(msg))
+
+    vManager.sendVideoStreamInformation(1, 1, 1)
+
+    // One message per address, not just the (loopback) selected one
+    assert.equal(received.length, 2)
+    // count reflects the total number of streams being advertised
+    assert.ok(received.every(msg => msg.count === 2))
+    // the real, reachable address should be advertised first...
+    assert.equal(received[0].streamId, 1)
+    assert.ok(received[0].uri.includes('10.0.2.100'))
+    // ...and loopback last, as a fallback rather than the primary choice
+    assert.equal(received[1].streamId, 2)
+    assert.ok(received[1].uri.includes('127.0.0.1'))
+  })
+
   it('#sendCameraSettings()', function (done) {
     settings.clear()
     const vManager = new VideoStream(settings)

--- a/server/videostream.test.js
+++ b/server/videostream.test.js
@@ -121,17 +121,21 @@ describe('Video Functions', function () {
     vManager.active = true
     vManager.cameraMode = 'video'
     vManager.videoSettings = { width: 1920, height: 1080 }
+    vManager.videoRecordSettings = { width: 3864, height: 2192 }
 
     // Test Save
     vManager.saveSettings()
     assert.equal(settings.value('camera.active'), true)
     assert.equal(settings.value('camera.mode'), 'video')
+    // Streaming and Video Recording are independent settings objects
     assert.deepEqual(settings.value('camera.videoSettings'), { width: 1920, height: 1080 })
+    assert.deepEqual(settings.value('camera.videoRecordSettings'), { width: 3864, height: 2192 })
 
     // Test Reset
     vManager.resetCamera()
     assert.equal(vManager.active, false)
     assert.equal(vManager.videoSettings, null)
+    assert.equal(vManager.videoRecordSettings, null)
     assert.equal(settings.value('camera.active'), false)
   })
 
@@ -225,14 +229,14 @@ describe('Video Functions', function () {
     settings.clear()
     const vManager = new VideoStream(settings)
     vManager.cameraMode = 'streaming' // not 'video'
-    vManager.videoSettings = { isRecording: false }
+    vManager.videoRecordSettings = { isRecording: false }
 
     // Stub out actual process management - this test is about the dispatch/
     // switching logic, not really spawning photovideo.py
     const calls = []
     vManager.stopCamera = (cb) => { calls.push('stopCamera'); vManager.active = false; cb(null, false) }
     vManager.startCamera = (cb) => { calls.push(`startCamera(${vManager.cameraMode})`); vManager.active = true; cb(null) }
-    vManager.toggleVideoRecording = () => { calls.push('toggleVideoRecording'); vManager.videoSettings.isRecording = true }
+    vManager.toggleVideoRecording = () => { calls.push('toggleVideoRecording'); vManager.videoRecordSettings.isRecording = true }
 
     const acks = []
     vManager.eventEmitter.on('camera_command_ack', (commandId, senderSysId, senderCompId, targetComponent, result) => {

--- a/server/videostream.test.js
+++ b/server/videostream.test.js
@@ -344,7 +344,7 @@ describe('Video Functions', function () {
       // Decode vendor name (plain byte array to string)
       const vendorText = String.fromCharCode(...msg.vendorName).replace(/\0/g, '')
       assert.equal(vendorText, 'Rpanion')
-      assert.equal(msg.flags, 256) // Default streaming flag
+      assert.equal(msg.flags, common.CameraCapFlags.CAPTURE_IMAGE | common.CameraCapFlags.CAPTURE_VIDEO | common.CameraCapFlags.HAS_VIDEO_STREAM) // Full capability set (mode auto-switching supports all)
       done()
     })
 

--- a/server/videostream.test.js
+++ b/server/videostream.test.js
@@ -266,7 +266,8 @@ describe('Video Functions', function () {
       rotation: 0,
       compression: 'H264',
       useUDP: false,
-      mavStreamSelected: '127.0.0.1' // deliberately select the loopback address
+      mavStreamSelected: '127.0.0.1', // deliberately select the loopback address
+      device: 'CSI-imx415'
     }
 
     // A loopback address plus a real, reachable one
@@ -284,8 +285,12 @@ describe('Video Functions', function () {
     // the real, reachable address should be advertised first...
     assert.equal(received[0].streamId, 1)
     assert.ok(received[0].uri.includes('10.0.2.100'))
+    // ...and each stream's name should be distinguishable (clean model name + its
+    // own address), not identical entries a user can't tell apart in a GCS dropdown
+    assert.equal(received[0].name, 'imx415 (10.0.2.100)')
     // ...and loopback last, as a fallback rather than the primary choice
     assert.equal(received[1].streamId, 2)
+    assert.equal(received[1].name, 'imx415 (127.0.0.1)')
     assert.ok(received[1].uri.includes('127.0.0.1'))
   })
 

--- a/server/videostream.test.js
+++ b/server/videostream.test.js
@@ -52,6 +52,24 @@ describe('Video Functions', function () {
     })
   }).timeout(5000)
 
+  it('#videomanagerscanReportsActiveRecordingState()', function (done) {
+    // getVideoDevices() must report whether Video Recording is actually
+    // recording right now, so the "Stop Recording" button on page load/
+    // refresh reflects reality instead of always showing "Start Recording".
+    settings.clear()
+    const vManager = new VideoStream(settings)
+
+    vManager.cameraMode = 'video'
+    vManager.deviceStream = { kill: () => {} } // simulate an active process
+    vManager.devices = [{ value: 'imx415', label: 'CSI imx415', caps: [] }]
+    vManager.videoRecordSettings = { device: 'imx415', isRecording: true }
+
+    vManager.getVideoDevices(function (err, data) {
+      assert.equal(data.selectedIsRecording, true)
+      done()
+    })
+  })
+
   it('#getStillDevices()', function (done) {
     // Scanning for still photo devices (CSI and UVC cameras)
     settings.clear()

--- a/src/video.jsx
+++ b/src/video.jsx
@@ -90,6 +90,12 @@ class VideoPage extends basePage {
         const videoData = await videoRes.json();
         const stillData = await stillRes.json();
 
+        // --- Process Network Interfaces ---
+        // Prefer a non-loopback interface as the default MAVLink video source IP,
+        // since 127.0.0.1 is never reachable by a remote GCS.
+        const ifaceList = (videoData.networkInterfaces || []).map(ip => ip);
+        const defaultMavStreamIface = ifaceList.find(ip => ip !== '127.0.0.1') || ifaceList[0] || '127.0.0.1';
+
         // --- Process Video Data ---
         const vidDevs = videoData.devices || [];
         const selVidDev = videoData.selectedDevice || (vidDevs.length > 0 ? vidDevs[0] : null);
@@ -165,7 +171,7 @@ class VideoPage extends basePage {
 
         this.setState({
           // Network
-          ifaces: (videoData.networkInterfaces || []).map(ip => ip), // Keep as array of strings
+          ifaces: ifaceList,
 
           // Video State
           videoDevices: vidDevs,
@@ -194,7 +200,7 @@ class VideoPage extends basePage {
           rotSelected: (videoData.selectedRotation && videoData.selectedRotation.value != null) ? videoData.selectedRotation.value : 0,
           timestamp: videoData.selectedUseTimestamp || false,
           enableCameraHeartbeat: videoData.selectedUseCameraHeartbeat || false,
-          mavStreamSelected: (videoData.selectedMavStreamURI && videoData.selectedMavStreamURI.value) ? videoData.selectedMavStreamURI.value : (this.state.ifaces[0] || '127.0.0.1'),
+          mavStreamSelected: (videoData.selectedMavStreamURI && videoData.selectedMavStreamURI.value) ? videoData.selectedMavStreamURI.value : defaultMavStreamIface,
 
           FPSMax: initialFpsMax,
           fpsOptions: initialFpsOpts,

--- a/src/video.jsx
+++ b/src/video.jsx
@@ -138,7 +138,7 @@ class VideoPage extends basePage {
           vidDeviceSelected: activeResolved.device,
           videoCaps: activeResolved.caps,
           vidCapSelected: activeResolved.cap,
-          videoIsRecording: false,
+          videoIsRecording: videoData.selectedIsRecording || false,
 
           // Still State
           stillDevices: stillDevs,

--- a/src/video.jsx
+++ b/src/video.jsx
@@ -98,17 +98,6 @@ class VideoPage extends basePage {
 
         // --- Process Video Data ---
         const vidDevs = videoData.devices || [];
-        const selVidDev = videoData.selectedDevice || (vidDevs.length > 0 ? vidDevs[0] : null);
-        const vidCaps = selVidDev ? selVidDev.caps : [];
-        const selVidCap = videoData.selectedCap || (vidCaps.length > 0 ? vidCaps[0] : null);
-
-        // FPS processing
-        const currentFpsOpts = selVidCap ? selVidCap.fps : [];
-        const currentFpsMax = selVidCap ? selVidCap.fpsmax : 0;
-        let selFps = videoData.selectedFps;
-        if (selFps == null) {
-          selFps = currentFpsMax > 0 ? currentFpsMax : (currentFpsOpts.length > 0 ? currentFpsOpts[0].value : 30);
-        }
 
         // --- Process Still Data ---
         const stillDevs = stillData.devices || [];
@@ -128,52 +117,16 @@ class VideoPage extends basePage {
           ? 'streaming' 
           : (videoData.cameraMode || 'streaming');
 
-        // Load the correct set of capabilities for the selected camera mode
-        let initialVidDevSel = selVidDev ? selVidDev.value : '';
-        let initialVidCaps = vidCaps;
-        let initialVidCapSel = selVidCap ? selVidCap.value : '';
-        let initialFpsOpts = currentFpsOpts;
-        let initialFpsMax = currentFpsMax;
-        let initialFps = selFps;
-        
-        if (cameraModeToUse === 'video') {
-            // Video recording mode now uses the same device/cap source as streaming mode
-            // so both modes offer the same resolution list.
-            const savedDeviceValue = videoData.selectedDevice ? videoData.selectedDevice.value : null;
-            let matchingVidDev = vidDevs.find(d => d.value === savedDeviceValue);
-            
-            if (!matchingVidDev && vidDevs.length > 0) {
-                matchingVidDev = vidDevs[0];
-            }
+        // Streaming and Video Recording have independent saved settings on the
+        // backend - resolve each against the device list, then remember both
+        // for the session so switching the mode radio button later restores
+        // the other mode's own selection instead of resetting to the first
+        // device/cap (see handleCameraModeChange).
+        const streamingResolved = this.resolveModeSelection(videoData.streamingSelection, vidDevs);
+        const videoRecordResolved = this.resolveModeSelection(videoData.videoRecordSelection, vidDevs);
+        this._modeSelectionCache = { streaming: streamingResolved, video: videoRecordResolved };
 
-            if (matchingVidDev) {
-                initialVidDevSel = matchingVidDev.value;
-                initialVidCaps = matchingVidDev.caps ||[];
-                const savedCapValue = videoData.selectedCap ? videoData.selectedCap.value : null;
-                let matchedCap = initialVidCaps.find(c => c.value === savedCapValue);
-                if (!matchedCap && initialVidCaps.length > 0) {
-                    matchedCap = initialVidCaps[0];
-                }
-                initialVidCapSel = matchedCap ? matchedCap.value : '';
-                initialFpsOpts = matchedCap ? (matchedCap.fps || []) : [];
-                initialFpsMax = matchedCap ? (matchedCap.fpsmax || 0) : 0;
-                // Only reuse the saved FPS if it's actually valid for the matched
-                // capability - if the saved device/resolution wasn't found above and
-                // we fell back to a different one, its FPS range/options may differ.
-                const savedFps = videoData.selectedFps;
-                const savedFpsIsValid = savedFps != null && (
-                    (initialFpsMax > 0 && savedFps >= 1 && savedFps <= initialFpsMax) ||
-                    (initialFpsMax === 0 && initialFpsOpts.some(f => String(f.value) === String(savedFps)))
-                );
-                initialFps = savedFpsIsValid ? savedFps : (initialFpsMax > 0 ? initialFpsMax : (initialFpsOpts.length > 0 ? initialFpsOpts[0].value : 30));
-            } else {
-                initialVidDevSel = '';
-                initialVidCaps = [];
-                initialVidCapSel = '';
-                initialFpsOpts =[];
-                initialFpsMax = 120;
-            }
-        }
+        const activeResolved = cameraModeToUse === 'video' ? videoRecordResolved : streamingResolved;
 
 
         this.setState({
@@ -182,9 +135,9 @@ class VideoPage extends basePage {
 
           // Video State
           videoDevices: vidDevs,
-          vidDeviceSelected: initialVidDevSel,
-          videoCaps: initialVidCaps,
-          vidCapSelected: initialVidCapSel,
+          vidDeviceSelected: activeResolved.device,
+          videoCaps: activeResolved.caps,
+          vidCapSelected: activeResolved.cap,
           videoIsRecording: false,
 
           // Still State
@@ -203,19 +156,19 @@ class VideoPage extends basePage {
           transportSelected: isRTP ? "RTP" : "RTSP",
           useUDPIP: videoData.selectedUseUDPIP || "127.0.0.1",
           useUDPPort: videoData.selectedUseUDPPort || 5600,
-          bitrate: videoData.selectedBitrate || 1100,
-          rotSelected: (videoData.selectedRotation && videoData.selectedRotation.value != null) ? videoData.selectedRotation.value : 0,
+          bitrate: activeResolved.bitrate,
+          rotSelected: activeResolved.rotation,
           timestamp: videoData.selectedUseTimestamp || false,
           enableCameraHeartbeat: videoData.selectedUseCameraHeartbeat || false,
           mavStreamSelected: (videoData.selectedMavStreamURI && videoData.selectedMavStreamURI.value) ? videoData.selectedMavStreamURI.value : defaultMavStreamIface,
 
-          FPSMax: initialFpsMax,
-          fpsOptions: initialFpsOpts,
-          fpsSelected: initialFps,
+          FPSMax: activeResolved.fpsMax,
+          fpsOptions: activeResolved.fpsOptions,
+          fpsSelected: activeResolved.fps,
 
           compression: (videoData.compression && videoData.compression.value) ? videoData.compression.value : 'H264',
 
-          videoMediaDestination: videoData.videoMediaDestination || '',
+          videoMediaDestination: activeResolved.mediaDestination,
           stillMediaDestination: stillData.stillMediaDestination || '',
         });
 
@@ -271,13 +224,90 @@ componentWillUnmount() {
     return `${cap.width}x${cap.height}x${cap.format}`;
   }
 
+  // Resolve a saved per-mode selection (backend's streamingSelection/
+  // videoRecordSelection) against the current device list, falling back to
+  // the first device/resolution/fps if nothing was saved yet or it no longer
+  // matches an available device/capability.
+  resolveModeSelection(selection, vidDevs) {
+    const savedDeviceValue = selection?.selectedDevice ? selection.selectedDevice.value : null;
+    let device = vidDevs.find(d => d.value === savedDeviceValue);
+    if (!device && vidDevs.length > 0) device = vidDevs[0];
+
+    if (!device) {
+      return { device: '', caps: [], cap: '', fpsOptions: [], fpsMax: 0, fps: 30, rotation: 0, bitrate: 1100, mediaDestination: '' };
+    }
+
+    const caps = device.caps || [];
+    const savedCapValue = selection?.selectedCap ? selection.selectedCap.value : null;
+    let cap = caps.find(c => c.value === savedCapValue);
+    if (!cap && caps.length > 0) cap = caps[0];
+
+    const fpsOptions = cap ? (cap.fps || []) : [];
+    const fpsMax = cap ? (cap.fpsmax || 0) : 0;
+    const savedFps = selection?.selectedFps;
+    // Only reuse the saved FPS if it's actually valid for the matched
+    // capability - if the saved device/resolution wasn't found above and we
+    // fell back to a different one, its FPS range/options may differ.
+    const savedFpsIsValid = savedFps != null && (
+      (fpsMax > 0 && savedFps >= 1 && savedFps <= fpsMax) ||
+      (fpsMax === 0 && fpsOptions.some(f => String(f.value) === String(savedFps)))
+    );
+    const fps = savedFpsIsValid ? savedFps : (fpsMax > 0 ? fpsMax : (fpsOptions.length > 0 ? fpsOptions[0].value : 30));
+
+    return {
+      device: device.value,
+      caps,
+      cap: cap ? cap.value : '',
+      fpsOptions,
+      fpsMax,
+      fps,
+      rotation: (selection?.selectedRotation && selection.selectedRotation.value != null) ? selection.selectedRotation.value : 0,
+      bitrate: selection?.selectedBitrate || 1100,
+      mediaDestination: selection?.mediaDestination || ''
+    };
+  }
+
   handleCameraModeChange = (event) => {
     const newMode = event.target.value;
-    const updates = { cameraMode: newMode };
+    const prevMode = this.state.cameraMode;
 
-    // Reset device/resolution selections when switching between streaming and video modes
-    if (newMode === 'video') {
-      // Video recording mode now uses the same device/cap source as streaming mode
+    // Streaming and Video Recording share the same device/cap/rotation/bitrate
+    // UI fields, but should not clobber each other's selection just because
+    // the user flipped the mode radio button. Remember the mode being left,
+    // then restore the target mode's last selection (seeded at load time from
+    // the backend's saved settings, and kept up to date as the user edits
+    // each mode) instead of resetting to the first device/cap.
+    this._modeSelectionCache = this._modeSelectionCache || {};
+    if (prevMode === 'streaming' || prevMode === 'video') {
+      this._modeSelectionCache[prevMode] = {
+        device: this.state.vidDeviceSelected,
+        caps: this.state.videoCaps,
+        cap: this.state.vidCapSelected,
+        fpsOptions: this.state.fpsOptions,
+        fpsMax: this.state.FPSMax,
+        fps: this.state.fpsSelected,
+        rotation: this.state.rotSelected,
+        bitrate: this.state.bitrate,
+        mediaDestination: this.state.videoMediaDestination
+      };
+    }
+
+    const updates = { cameraMode: newMode };
+    const cached = (newMode === 'streaming' || newMode === 'video') ? this._modeSelectionCache[newMode] : null;
+
+    if (cached) {
+      updates.vidDeviceSelected = cached.device;
+      updates.videoCaps = cached.caps;
+      updates.vidCapSelected = cached.cap;
+      updates.fpsOptions = cached.fpsOptions;
+      updates.FPSMax = cached.fpsMax;
+      updates.fpsSelected = cached.fps;
+      updates.rotSelected = cached.rotation;
+      updates.bitrate = cached.bitrate;
+      updates.videoMediaDestination = cached.mediaDestination;
+    } else if (newMode === 'video' || newMode === 'streaming') {
+      // No previous selection for this mode - default to the first available
+      // device/resolution/fps.
       const firstVidDevice = this.state.videoDevices.length > 0 ? this.state.videoDevices[0] : null;
       const firstCap = firstVidDevice && firstVidDevice.caps.length > 0 ? firstVidDevice.caps[0] : null;
 
@@ -287,20 +317,6 @@ componentWillUnmount() {
       updates.fpsOptions = firstCap ? (firstCap.fps || []) : [];
       updates.FPSMax = firstCap ? (firstCap.fpsmax || 0) : 0;
       updates.fpsSelected = updates.FPSMax > 0 ? updates.FPSMax : (updates.fpsOptions.length > 0 ? updates.fpsOptions[0].value : 30);
-    } else if (newMode === 'streaming') {
-      // Reset back to Streaming capabilities
-      const firstVidDevice = this.state.videoDevices.length > 0 ? this.state.videoDevices[0] : null;
-      const firstCap = firstVidDevice && firstVidDevice.caps.length > 0 ? firstVidDevice.caps[0] : null;
-
-      updates.vidDeviceSelected = firstVidDevice ? firstVidDevice.value : '';
-      updates.videoCaps = firstVidDevice ? firstVidDevice.caps :[];
-      updates.vidCapSelected = firstCap ? firstCap.value : '';
-      
-      const newFpsOpts = firstCap ? (firstCap.fps || []) :[];
-      const newFpsMax = firstCap ? (firstCap.fpsmax || 0) : 0;
-      updates.FPSMax = newFpsMax;
-      updates.fpsOptions = newFpsOpts;
-      updates.fpsSelected = newFpsMax > 0 ? newFpsMax : (newFpsOpts.length > 0 ? newFpsOpts[0].value : 30);
     }
 
     this.setState(updates);

--- a/src/video.jsx
+++ b/src/video.jsx
@@ -360,11 +360,22 @@ componentWillUnmount() {
       const newFpsOpts = cap.fps || [];
       const newFpsMax = cap.fpsmax || 0;
 
+      // Keep the currently-selected FPS if it's still valid for the new
+      // resolution's range/options, instead of always resetting it - e.g.
+      // switching between two resolutions that both support up to 30fps
+      // shouldn't discard a deliberately-chosen lower FPS.
+      const currentFps = this.state.fpsSelected;
+      const currentFpsIsValid = currentFps != null && (
+        (newFpsMax > 0 && currentFps >= 1 && currentFps <= newFpsMax) ||
+        (newFpsMax === 0 && newFpsOpts.some(f => String(f.value) === String(currentFps)))
+      );
+      const newFps = currentFpsIsValid ? currentFps : (newFpsMax > 0 ? newFpsMax : (newFpsOpts.length > 0 ? newFpsOpts[0].value : 30));
+
       this.setState({
         vidCapSelected: value,
         FPSMax: newFpsMax,
         fpsOptions: newFpsOpts,
-        fpsSelected: newFpsMax > 0 ? Math.min(newFpsMax, 10) : (newFpsOpts.length > 0 ? newFpsOpts[0].value : 30)
+        fpsSelected: newFps
       });
 
     if (cap.format === "video/x-h264") {

--- a/src/video.jsx
+++ b/src/video.jsx
@@ -157,8 +157,15 @@ class VideoPage extends basePage {
                 initialVidCapSel = matchedCap ? matchedCap.value : '';
                 initialFpsOpts = matchedCap ? (matchedCap.fps || []) : [];
                 initialFpsMax = matchedCap ? (matchedCap.fpsmax || 0) : 0;
+                // Only reuse the saved FPS if it's actually valid for the matched
+                // capability - if the saved device/resolution wasn't found above and
+                // we fell back to a different one, its FPS range/options may differ.
                 const savedFps = videoData.selectedFps;
-                initialFps = savedFps != null ? savedFps : (initialFpsMax > 0 ? initialFpsMax : (initialFpsOpts.length > 0 ? initialFpsOpts[0].value : 30));
+                const savedFpsIsValid = savedFps != null && (
+                    (initialFpsMax > 0 && savedFps >= 1 && savedFps <= initialFpsMax) ||
+                    (initialFpsMax === 0 && initialFpsOpts.some(f => String(f.value) === String(savedFps)))
+                );
+                initialFps = savedFpsIsValid ? savedFps : (initialFpsMax > 0 ? initialFpsMax : (initialFpsOpts.length > 0 ? initialFpsOpts[0].value : 30));
             } else {
                 initialVidDevSel = '';
                 initialVidCaps = [];


### PR DESCRIPTION
This includes many small enhancements and fixes to the Video and Photo feature.  This PR is built on top of PR https://github.com/stephendade/Rpanion-server/pull/416 so it should be merged before this one.  Once that's done we will rebase this one and the commit list will become much smaller

The code is mostly generated with Claude but I have tested it fairly thoroughly myself.  I would like to do a bit more testing before we merge it.

The changes are:

1. Strip CSI- prefix from CameraInformation.model_name so the name is consistent regardless of the camera mode (e.g. streaming, photo or video)
2. CAMERA_INFORMATION.firmware_version uses Rpanion's version number instead of just 0.  This number is displayed to the user in the GCS messages tab.
3. VIDEO_STREAM_INFORMATION is sent for every available IP address.  This results in users seeing a list of video stream in their GCS (e.g. Mission Planner) which they can select from depending upon whether they are connecting using WifiAP, LTE or Ethernet
4. Correct NACK capture/recording commands sent while in the wrong camera mode
5. Automatically switch camera mode to service MAVLink commands.  E.g. "take photo" command while streaming now switches Rpanion to Photo mode and captures, instead of rejecting.
6. Photo and Video's Video Recording page's resolutions appear in the list from largest-to-smallest
7. FPS is validated against the camera's capability to catch an edge case where the FPS is somehow no longer valid (e.g. if the camera was changed)
8. CAMERA_INFORMATION advertise the full capability (e.g. streaming, recording, take photo) regardless of the camera mode (see item 5 above)
9. Streaming and Video Recording get independent settings to avoid settings from one page affecting the other
10. Improve video playback to be closer to real-time by setting frame duration and framerate.
11. Proactively send CameraInformation/CameraSettings while in Streaming mode.  This helps the GCS know about teh camera and video recording even though its not using them
12. Fix changes to Resolution from also resetting the FPS
13. Fall back to reasonable defaults for never-configured modes.   E.g. if the user has just setup Rpanion and has not manually configured the streaming, recording and photo resolutions, etc, it should still work

