### PR TITLE
Flight Controller: fix crash loop when startLink fails on startup

### DIFF
--- a/server/flightController.js
+++ b/server/flightController.js
@@ -117,8 +117,9 @@ class FCDetails {
                   console.log("Can't open found FC " + this.activeDevice.serial + ', resetting link')
                   this.activeDevice = null
                   this.active = false
+                } else {
+                  this.startInterval()
                 }
-                this.startInterval()
               })
               break
             }
@@ -134,8 +135,9 @@ class FCDetails {
               console.log("Can't open UDP port " + this.activeDevice.udpInputPort + ', resetting link')
               this.activeDevice = null
               this.active = false
+            } else {
+              this.startInterval()
             }
-            this.startInterval()
           })
         }
       })
@@ -546,12 +548,12 @@ class FCDetails {
     this.intervalObj = setInterval(() => {
     
     // Send heartbeats, if they are enabled
-    if(this.enableHeartbeat){
+    if(this.enableHeartbeat && this.m){
       this.m.sendHeartbeat()
     }
-    
+
     // Send timesync messages every 10 seconds, if enabled
-    if(this.enableTimesync){
+    if(this.enableTimesync && this.m){
       const now = Date.now();
       if (now - this.lastTimesyncSent >= 10000) {
         this.m.sendSystemTime();


### PR DESCRIPTION
This fixes a potential crash loop in cases where the connection between the Rpanion and the flight controller isn't working and the user has enabled either the, "Enable MAVLink heartbeats" or "Enable SYSTEM_TIME messages" on the Flight Controller page.

I don't think it's actually possible for the failure to happen for most users.  It can only happen if there's an issue with the .deb package (which is what happened to me).

This has been lightly tested on an RPI CM5 to confirm everything works as expected after the change.

Here's Claude's explanation:

 If telemetry was enabled last time Rpanion ran, it tries to reconnect to the saved flight-controller link automatically on startup. If that reconnect attempt fails for any reason, Rpanion was still starting its 1-second heartbeat timer regardless — and that timer immediately tried to send a heartbeat through a connection that was never actually opened, which threw an unhandled exception. Rpanion treats any unhandled exception as fatal by design (so it restarts into a clean state rather than keep running broken) — so this one bad line took the entire server down, not just telemetry. Since the same failure happens again on the next boot, it crash-loops indefinitely (we saw restart counts in the hundreds).

How we found it: a test build was accidentally missing the mavlink-routerd binary it depends on, which made the startup reconnect fail every time — surfacing the bug on every single boot. That specific trigger was a packaging accident, not something a real install should hit, but the underlying bug is general: any reason the link fails to open at startup (a bad serial device, a permissions issue, anything) would hit the exact same crash.