### PR TITLE
Flightcontroller: Add timesync option

### DIFF
--- a/mavlink/mavManager.js
+++ b/mavlink/mavManager.js
@@ -32,6 +32,9 @@ class mavManager {
     this.statusText = ''
     this.statusArmed = 0
     this.seq = 0
+    
+    // Track when this manager started for uptime calculation
+    this.startTime = Date.now()
 
     // the vehicle
     this.targetSystem = null
@@ -285,6 +288,21 @@ class mavManager {
     heartbeatMessage.systemStatus = 0
 
     this.sendData(heartbeatMessage, component)
+  }
+
+  sendSystemTime () {
+    // Send SYSTEM_TIME message for time synchronization with flight controller
+    // Following MAVProxy pattern: send Unix time and system uptime
+    const systemTimeMessage = new common.SystemTime()
+    
+    // timeUnixUsec: Unix time in microseconds since UNIX epoch
+    systemTimeMessage.timeUnixUsec = BigInt(Math.floor(Date.now() * 1000))
+    // timeBootMs: Time since system boot in milliseconds
+    systemTimeMessage.timeBootMs = Date.now() - this.startTime
+
+    console.log(`Sending SYSTEM_TIME message: timeUnixUsec=${systemTimeMessage.timeUnixUsec}, timeBootMs=${systemTimeMessage.timeBootMs}`)
+    
+    this.sendData(systemTimeMessage, minimal.MavComponent.ONBOARD_COMPUTER)
   }
 
   sendCommandAck (commandReceived, commandResult, senderSysId, senderCompId, targetComponent) {

--- a/mavlink/mavManager.test.js
+++ b/mavlink/mavManager.test.js
@@ -136,6 +136,35 @@ describe('MAVLink Functions', function () {
     })
   })
 
+  it('#systemTimeSend()', function (done) {
+    const m = new mavManager(2, '127.0.0.1', 15100)
+    const udpStream = udp.createSocket('udp4')
+
+    m.eventEmitter.on('linkready', () => {
+      m.sendSystemTime()
+    })
+
+    udpStream.on('message', (msg) => {
+      // Verify MAVLink message structure
+      assert.equal(msg[0], 0xfd) // MAVLink v2 header
+      assert.equal(msg[7], 0x02) // Message ID for SYSTEM_TIME (low byte)
+      assert.equal(msg[8], 0x00) // Message ID for SYSTEM_TIME (high byte)
+      
+      // Verify message has reasonable length
+      assert.ok(msg.length > 10)
+      
+      m.close()
+      udpStream.close()
+      done()
+    })
+
+    udpStream.send(Buffer.from([0xfd, 0x06]), 15100, '127.0.0.1', (error) => {
+      if (error) {
+        console.error(error)
+      }
+    })
+  })
+
   it('#commandAckSend()', function (done) {
     const m = new mavManager(2, '127.0.0.1', 15000)
     const udpStream = udp.createSocket('udp4')

--- a/server/flightController.js
+++ b/server/flightController.js
@@ -64,6 +64,10 @@ class FCDetails {
     // Send datastream requests to flight controller?
     this.enableDSRequest = false
 
+    // Send TIMESYNC messages to flight controller?
+    this.enableTimesync = false
+    this.lastTimesyncSent = 0
+
     // Current binlog via mavlink-router
     this.binlog = null
 
@@ -96,6 +100,7 @@ class FCDetails {
     this.enableUDPB = this.settings.value('flightcontroller.enableUDPB', true)
     this.UDPBPort = this.settings.value('flightcontroller.UDPBPort', 14550)
     this.enableDSRequest = this.settings.value('flightcontroller.enableDSRequest', false)
+    this.enableTimesync = this.settings.value('flightcontroller.enableTimesync', false)
     this.doLogging = this.settings.value('flightcontroller.doLogging', false)
     this.active = this.settings.value('flightcontroller.active', false)
 
@@ -521,18 +526,18 @@ class FCDetails {
     if (this.active && this.activeDevice && this.activeDevice.inputType === 'UART') {
       return callback(retError, this.serialDevices, this.baudRates, this.activeDevice.serial,
         this.activeDevice.baud, this.mavlinkVersions, this.activeDevice.mavversion,
-        this.active, this.enableHeartbeat, this.enableTCP, this.enableUDPB, this.UDPBPort, this.enableDSRequest, this.doLogging, this.activeDevice.udpInputPort,
+        this.active, this.enableHeartbeat, this.enableTCP, this.enableUDPB, this.UDPBPort, this.enableDSRequest, this.enableTimesync, this.doLogging, this.activeDevice.udpInputPort,
         this.inputTypes[0].value, this.inputTypes)
     } else if (this.active && this.activeDevice && this.activeDevice.inputType === 'UDP') {
       return callback(retError, this.serialDevices, this.baudRates, this.serialDevices.length > 0 ? this.serialDevices[0].value : [], this.baudRates[3].value,
         this.mavlinkVersions, this.activeDevice.mavversion, this.active, this.enableHeartbeat,
-        this.enableTCP, this.enableUDPB, this.UDPBPort, this.enableDSRequest, this.doLogging, this.activeDevice.udpInputPort,
+        this.enableTCP, this.enableUDPB, this.UDPBPort, this.enableDSRequest, this.enableTimesync, this.doLogging, this.activeDevice.udpInputPort,
         this.inputTypes[1].value, this.inputTypes)
     } else {
       // no connection
       return callback(retError, this.serialDevices, this.baudRates, this.serialDevices.length > 0 ? this.serialDevices[0].value : [],
         this.baudRates[3].value, this.mavlinkVersions, this.mavlinkVersions[1].value, this.active, this.enableHeartbeat,
-        this.enableTCP, this.enableUDPB, this.UDPBPort, this.enableDSRequest, this.doLogging, 9000, this.inputTypes[0].value, this.inputTypes)
+        this.enableTCP, this.enableUDPB, this.UDPBPort, this.enableDSRequest, this.enableTimesync, this.doLogging, 9000, this.inputTypes[0].value, this.inputTypes)
     }
   }
 
@@ -543,6 +548,15 @@ class FCDetails {
     // Send heartbeats, if they are enabled
     if(this.enableHeartbeat){
       this.m.sendHeartbeat()
+    }
+    
+    // Send timesync messages every 10 seconds, if enabled
+    if(this.enableTimesync){
+      const now = Date.now();
+      if (now - this.lastTimesyncSent >= 10000) {
+        this.m.sendSystemTime();
+        this.lastTimesyncSent = now;
+      }
     }
       // check for timeouts in serial link (ie disconnected cable or reboot)
       if (this.m && this.m.conStatusInt() === -1) {
@@ -562,7 +576,7 @@ class FCDetails {
   }
 
   startStopTelemetry (device, baud, mavversion, enableHeartbeat, enableTCP, enableUDPB, UDPBPort, enableDSRequest,
-                      doLogging, inputType, udpInputPort, callback) {
+                      enableTimesync, doLogging, inputType, udpInputPort, callback) {
     // user wants to start or stop telemetry
     // callback is (err, isSuccessful)
 
@@ -571,6 +585,7 @@ class FCDetails {
     this.enableUDPB = enableUDPB
     this.UDPBPort = UDPBPort
     this.enableDSRequest = enableDSRequest
+    this.enableTimesync = enableTimesync
     this.doLogging = doLogging
 
     if (this.m) {
@@ -653,6 +668,7 @@ class FCDetails {
       this.settings.setValue('flightcontroller.enableUDPB', this.enableUDPB)
       this.settings.setValue('flightcontroller.UDPBPort', this.UDPBPort)
       this.settings.setValue('flightcontroller.enableDSRequest', this.enableDSRequest)
+      this.settings.setValue('flightcontroller.enableTimesync', this.enableTimesync)
       this.settings.setValue('flightcontroller.doLogging', this.doLogging)
       this.settings.setValue('flightcontroller.active', this.active)
       console.log('Saved FC settings')

--- a/server/flightController.test.js
+++ b/server/flightController.test.js
@@ -1,6 +1,7 @@
 const assert = require('assert')
 const settings = require('settings-store')
 const FCManagerClass = require('./flightController')
+const { act } = require('react')
 
 describe('Flight Controller Functions', function () {
   it('#fcinit()', function () {
@@ -17,7 +18,7 @@ describe('Flight Controller Functions', function () {
     const FC = new FCManagerClass(settings)
 
     await FC.getDeviceSettings((err, devices, bauds, seldevice, selbaud, mavers, selmav,
-    active, enableHeartbeat, enableTCP, enableUDPB, UDPBPort, enableDSRequest, tlogging,
+    active, enableHeartbeat, enableTCP, enableUDPB, UDPBPort, enableDSRequest, enableTimesync, tlogging,
     udpInputPort, selInputType, inputTypes) => {
       assert.equal(err, null)
       assert.equal(devices.length, 0)
@@ -32,6 +33,7 @@ describe('Flight Controller Functions', function () {
       assert.equal(enableUDPB, true)
       assert.equal(UDPBPort, 14550)
       assert.equal(enableDSRequest, false)
+      assert.equal(enableTimesync, false)
       assert.equal(active, false)
       assert.equal(udpInputPort, 9000)
       assert.equal(selInputType, 'UART')
@@ -72,12 +74,12 @@ describe('Flight Controller Functions', function () {
     const FC = new FCManagerClass(settings)
     FC.serialDevices.push({ value: '/dev/ttyS0', label: '/dev/ttyS0', pnpId: '456' })
 
-    FC.startStopTelemetry('/dev/ttyS0', 115200, 2, false, true, false, 0, false, false,
+    FC.startStopTelemetry('/dev/ttyS0', 115200, 2, false, true, false, 0, false, false, false,
       'UART', 9000, (err, isSuccess) => {
       assert.equal(err, null)
       assert.equal(isSuccess, true)
 
-      FC.startStopTelemetry('/dev/ttyS0', 115200, 2 , false, true, false, 0, false, false,
+      FC.startStopTelemetry('/dev/ttyS0', 115200, 2 , false, true, false, 0, false, false, false,
         'UART', 9000, (err, isSuccess) => {
         assert.equal(err, null)
         assert.equal(isSuccess, false)

--- a/server/index.js
+++ b/server/index.js
@@ -996,7 +996,7 @@ app.get('/api/FCOutputs', authenticateToken, (req, res) => {
 app.get('/api/FCDetails', authenticateToken, (req, res) => {
   res.setHeader('Content-Type', 'application/json')
   fcManager.getDeviceSettings((err, devices, bauds, seldevice, selbaud, mavers, selmav,
-    active, enableHeartbeat, enableTCP, enableUDPB, UDPBPort, enableDSRequest, doLogging,
+    active, enableHeartbeat, enableTCP, enableUDPB, UDPBPort, enableDSRequest, enableTimesync, doLogging,
     udpInputPort, selInputType, inputTypes) => {
     // hacky way to pass through the
     if (!err) {
@@ -1015,6 +1015,7 @@ app.get('/api/FCDetails', authenticateToken, (req, res) => {
         enableUDPB,
         UDPBPort,
         enableDSRequest,
+        enableTimesync,
         doLogging,
         udpInputPort,
         selInputType,
@@ -1036,6 +1037,7 @@ app.get('/api/FCDetails', authenticateToken, (req, res) => {
         enableUDPB,
         UDPBPort,
         enableDSRequest,
+        enableTimesync,
         doLogging,
         udpInputPort,
         selInputType,
@@ -1075,7 +1077,7 @@ app.post('/api/resetsettings', authenticateToken, function (req, res) {
   }
 })
 
-app.post('/api/FCModify', authenticateToken, [check('device'), check('baud').isInt(), check('mavversion').isInt(), check('enableHeartbeat').isBoolean(), check('enableTCP').isBoolean(), check('enableUDPB').isBoolean(), check('UDPBPort').isPort(), check('enableDSRequest').isBoolean(), check('doLogging').isBoolean()], function (req, res) {
+app.post('/api/FCModify', authenticateToken, [check('device'), check('baud').isInt(), check('mavversion').isInt(), check('enableHeartbeat').isBoolean(), check('enableTCP').isBoolean(), check('enableUDPB').isBoolean(), check('UDPBPort').isPort(), check('enableDSRequest').isBoolean(), check('enableTimesync').isBoolean(), check('doLogging').isBoolean()], function (req, res) {
   // User wants to start/stop FC telemetry
   const errors = validationResult(req)
   if (!errors.isEmpty()) {
@@ -1085,7 +1087,7 @@ app.post('/api/FCModify', authenticateToken, [check('device'), check('baud').isI
 
   fcManager.startStopTelemetry(req.body.device, req.body.baud, req.body.mavversion, req.body.enableHeartbeat,
                                req.body.enableTCP, req.body.enableUDPB, req.body.UDPBPort, req.body.enableDSRequest,
-                               req.body.doLogging, req.body.inputType, req.body.udpInputPort, (err, isSuccess) => {
+                               req.body.enableTimesync, req.body.doLogging, req.body.inputType, req.body.udpInputPort, (err, isSuccess) => {
     if (!err) {
       res.setHeader('Content-Type', 'application/json')
       // console.log(isSuccess);

--- a/src/flightcontroller.jsx
+++ b/src/flightcontroller.jsx
@@ -32,6 +32,7 @@ class FCPage extends basePage {
       enableUDPB: false,
       UDPBPort: 14550,
       enableDSRequest: false,
+      enableTimesync: false,
       doLogging: false
     }
 
@@ -87,6 +88,10 @@ class FCPage extends basePage {
     this.setState({ enableDSRequest: event.target.checked });
   }
 
+  handleTimesyncChange = (event) => {
+    this.setState({ enableTimesync: event.target.checked });
+  }
+
   handleUseUDPBChange = (event) => {
     this.setState({ enableUDPB: event.target.checked });
   }
@@ -115,6 +120,7 @@ class FCPage extends basePage {
         enableUDPB: this.state.enableUDPB,
         UDPBPort: this.state.UDPBPort,
         enableDSRequest: this.state.enableDSRequest,
+        enableTimesync: this.state.enableTimesync,
         doLogging: this.state.doLogging
       })
     }).then(response => response.json()).then(state => { this.setState(state) });
@@ -322,6 +328,14 @@ class FCPage extends basePage {
               <label className="col-sm-5 col-form-label">Enable MAVLink heartbeats</label>
               <div className="col-sm-7">
               <input type="checkbox" checked={this.state.enableHeartbeat} disabled={this.state.telemetryStatus} onChange={this.handleUseHeartbeatChange} />
+              </div>
+            </div>
+            <br />
+            <p><i>Send SYSTEM_TIME messages to synchronize flight controller clock (every 10 seconds)</i></p>
+            <div className="form-group row" style={{ marginBottom: '5px' }}>
+              <label className="col-sm-5 col-form-label">Enable SYSTEM_TIME messages</label>
+              <div className="col-sm-7">
+              <input type="checkbox" checked={this.state.enableTimesync} disabled={this.state.telemetryStatus} onChange={this.handleTimesyncChange} />
               </div>
             </div>
             <br />


### PR DESCRIPTION
Add option to have flight controller synchonise the the companion computer's time, using https://ardupilot.org/mavproxy/docs/modules/systemtime.html as an exemplar

So, if the flight controller does not have a GPS connection is can get the time from this.