### PR TITLE
Cloud upload fixes and enhancements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,8 @@ yarn-debug.log*
 yarn-error.log*
 /package-lock.json
 
-./config/settings.json
+/config/settings.json
+/config/ssh
 settingsTest.json
 /logs
 /flightlogs

--- a/server/cloudUpload.js
+++ b/server/cloudUpload.js
@@ -11,7 +11,11 @@ const logpaths = require('./paths.js')
 // logpaths.sshDir instead of the conventional ~/.ssh/.
 const SSH_KEY_PATH = path.join(logpaths.sshDir, 'id_rsa')
 const KNOWN_HOSTS_PATH = path.join(logpaths.sshDir, 'known_hosts')
-const SSH_SHELL = `ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=${KNOWN_HOSTS_PATH} -i ${SSH_KEY_PATH}`
+// ServerAlive* detects a dead connection (e.g. dropped VPN/wifi) within ~45s
+// instead of leaving rsync hung indefinitely on a socket that'll never reply.
+const SSH_SHELL = `ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=${KNOWN_HOSTS_PATH} -o ServerAliveInterval=15 -o ServerAliveCountMax=3 -i ${SSH_KEY_PATH}`
+// Backstop for hangs ServerAlive can't see (e.g. remote stuck on disk I/O).
+const RSYNC_TIMEOUT_MINUTES = 10
 
 class cloudUpload {
   constructor (settings) {
@@ -44,22 +48,22 @@ class cloudUpload {
         return
       }
       console.log('Upload interval')
-      if (this.options.uploadLogs) {
-        if (this.rsyncPidLogs) {
-          this.rsyncPidLogs.kill()
-        }
+      // Skip a category that's still mid-sync - large media can take longer than one interval.
+      if (this.options.uploadLogs && !this.isRunning(this.rsyncPidLogs)) {
         this.rsyncPidLogs = this.runRsync(this.logsFolder, this.options.binUploadLink, ['*.bin'],
           (error) => { this.lastErrorLogs = error })
       }
-      if (this.options.uploadMedia) {
+      if (this.options.uploadMedia && !this.isRunning(this.rsyncPidMedia)) {
         // Own subfolder on the remote end so media doesn't mix in with logs
-        if (this.rsyncPidMedia) {
-          this.rsyncPidMedia.kill()
-        }
         this.rsyncPidMedia = this.runRsync(this.mediaFolder, this.options.binUploadLink + '/media', [],
           (error) => { this.lastErrorMedia = error })
       }
     }, this.options.interval * 1000)
+  }
+
+  // True if pid is a still-running child process (rsync.execute() return value).
+  isRunning (pid) {
+    return !!pid && pid.exitCode === null
   }
 
   // Syncs source/ to destination over ssh. onDone(error) fires once rsync
@@ -85,8 +89,10 @@ class cloudUpload {
       outputBuffer += data.toString()
       console.log('rsync:', data.toString().trim())
     }
+    let timeoutHandle
     // 3rd arg is never called (same library bug) but must be a function.
-    return rsync.execute((error, code, cmd) => {
+    const pid = rsync.execute((error, code, cmd) => {
+      clearTimeout(timeoutHandle)
       if (error) {
         console.log(error)
         console.log(code)
@@ -94,6 +100,13 @@ class cloudUpload {
       }
       onDone(code === 0 ? '' : (outputBuffer.trim() || `rsync exited with code ${code}`))
     }, captureOutput, captureOutput)
+
+    timeoutHandle = setTimeout(() => {
+      console.log(`rsync timed out after ${RSYNC_TIMEOUT_MINUTES} minutes, killing:`, source)
+      pid.kill()
+    }, RSYNC_TIMEOUT_MINUTES * 60 * 1000)
+
+    return pid
   }
 
   quitting () {
@@ -174,7 +187,7 @@ class cloudUpload {
     if (active.length === 0) {
       return 'Nothing selected to upload'
     }
-    if (active.some(a => a.pid && a.pid.exitCode === null)) {
+    if (active.some(a => this.isRunning(a.pid))) {
       return 'Running'
     }
     const failed = active.filter(a => a.error)

--- a/server/cloudUpload.js
+++ b/server/cloudUpload.js
@@ -18,7 +18,7 @@ const SSH_SHELL = `ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=${KNOWN
 const RSYNC_TIMEOUT_MINUTES = 10
 
 class cloudUpload {
-  constructor (settings) {
+  constructor (settings, fcManager) {
     this.options = {
       // the interval of sync, every 20 sec
       interval: 20
@@ -34,18 +34,23 @@ class cloudUpload {
 
     // load settings
     this.settings = settings
+    this.fcManager = fcManager
     this.options.uploadEnabled = this.settings.value('cloud.uploadEnabled', false)
     this.options.uploadLogs = this.settings.value('cloud.uploadLogs', true)
     this.options.uploadMedia = this.settings.value('cloud.uploadMedia', true)
     this.options.binUploadLink = this.settings.value('cloud.binUploadLink', '')
     this.options.syncDeletions = this.settings.value('cloud.syncDeletions', false)
     this.options.windowsDestination = this.settings.value('cloud.windowsDestination', false)
+    this.options.onlyWhenDisarmed = this.settings.value('cloud.onlyWhenDisarmed', false)
 
     this.ensureSshKey()
 
     // interval for upload checks
     this.intervalObj = setInterval(() => {
       if (!this.options.uploadEnabled) {
+        return
+      }
+      if (this.options.onlyWhenDisarmed && this.getVehicleArmedState() !== 'disarmed') {
         return
       }
       console.log('Upload interval')
@@ -65,6 +70,16 @@ class cloudUpload {
   // True if pid is a still-running child process (rsync.execute() return value).
   isRunning (pid) {
     return !!pid && pid.exitCode === null
+  }
+
+  // 'armed', 'disarmed', or 'unknown' if there's no live telemetry to trust
+  // (no link, or none within the last 5s - see mavManager.conStatusInt()).
+  // Unknown is treated as unsafe by callers, not assumed disarmed.
+  getVehicleArmedState () {
+    if (!this.fcManager || !this.fcManager.m || this.fcManager.m.conStatusInt() !== 1) {
+      return 'unknown'
+    }
+    return this.fcManager.m.statusArmed ? 'armed' : 'disarmed'
   }
 
   // Syncs source/ to destination over ssh. onDone(error) fires once rsync
@@ -161,10 +176,11 @@ class cloudUpload {
       console.error('Failed to read SSH public keys:', e.message)
     }
     return callback(this.options.uploadEnabled, this.options.uploadLogs, this.options.uploadMedia,
-      this.options.binUploadLink, this.options.syncDeletions, this.options.windowsDestination, pubkey)
+      this.options.binUploadLink, this.options.syncDeletions, this.options.windowsDestination,
+      this.options.onlyWhenDisarmed, this.getVehicleArmedState(), pubkey)
   }
 
-  setSettingsBin (uploadEnabled, uploadLogs, uploadMedia, binUploadLink, syncDeletions, windowsDestination) {
+  setSettingsBin (uploadEnabled, uploadLogs, uploadMedia, binUploadLink, syncDeletions, windowsDestination, onlyWhenDisarmed) {
     // save new settings
     this.options.uploadEnabled = uploadEnabled
     this.options.uploadLogs = uploadLogs
@@ -172,6 +188,7 @@ class cloudUpload {
     this.options.binUploadLink = binUploadLink
     this.options.syncDeletions = syncDeletions
     this.options.windowsDestination = windowsDestination
+    this.options.onlyWhenDisarmed = onlyWhenDisarmed
 
     // and save to file
     try {
@@ -181,6 +198,7 @@ class cloudUpload {
       this.settings.setValue('cloud.binUploadLink', this.options.binUploadLink)
       this.settings.setValue('cloud.syncDeletions', this.options.syncDeletions)
       this.settings.setValue('cloud.windowsDestination', this.options.windowsDestination)
+      this.settings.setValue('cloud.onlyWhenDisarmed', this.options.onlyWhenDisarmed)
       console.log('Saved Cloud Upload settings')
     } catch (e) {
       console.log(e)
@@ -192,6 +210,15 @@ class cloudUpload {
   conStatusStr () {
     if (!this.options.uploadEnabled) {
       return 'Disabled'
+    }
+    if (this.options.onlyWhenDisarmed) {
+      const armedState = this.getVehicleArmedState()
+      if (armedState === 'armed') {
+        return 'Paused - vehicle armed'
+      }
+      if (armedState === 'unknown') {
+        return 'Paused - vehicle state unknown'
+      }
     }
     const active = []
     if (this.options.uploadLogs) active.push({ pid: this.rsyncPidLogs, error: this.lastErrorLogs })

--- a/server/cloudUpload.js
+++ b/server/cloudUpload.js
@@ -54,17 +54,27 @@ class cloudUpload {
         return
       }
       console.log('Upload interval')
-      // Skip a category that's still mid-sync - large media can take longer than one interval.
-      if (this.options.uploadLogs && !this.isRunning(this.rsyncPidLogs)) {
-        this.rsyncPidLogs = this.runRsync(this.logsFolder, this.options.binUploadLink, ['*.bin'],
-          (error) => { this.lastErrorLogs = error })
-      }
-      if (this.options.uploadMedia && !this.isRunning(this.rsyncPidMedia)) {
-        // Own subfolder on the remote end so media doesn't mix in with logs
-        this.rsyncPidMedia = this.runRsync(this.mediaFolder, this.options.binUploadLink + '/media', [],
-          (error) => { this.lastErrorMedia = error })
-      }
+      this.syncNow()
     }, this.options.interval * 1000)
+  }
+
+  // Starts a sync for each selected category, ignoring uploadEnabled and
+  // onlyWhenDisarmed - used by both the interval above and the "Upload Now"
+  // button, which needs to work regardless of those settings.
+  syncNow () {
+    if (!this.options.binUploadLink) {
+      return
+    }
+    // Skip a category that's still mid-sync - large media can take longer than one interval.
+    if (this.options.uploadLogs && !this.isRunning(this.rsyncPidLogs)) {
+      this.rsyncPidLogs = this.runRsync(this.logsFolder, this.options.binUploadLink, ['*.bin'],
+        (error) => { this.lastErrorLogs = error })
+    }
+    if (this.options.uploadMedia && !this.isRunning(this.rsyncPidMedia)) {
+      // Own subfolder on the remote end so media doesn't mix in with logs
+      this.rsyncPidMedia = this.runRsync(this.mediaFolder, this.options.binUploadLink + '/media', [],
+        (error) => { this.lastErrorMedia = error })
+    }
   }
 
   // True if pid is a still-running child process (rsync.execute() return value).
@@ -117,14 +127,21 @@ class cloudUpload {
     }
     let timeoutHandle
     // 3rd arg is never called (same library bug) but must be a function.
+    // This callback runs outside any request's call stack, so an uncaught
+    // throw here would hit the process-wide handler and take the whole
+    // server down - catch defensively rather than let that happen.
     const pid = rsync.execute((error, code, cmd) => {
-      clearTimeout(timeoutHandle)
-      if (error) {
-        console.log(error)
-        console.log(code)
-        console.log(cmd)
+      try {
+        clearTimeout(timeoutHandle)
+        if (error) {
+          console.log(error)
+          console.log(code)
+          console.log(cmd)
+        }
+        onDone(code === 0 ? '' : (outputBuffer.trim() || `rsync exited with code ${code}`))
+      } catch (e) {
+        console.error('Error handling rsync completion:', e)
       }
-      onDone(code === 0 ? '' : (outputBuffer.trim() || `rsync exited with code ${code}`))
     }, captureOutput, captureOutput)
 
     timeoutHandle = setTimeout(() => {
@@ -207,7 +224,23 @@ class cloudUpload {
 
   // Single combined status covering whichever of Logs/Media are selected -
   // "worst wins": an error beats running, running beats success/waiting.
+  // A running/finished sync is reported regardless of uploadEnabled, since
+  // "Upload Now" can trigger one even while automatic uploads are off.
   conStatusStr () {
+    const active = []
+    if (this.options.uploadLogs) active.push({ pid: this.rsyncPidLogs, error: this.lastErrorLogs })
+    if (this.options.uploadMedia) active.push({ pid: this.rsyncPidMedia, error: this.lastErrorMedia })
+
+    if (active.some(a => this.isRunning(a.pid))) {
+      return 'Running'
+    }
+    const failed = active.filter(a => a.error)
+    if (failed.length > 0) {
+      return 'Error: ' + failed.map(a => a.error).join(' / ')
+    }
+    if (active.length > 0 && active.every(a => a.pid && a.pid.exitCode === 0)) {
+      return 'Success'
+    }
     if (!this.options.uploadEnabled) {
       return 'Disabled'
     }
@@ -220,22 +253,8 @@ class cloudUpload {
         return 'Paused - vehicle state unknown'
       }
     }
-    const active = []
-    if (this.options.uploadLogs) active.push({ pid: this.rsyncPidLogs, error: this.lastErrorLogs })
-    if (this.options.uploadMedia) active.push({ pid: this.rsyncPidMedia, error: this.lastErrorMedia })
-
     if (active.length === 0) {
       return 'Nothing selected to upload'
-    }
-    if (active.some(a => this.isRunning(a.pid))) {
-      return 'Running'
-    }
-    const failed = active.filter(a => a.error)
-    if (failed.length > 0) {
-      return 'Error: ' + failed.map(a => a.error).join(' / ')
-    }
-    if (active.every(a => a.pid && a.pid.exitCode === 0)) {
-      return 'Success'
     }
     return 'Waiting for first run'
   }

--- a/server/cloudUpload.js
+++ b/server/cloudUpload.js
@@ -6,9 +6,12 @@ const { execSync } = require('child_process')
 const logpaths = require('./paths.js')
 
 // The rpanion service account is a system user with no usable home directory
-// (HOME=/nonexistent), so the upload SSH keypair is kept under logpaths.sshDir
-// instead of the conventional ~/.ssh/.
+// (HOME=/nonexistent), so the upload SSH keypair - and known_hosts, which ssh
+// writes to even with StrictHostKeyChecking=no - are kept under
+// logpaths.sshDir instead of the conventional ~/.ssh/.
 const SSH_KEY_PATH = path.join(logpaths.sshDir, 'id_rsa')
+const KNOWN_HOSTS_PATH = path.join(logpaths.sshDir, 'known_hosts')
+const SSH_SHELL = `ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=${KNOWN_HOSTS_PATH} -i ${SSH_KEY_PATH}`
 
 class cloudUpload {
   constructor (settings) {
@@ -17,13 +20,19 @@ class cloudUpload {
       interval: 20
     }
 
-    this.topfolder = logpaths.flightsLogsDir
+    this.logsFolder = logpaths.flightsLogsDir
+    this.mediaFolder = logpaths.mediaDir
 
-    this.rsyncPid = null
+    this.rsyncPidLogs = null
+    this.rsyncPidMedia = null
+    this.lastErrorLogs = ''
+    this.lastErrorMedia = ''
 
     // load settings
     this.settings = settings
-    this.options.doBinUpload = this.settings.value('cloud.doBinUpload', false)
+    this.options.uploadEnabled = this.settings.value('cloud.uploadEnabled', false)
+    this.options.uploadLogs = this.settings.value('cloud.uploadLogs', true)
+    this.options.uploadMedia = this.settings.value('cloud.uploadMedia', true)
     this.options.binUploadLink = this.settings.value('cloud.binUploadLink', '')
     this.options.syncDeletions = this.settings.value('cloud.syncDeletions', false)
 
@@ -31,41 +40,68 @@ class cloudUpload {
 
     // interval for upload checks
     this.intervalObj = setInterval(() => {
+      if (!this.options.uploadEnabled) {
+        return
+      }
       console.log('Upload interval')
-      if (this.options.doBinUpload) {
-        console.log('Doing binfile')
-        const rsync = new Rsync()
-          .shell(`ssh -o StrictHostKeyChecking=no -i ${SSH_KEY_PATH}`)
-          .flags('avzP')
-          .source(this.topfolder + '/')
-          .destination(this.options.binUploadLink)
-          .include('*.bin')
-
-        if (this.options.syncDeletions) {
-          rsync.set('delete')
+      if (this.options.uploadLogs) {
+        if (this.rsyncPidLogs) {
+          this.rsyncPidLogs.kill()
         }
-
-        // Kill old rsync and create new one
-        if (this.rsyncPid) {
-          this.rsyncPid.kill()
+        this.rsyncPidLogs = this.runRsync(this.logsFolder, this.options.binUploadLink, ['*.bin'],
+          (error) => { this.lastErrorLogs = error })
+      }
+      if (this.options.uploadMedia) {
+        // Own subfolder on the remote end so media doesn't mix in with logs
+        if (this.rsyncPidMedia) {
+          this.rsyncPidMedia.kill()
         }
-
-        this.rsyncPid = rsync.execute(function (error, code, cmd) {
-          // we're done
-          // this.rsyncPid = null
-          if (error) {
-            console.log(error)
-            console.log(code)
-            console.log(cmd)
-          }
-        })
+        this.rsyncPidMedia = this.runRsync(this.mediaFolder, this.options.binUploadLink + '/media', [],
+          (error) => { this.lastErrorMedia = error })
       }
     }, this.options.interval * 1000)
   }
 
+  // Syncs source/ to destination over ssh. onDone(error) fires once rsync
+  // finishes, '' on success. One output handler covers both stdout/stderr -
+  // the installed rsync package silently never calls a separate stderr
+  // callback (bug in rsync.js:474).
+  runRsync (source, destination, includes, onDone) {
+    console.log('Syncing', source, 'to', destination)
+    const rsync = new Rsync()
+      .shell(SSH_SHELL)
+      .flags('avzP')
+      .source(source + '/')
+      .destination(destination)
+
+    includes.forEach(pattern => rsync.include(pattern))
+
+    if (this.options.syncDeletions) {
+      rsync.set('delete')
+    }
+
+    let outputBuffer = ''
+    const captureOutput = (data) => {
+      outputBuffer += data.toString()
+      console.log('rsync:', data.toString().trim())
+    }
+    // 3rd arg is never called (same library bug) but must be a function.
+    return rsync.execute((error, code, cmd) => {
+      if (error) {
+        console.log(error)
+        console.log(code)
+        console.log(cmd)
+      }
+      onDone(code === 0 ? '' : (outputBuffer.trim() || `rsync exited with code ${code}`))
+    }, captureOutput, captureOutput)
+  }
+
   quitting () {
-    if (this.rsyncPid) {
-      this.rsyncPid.kill()
+    if (this.rsyncPidLogs) {
+      this.rsyncPidLogs.kill()
+    }
+    if (this.rsyncPidMedia) {
+      this.rsyncPidMedia.kill()
     }
     clearInterval(this.intervalObj)
   }
@@ -100,40 +136,53 @@ class cloudUpload {
     } catch (e) {
       console.error('Failed to read SSH public keys:', e.message)
     }
-    return callback(this.options.doBinUpload,
+    return callback(this.options.uploadEnabled, this.options.uploadLogs, this.options.uploadMedia,
       this.options.binUploadLink, this.options.syncDeletions, pubkey)
   }
 
-  setSettingsBin (doBinUpload, binUploadLink, syncDeletions) {
+  setSettingsBin (uploadEnabled, uploadLogs, uploadMedia, binUploadLink, syncDeletions) {
     // save new settings
-    this.options.doBinUpload = doBinUpload
+    this.options.uploadEnabled = uploadEnabled
+    this.options.uploadLogs = uploadLogs
+    this.options.uploadMedia = uploadMedia
     this.options.binUploadLink = binUploadLink
     this.options.syncDeletions = syncDeletions
 
     // and save to file
     try {
-      this.settings.setValue('cloud.doBinUpload', this.options.doBinUpload)
+      this.settings.setValue('cloud.uploadEnabled', this.options.uploadEnabled)
+      this.settings.setValue('cloud.uploadLogs', this.options.uploadLogs)
+      this.settings.setValue('cloud.uploadMedia', this.options.uploadMedia)
       this.settings.setValue('cloud.binUploadLink', this.options.binUploadLink)
       this.settings.setValue('cloud.syncDeletions', this.options.syncDeletions)
-      console.log('Saved Cloud Bin settings')
+      console.log('Saved Cloud Upload settings')
     } catch (e) {
       console.log(e)
     }
   }
 
-  // Get the rsync status for binlog
-  conStatusBinStr () {
-    if (!this.options.doBinUpload) {
+  // Single combined status covering whichever of Logs/Media are selected -
+  // "worst wins": an error beats running, running beats success/waiting.
+  conStatusStr () {
+    if (!this.options.uploadEnabled) {
       return 'Disabled'
     }
-    if (this.rsyncPid) {
-      if (this.rsyncPid.exitCode === null) {
-        return 'Running'
-      } else if (this.rsyncPid.exitCode === 0) {
-        return 'Success'
-      } else {
-        return 'Error running Rsync'
-      }
+    const active = []
+    if (this.options.uploadLogs) active.push({ pid: this.rsyncPidLogs, error: this.lastErrorLogs })
+    if (this.options.uploadMedia) active.push({ pid: this.rsyncPidMedia, error: this.lastErrorMedia })
+
+    if (active.length === 0) {
+      return 'Nothing selected to upload'
+    }
+    if (active.some(a => a.pid && a.pid.exitCode === null)) {
+      return 'Running'
+    }
+    const failed = active.filter(a => a.error)
+    if (failed.length > 0) {
+      return 'Error: ' + failed.map(a => a.error).join(' / ')
+    }
+    if (active.every(a => a.pid && a.pid.exitCode === 0)) {
+      return 'Success'
     }
     return 'Waiting for first run'
   }

--- a/server/cloudUpload.js
+++ b/server/cloudUpload.js
@@ -1,10 +1,14 @@
 const Rsync = require('rsync')
 const path = require('path')
 const fs = require('fs')
-const os = require('os')
 const { execSync } = require('child_process')
 
 const logpaths = require('./paths.js')
+
+// The rpanion service account is a system user with no usable home directory
+// (HOME=/nonexistent), so the upload SSH keypair is kept under logpaths.sshDir
+// instead of the conventional ~/.ssh/.
+const SSH_KEY_PATH = path.join(logpaths.sshDir, 'id_rsa')
 
 class cloudUpload {
   constructor (settings) {
@@ -23,13 +27,7 @@ class cloudUpload {
     this.options.binUploadLink = this.settings.value('cloud.binUploadLink', '')
     this.options.syncDeletions = this.settings.value('cloud.syncDeletions', false)
 
-    // create ssh key if none already
-    if (fs.existsSync(os.homedir() + '/.ssh/')) {
-      const files = fs.readdirSync(os.homedir() + '/.ssh/')
-      if (files.length === 0) {
-        execSync('< /dev/zero ssh-keygen -q -N ""')
-      }
-    }
+    this.ensureSshKey()
 
     // interval for upload checks
     this.intervalObj = setInterval(() => {
@@ -37,7 +35,7 @@ class cloudUpload {
       if (this.options.doBinUpload) {
         console.log('Doing binfile')
         const rsync = new Rsync()
-          .shell('ssh -o StrictHostKeyChecking=no')
+          .shell(`ssh -o StrictHostKeyChecking=no -i ${SSH_KEY_PATH}`)
           .flags('avzP')
           .source(this.topfolder + '/')
           .destination(this.options.binUploadLink)
@@ -72,22 +70,35 @@ class cloudUpload {
     clearInterval(this.intervalObj)
   }
 
+  // Create the upload SSH keypair under logpaths.sshDir if it doesn't
+  // already exist. Errors are caught and logged rather than thrown, so a
+  // failure here can't take down the caller (e.g. the /api/cloudinfo route).
+  ensureSshKey () {
+    try {
+      fs.mkdirSync(logpaths.sshDir, { recursive: true })
+      fs.chmodSync(logpaths.sshDir, 0o700)
+      if (!fs.existsSync(SSH_KEY_PATH)) {
+        execSync(`ssh-keygen -q -N "" -f ${SSH_KEY_PATH}`)
+        console.log('Created new SSH keypair for cloud upload:', SSH_KEY_PATH)
+      }
+    } catch (e) {
+      console.error('Failed to create SSH key for cloud upload:', e.message)
+    }
+  }
+
   getSettings (callback) {
     // get current settings and pubkey(s)
     const pubkey = []
-    if (fs.existsSync(os.homedir() + '/.ssh/')) {
-      const files = fs.readdirSync(os.homedir() + '/.ssh/')
+    this.ensureSshKey()
+    try {
+      const files = fs.readdirSync(logpaths.sshDir)
       files.forEach(file => {
         if (path.extname(file) === '.pub') {
-          pubkey.push(fs.readFileSync(os.homedir() + '/.ssh/' + file, { encoding: 'utf8', flag: 'r' }))
+          pubkey.push(fs.readFileSync(path.join(logpaths.sshDir, file), { encoding: 'utf8', flag: 'r' }))
         }
       })
-    }
-    // if pubKey is empty, create a new default ssh key
-    if (pubkey.length === 0) {
-      console.log('No SSH keys found, creating new one')
-      execSync('< /dev/zero ssh-keygen -q -N ""')
-      pubkey.push(fs.readFileSync(os.homedir() + '/.ssh/id_rsa.pub', { encoding: 'utf8', flag: 'r' }))
+    } catch (e) {
+      console.error('Failed to read SSH public keys:', e.message)
     }
     return callback(this.options.doBinUpload,
       this.options.binUploadLink, this.options.syncDeletions, pubkey)

--- a/server/cloudUpload.js
+++ b/server/cloudUpload.js
@@ -39,6 +39,7 @@ class cloudUpload {
     this.options.uploadMedia = this.settings.value('cloud.uploadMedia', true)
     this.options.binUploadLink = this.settings.value('cloud.binUploadLink', '')
     this.options.syncDeletions = this.settings.value('cloud.syncDeletions', false)
+    this.options.windowsDestination = this.settings.value('cloud.windowsDestination', false)
 
     this.ensureSshKey()
 
@@ -74,9 +75,19 @@ class cloudUpload {
     console.log('Syncing', source, 'to', destination)
     const rsync = new Rsync()
       .shell(SSH_SHELL)
-      .flags('avzP')
       .source(source + '/')
       .destination(destination)
+
+    if (this.options.windowsDestination) {
+      // rtvP not -a(rchive): -a also preserves Unix perms/owner (-p -o -g),
+      // which Windows destinations reject. No -z either - known to corrupt
+      // the protocol stream on some Windows rsync builds.
+      rsync.flags('rtvP')
+      // Explicitly set broad perms instead of preserving source perms.
+      rsync.set('chmod', 'ugo=rwX')
+    } else {
+      rsync.flags('avzP')
+    }
 
     includes.forEach(pattern => rsync.include(pattern))
 
@@ -150,16 +161,17 @@ class cloudUpload {
       console.error('Failed to read SSH public keys:', e.message)
     }
     return callback(this.options.uploadEnabled, this.options.uploadLogs, this.options.uploadMedia,
-      this.options.binUploadLink, this.options.syncDeletions, pubkey)
+      this.options.binUploadLink, this.options.syncDeletions, this.options.windowsDestination, pubkey)
   }
 
-  setSettingsBin (uploadEnabled, uploadLogs, uploadMedia, binUploadLink, syncDeletions) {
+  setSettingsBin (uploadEnabled, uploadLogs, uploadMedia, binUploadLink, syncDeletions, windowsDestination) {
     // save new settings
     this.options.uploadEnabled = uploadEnabled
     this.options.uploadLogs = uploadLogs
     this.options.uploadMedia = uploadMedia
     this.options.binUploadLink = binUploadLink
     this.options.syncDeletions = syncDeletions
+    this.options.windowsDestination = windowsDestination
 
     // and save to file
     try {
@@ -168,6 +180,7 @@ class cloudUpload {
       this.settings.setValue('cloud.uploadMedia', this.options.uploadMedia)
       this.settings.setValue('cloud.binUploadLink', this.options.binUploadLink)
       this.settings.setValue('cloud.syncDeletions', this.options.syncDeletions)
+      this.settings.setValue('cloud.windowsDestination', this.options.windowsDestination)
       console.log('Saved Cloud Upload settings')
     } catch (e) {
       console.log(e)

--- a/server/cloudUpload.test.js
+++ b/server/cloudUpload.test.js
@@ -59,4 +59,29 @@ describe('Cloud Upload Functions', function () {
 
     clearInterval(cloudVar.intervalObj)
   })
+
+  it('#cloudsyncnownodest()', function () {
+    // syncNow() should be a no-op with no destination configured
+    settings.clear()
+    const cloudVar = new CloudTest(settings)
+
+    cloudVar.syncNow()
+    assert.equal(cloudVar.rsyncPidLogs, null)
+    assert.equal(cloudVar.rsyncPidMedia, null)
+
+    clearInterval(cloudVar.intervalObj)
+  })
+
+  it('#cloudstatusregardlessofenabled()', function () {
+    // "Upload Now" can trigger a sync even while uploadEnabled is off, so
+    // its status should be reported regardless of that setting
+    settings.clear()
+    const cloudVar = new CloudTest(settings)
+
+    cloudVar.options.uploadLogs = true
+    cloudVar.rsyncPidLogs = { exitCode: null }
+    assert.equal(cloudVar.conStatusStr(), 'Running')
+
+    clearInterval(cloudVar.intervalObj)
+  })
 })

--- a/server/cloudUpload.test.js
+++ b/server/cloudUpload.test.js
@@ -23,12 +23,39 @@ describe('Cloud Upload Functions', function () {
     assert.equal(cloudVar.options.uploadEnabled, false)
     assert.equal(cloudVar.conStatusStr(), 'Disabled')
 
-    cloudVar.setSettingsBin(true, true, true, 'tmpfolder', false, false)
+    cloudVar.setSettingsBin(true, true, true, 'tmpfolder', false, false, false)
 
     assert.equal(cloudVar.conStatusStr(), 'Waiting for first run')
     assert.equal(cloudVar.options.uploadEnabled, true)
     assert.equal(cloudVar.options.uploadLogs, true)
     assert.equal(cloudVar.options.uploadMedia, true)
+
+    clearInterval(cloudVar.intervalObj)
+  })
+
+  it('#cloudpausedwhenarmed()', function () {
+    settings.clear()
+    const fcManager = { m: { statusArmed: 1, conStatusInt: () => 1 } }
+    const cloudVar = new CloudTest(settings, fcManager)
+
+    cloudVar.setSettingsBin(true, true, true, 'tmpfolder', false, false, true)
+    assert.equal(cloudVar.conStatusStr(), 'Paused - vehicle armed')
+
+    fcManager.m.statusArmed = 0
+    assert.equal(cloudVar.conStatusStr(), 'Waiting for first run')
+
+    clearInterval(cloudVar.intervalObj)
+  })
+
+  it('#cloudpausedwhenunknown()', function () {
+    // "Only upload while disarmed" must treat an unknown vehicle state (no
+    // live telemetry) as unsafe, not assume disarmed.
+    settings.clear()
+    const cloudVar = new CloudTest(settings) // no fcManager - state is unknown
+
+    cloudVar.setSettingsBin(true, true, true, 'tmpfolder', false, false, true)
+    assert.equal(cloudVar.getVehicleArmedState(), 'unknown')
+    assert.equal(cloudVar.conStatusStr(), 'Paused - vehicle state unknown')
 
     clearInterval(cloudVar.intervalObj)
   })

--- a/server/cloudUpload.test.js
+++ b/server/cloudUpload.test.js
@@ -8,7 +8,7 @@ describe('Cloud Upload Functions', function () {
     const cloudVar = new CloudTest(settings)
 
     // check initial status
-    assert.equal(cloudVar.options.doBinUpload, false)
+    assert.equal(cloudVar.options.uploadEnabled, false)
     assert.equal(cloudVar.options.syncDeletions, false)
 
     clearInterval(cloudVar.intervalObj)
@@ -20,13 +20,15 @@ describe('Cloud Upload Functions', function () {
     const cloudVar = new CloudTest(settings)
 
     // check initial status
-    assert.equal(cloudVar.options.doBinUpload, false)
-    assert.equal(cloudVar.conStatusBinStr(), 'Disabled')
+    assert.equal(cloudVar.options.uploadEnabled, false)
+    assert.equal(cloudVar.conStatusStr(), 'Disabled')
 
-    cloudVar.setSettingsBin(true, 'tmpfolder', false)
+    cloudVar.setSettingsBin(true, true, true, 'tmpfolder', false)
 
-    assert.equal(cloudVar.conStatusBinStr(), 'Waiting for first run')
-    assert.equal(cloudVar.options.doBinUpload, true)
+    assert.equal(cloudVar.conStatusStr(), 'Waiting for first run')
+    assert.equal(cloudVar.options.uploadEnabled, true)
+    assert.equal(cloudVar.options.uploadLogs, true)
+    assert.equal(cloudVar.options.uploadMedia, true)
 
     clearInterval(cloudVar.intervalObj)
   })

--- a/server/cloudUpload.test.js
+++ b/server/cloudUpload.test.js
@@ -23,7 +23,7 @@ describe('Cloud Upload Functions', function () {
     assert.equal(cloudVar.options.uploadEnabled, false)
     assert.equal(cloudVar.conStatusStr(), 'Disabled')
 
-    cloudVar.setSettingsBin(true, true, true, 'tmpfolder', false)
+    cloudVar.setSettingsBin(true, true, true, 'tmpfolder', false, false)
 
     assert.equal(cloudVar.conStatusStr(), 'Waiting for first run')
     assert.equal(cloudVar.options.uploadEnabled, true)

--- a/server/index.js
+++ b/server/index.js
@@ -777,6 +777,18 @@ app.post('/api/binlogupload', authenticateToken, [check('uploadEnabled').isBoole
   }
 })
 
+// manually trigger a sync now, regardless of the uploadEnabled/onlyWhenDisarmed settings
+app.post('/api/cloudsyncnow', authenticateToken, (req, res) => {
+  res.setHeader('Content-Type', 'application/json')
+  try {
+    cloud.syncNow()
+    res.send(JSON.stringify({ ok: true }))
+  } catch (e) {
+    console.error('Failed to trigger cloud sync:', e)
+    res.status(500).send(JSON.stringify({ error: e.message }))
+  }
+})
+
 // Serve the logconversion info
 app.get('/api/logconversioninfo', authenticateToken, (req, res) => {
   logConversion.getSettings((doLogConversion) => {

--- a/server/index.js
+++ b/server/index.js
@@ -748,14 +748,16 @@ app.get('/api/ntripconfig', authenticateToken, (req, res) => {
 
 // Serve the cloud info
 app.get('/api/cloudinfo', authenticateToken, (req, res) => {
-  cloud.getSettings((doBinUpload, binUploadLink, syncDeletions, pubkey) => {
+  cloud.getSettings((uploadEnabled, uploadLogs, uploadMedia, binUploadLink, syncDeletions, pubkey) => {
     res.setHeader('Content-Type', 'application/json')
-    res.send(JSON.stringify({ doBinUpload, binUploadLink, syncDeletions, pubkey }))
+    res.send(JSON.stringify({ uploadEnabled, uploadLogs, uploadMedia, binUploadLink, syncDeletions, pubkey }))
   })
 })
 
-// activate or deactivate bin log upload
-app.post('/api/binlogupload', authenticateToken, [check('doBinUpload').isBoolean(),
+// activate or deactivate cloud upload
+app.post('/api/binlogupload', authenticateToken, [check('uploadEnabled').isBoolean(),
+  check('uploadLogs').isBoolean(),
+  check('uploadMedia').isBoolean(),
   check('binUploadLink').not().isEmpty().not().contains(';').not().contains('\'').not().contains('"').trim(),
   check('syncDeletions').isBoolean()], function (req, res) {
   const errors = validationResult(req)
@@ -764,11 +766,11 @@ app.post('/api/binlogupload', authenticateToken, [check('doBinUpload').isBoolean
     console.log('Bad POST vars in /api/binlogupload', { message: JSON.stringify(errors.array()) })
     return res.status(422).json({ error: JSON.stringify(errors.array()) })
   } else {
-    cloud.setSettingsBin(req.body.doBinUpload, req.body.binUploadLink, req.body.syncDeletions)
+    cloud.setSettingsBin(req.body.uploadEnabled, req.body.uploadLogs, req.body.uploadMedia, req.body.binUploadLink, req.body.syncDeletions)
     // send back refreshed settings
-    cloud.getSettings((doBinUpload, binUploadLink, syncDeletions) => {
+    cloud.getSettings((uploadEnabled, uploadLogs, uploadMedia, binUploadLink, syncDeletions) => {
       res.setHeader('Content-Type', 'application/json')
-      res.send(JSON.stringify({ doBinUpload, binUploadLink, syncDeletions }))
+      res.send(JSON.stringify({ uploadEnabled, uploadLogs, uploadMedia, binUploadLink, syncDeletions }))
     })
   }
 })
@@ -1148,7 +1150,7 @@ io.on('connection', function () {
   FCStatusLoop = setInterval(function () {
     io.sockets.emit('FCStatus', fcManager.getSystemStatus())
     io.sockets.emit('NTRIPStatus', ntripClient.conStatusStr())
-    io.sockets.emit('CloudBinStatus', cloud.conStatusBinStr())
+    io.sockets.emit('CloudUploadStatus', cloud.conStatusStr())
     io.sockets.emit('LogConversionStatus', logConversion.conStatusLogStr())
     io.sockets.emit('PPPStatus', pppConnectionManager.conStatusStr())
     io.sockets.emit('VideoStreamStatus', vManager.getStreamingStatus())

--- a/server/index.js
+++ b/server/index.js
@@ -748,9 +748,9 @@ app.get('/api/ntripconfig', authenticateToken, (req, res) => {
 
 // Serve the cloud info
 app.get('/api/cloudinfo', authenticateToken, (req, res) => {
-  cloud.getSettings((uploadEnabled, uploadLogs, uploadMedia, binUploadLink, syncDeletions, pubkey) => {
+  cloud.getSettings((uploadEnabled, uploadLogs, uploadMedia, binUploadLink, syncDeletions, windowsDestination, pubkey) => {
     res.setHeader('Content-Type', 'application/json')
-    res.send(JSON.stringify({ uploadEnabled, uploadLogs, uploadMedia, binUploadLink, syncDeletions, pubkey }))
+    res.send(JSON.stringify({ uploadEnabled, uploadLogs, uploadMedia, binUploadLink, syncDeletions, windowsDestination, pubkey }))
   })
 })
 
@@ -759,18 +759,19 @@ app.post('/api/binlogupload', authenticateToken, [check('uploadEnabled').isBoole
   check('uploadLogs').isBoolean(),
   check('uploadMedia').isBoolean(),
   check('binUploadLink').not().isEmpty().not().contains(';').not().contains('\'').not().contains('"').trim(),
-  check('syncDeletions').isBoolean()], function (req, res) {
+  check('syncDeletions').isBoolean(),
+  check('windowsDestination').isBoolean()], function (req, res) {
   const errors = validationResult(req)
   if (!errors.isEmpty()) {
     console.log(req.body)
     console.log('Bad POST vars in /api/binlogupload', { message: JSON.stringify(errors.array()) })
     return res.status(422).json({ error: JSON.stringify(errors.array()) })
   } else {
-    cloud.setSettingsBin(req.body.uploadEnabled, req.body.uploadLogs, req.body.uploadMedia, req.body.binUploadLink, req.body.syncDeletions)
+    cloud.setSettingsBin(req.body.uploadEnabled, req.body.uploadLogs, req.body.uploadMedia, req.body.binUploadLink, req.body.syncDeletions, req.body.windowsDestination)
     // send back refreshed settings
-    cloud.getSettings((uploadEnabled, uploadLogs, uploadMedia, binUploadLink, syncDeletions) => {
+    cloud.getSettings((uploadEnabled, uploadLogs, uploadMedia, binUploadLink, syncDeletions, windowsDestination) => {
       res.setHeader('Content-Type', 'application/json')
-      res.send(JSON.stringify({ uploadEnabled, uploadLogs, uploadMedia, binUploadLink, syncDeletions }))
+      res.send(JSON.stringify({ uploadEnabled, uploadLogs, uploadMedia, binUploadLink, syncDeletions, windowsDestination }))
     })
   }
 })

--- a/server/index.js
+++ b/server/index.js
@@ -69,7 +69,7 @@ const vManager = new videoStream(settings)
 const fcManager = new fcManagerClass(settings)
 const logManager = new flightLogger()
 const ntripClient = new ntrip(settings)
-const cloud = new cloudManager(settings)
+const cloud = new cloudManager(settings, fcManager)
 
 // Pass the fcManager instance to the videoStream,
 // so it can access position data for geotagging photos
@@ -748,9 +748,9 @@ app.get('/api/ntripconfig', authenticateToken, (req, res) => {
 
 // Serve the cloud info
 app.get('/api/cloudinfo', authenticateToken, (req, res) => {
-  cloud.getSettings((uploadEnabled, uploadLogs, uploadMedia, binUploadLink, syncDeletions, windowsDestination, pubkey) => {
+  cloud.getSettings((uploadEnabled, uploadLogs, uploadMedia, binUploadLink, syncDeletions, windowsDestination, onlyWhenDisarmed, vehicleArmedState, pubkey) => {
     res.setHeader('Content-Type', 'application/json')
-    res.send(JSON.stringify({ uploadEnabled, uploadLogs, uploadMedia, binUploadLink, syncDeletions, windowsDestination, pubkey }))
+    res.send(JSON.stringify({ uploadEnabled, uploadLogs, uploadMedia, binUploadLink, syncDeletions, windowsDestination, onlyWhenDisarmed, vehicleArmedState, pubkey }))
   })
 })
 
@@ -760,18 +760,19 @@ app.post('/api/binlogupload', authenticateToken, [check('uploadEnabled').isBoole
   check('uploadMedia').isBoolean(),
   check('binUploadLink').not().isEmpty().not().contains(';').not().contains('\'').not().contains('"').trim(),
   check('syncDeletions').isBoolean(),
-  check('windowsDestination').isBoolean()], function (req, res) {
+  check('windowsDestination').isBoolean(),
+  check('onlyWhenDisarmed').isBoolean()], function (req, res) {
   const errors = validationResult(req)
   if (!errors.isEmpty()) {
     console.log(req.body)
     console.log('Bad POST vars in /api/binlogupload', { message: JSON.stringify(errors.array()) })
     return res.status(422).json({ error: JSON.stringify(errors.array()) })
   } else {
-    cloud.setSettingsBin(req.body.uploadEnabled, req.body.uploadLogs, req.body.uploadMedia, req.body.binUploadLink, req.body.syncDeletions, req.body.windowsDestination)
+    cloud.setSettingsBin(req.body.uploadEnabled, req.body.uploadLogs, req.body.uploadMedia, req.body.binUploadLink, req.body.syncDeletions, req.body.windowsDestination, req.body.onlyWhenDisarmed)
     // send back refreshed settings
-    cloud.getSettings((uploadEnabled, uploadLogs, uploadMedia, binUploadLink, syncDeletions, windowsDestination) => {
+    cloud.getSettings((uploadEnabled, uploadLogs, uploadMedia, binUploadLink, syncDeletions, windowsDestination, onlyWhenDisarmed, vehicleArmedState) => {
       res.setHeader('Content-Type', 'application/json')
-      res.send(JSON.stringify({ uploadEnabled, uploadLogs, uploadMedia, binUploadLink, syncDeletions, windowsDestination }))
+      res.send(JSON.stringify({ uploadEnabled, uploadLogs, uploadMedia, binUploadLink, syncDeletions, windowsDestination, onlyWhenDisarmed, vehicleArmedState }))
     })
   }
 })
@@ -1152,6 +1153,7 @@ io.on('connection', function () {
     io.sockets.emit('FCStatus', fcManager.getSystemStatus())
     io.sockets.emit('NTRIPStatus', ntripClient.conStatusStr())
     io.sockets.emit('CloudUploadStatus', cloud.conStatusStr())
+    io.sockets.emit('CloudVehicleArmedState', cloud.getVehicleArmedState())
     io.sockets.emit('LogConversionStatus', logConversion.conStatusLogStr())
     io.sockets.emit('PPPStatus', pppConnectionManager.conStatusStr())
     io.sockets.emit('VideoStreamStatus', vManager.getStreamingStatus())

--- a/server/paths.js
+++ b/server/paths.js
@@ -30,5 +30,6 @@ module.exports = {
     flightsLogsDir: path.join(baseDir, 'flightlogs'),
     kmzDir: path.join(baseDir, 'flightlogs', 'kmzlogs'),
     mediaDir: path.join(baseDir, 'media'),
+    sshDir: path.join(baseDir, 'config', 'ssh'),
     getPythonPath: getPythonPath,
 };

--- a/src/cloud.jsx
+++ b/src/cloud.jsx
@@ -17,6 +17,7 @@ class CloudConfig extends basePage {
       binUploadLink: '',
       uploadStatus: 'N/A',
       syncDeletions: false,
+      windowsDestination: false,
       pubkey: []
     }
 
@@ -55,6 +56,10 @@ class CloudConfig extends basePage {
     this.setState({ syncDeletions: event.target.checked });
   }
 
+  toggleWindowsDestination = event => {
+    this.setState({ windowsDestination: event.target.checked });
+  }
+
   toggleUploadLogs = event => {
     this.setState({ uploadLogs: event.target.checked });
   }
@@ -78,6 +83,7 @@ class CloudConfig extends basePage {
             uploadLogs: this.state.uploadLogs,
             uploadMedia: this.state.uploadMedia,
             syncDeletions: this.state.syncDeletions,
+            windowsDestination: this.state.windowsDestination,
         })
       })
       .then(response => response.json())
@@ -110,6 +116,12 @@ class CloudConfig extends basePage {
                         <label className="col-sm-3 col-form-label">Sync file deletions</label>
                         <div className="col-sm-7">
                         <input name="syncDeletions" type="checkbox" disabled={this.state.uploadEnabled === true ? true : false} checked={this.state.syncDeletions} onChange={this.toggleSyncDelete}/>
+                        </div>
+                    </div>
+                    <div className="form-group row" style={{ marginBottom: '5px' }}>
+                        <label className="col-sm-3 col-form-label">Destination is Windows</label>
+                        <div className="col-sm-7">
+                        <input name="windowsDestination" type="checkbox" disabled={this.state.uploadEnabled === true ? true : false} checked={this.state.windowsDestination} onChange={this.toggleWindowsDestination}/>
                         </div>
                     </div>
                     <div className="form-group row" style={{ marginBottom: '5px' }}>

--- a/src/cloud.jsx
+++ b/src/cloud.jsx
@@ -18,12 +18,17 @@ class CloudConfig extends basePage {
       uploadStatus: 'N/A',
       syncDeletions: false,
       windowsDestination: false,
+      onlyWhenDisarmed: false,
+      vehicleArmedState: 'unknown',
       pubkey: []
     }
 
     //Socket.io client for reading in analog update values
     this.socket.on('CloudUploadStatus', function (msg) {
       this.setState({ uploadStatus: msg })
+    }.bind(this))
+    this.socket.on('CloudVehicleArmedState', function (msg) {
+      this.setState({ vehicleArmedState: msg })
     }.bind(this))
     this.socket.on('reconnect', function () {
       //refresh state
@@ -60,6 +65,10 @@ class CloudConfig extends basePage {
     this.setState({ windowsDestination: event.target.checked });
   }
 
+  toggleOnlyWhenDisarmed = event => {
+    this.setState({ onlyWhenDisarmed: event.target.checked });
+  }
+
   toggleUploadLogs = event => {
     this.setState({ uploadLogs: event.target.checked });
   }
@@ -84,6 +93,7 @@ class CloudConfig extends basePage {
             uploadMedia: this.state.uploadMedia,
             syncDeletions: this.state.syncDeletions,
             windowsDestination: this.state.windowsDestination,
+            onlyWhenDisarmed: this.state.onlyWhenDisarmed,
         })
       })
       .then(response => response.json())
@@ -122,6 +132,13 @@ class CloudConfig extends basePage {
                         <label className="col-sm-3 col-form-label">Destination is Windows</label>
                         <div className="col-sm-7">
                         <input name="windowsDestination" type="checkbox" disabled={this.state.uploadEnabled === true ? true : false} checked={this.state.windowsDestination} onChange={this.toggleWindowsDestination}/>
+                        </div>
+                    </div>
+                    <div className="form-group row" style={{ marginBottom: '5px' }}>
+                        <label className="col-sm-3 col-form-label">Only upload while disarmed</label>
+                        <div className="col-sm-7" style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
+                        <input name="onlyWhenDisarmed" type="checkbox" disabled={this.state.uploadEnabled === true ? true : false} checked={this.state.onlyWhenDisarmed} onChange={this.toggleOnlyWhenDisarmed}/>
+                        <span>Vehicle state: {this.state.vehicleArmedState.charAt(0).toUpperCase() + this.state.vehicleArmedState.slice(1)}</span>
                         </div>
                     </div>
                     <div className="form-group row" style={{ marginBottom: '5px' }}>

--- a/src/cloud.jsx
+++ b/src/cloud.jsx
@@ -104,6 +104,49 @@ class CloudConfig extends basePage {
       });
   }
 
+  handleUploadNowSubmit = () => {
+    // Save the current form settings first (without toggling Enable/Disable) so
+    // Upload Now reflects what's on screen, not just what was last saved -
+    // then trigger a sync immediately, regardless of the Enable/disarmed settings.
+    fetch('/api/binlogupload', {
+        method: 'POST',
+        headers: {
+          'Accept': 'application/json',
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${this.state.token}`
+        },
+        body: JSON.stringify({
+            binUploadLink: this.state.binUploadLink,
+            uploadEnabled: this.state.uploadEnabled,
+            uploadLogs: this.state.uploadLogs,
+            uploadMedia: this.state.uploadMedia,
+            syncDeletions: this.state.syncDeletions,
+            windowsDestination: this.state.windowsDestination,
+            onlyWhenDisarmed: this.state.onlyWhenDisarmed,
+        })
+      })
+      .then(response => response.json())
+      .then(state => {
+        this.setState(state)
+        return fetch('/api/cloudsyncnow', {
+          method: 'POST',
+          headers: {
+            'Accept': 'application/json',
+            'Authorization': `Bearer ${this.state.token}`
+          }
+        })
+      })
+      .then(response => {
+        if (!response.ok) {
+          return response.json().then(body => { throw new Error(body.error || `Server returned ${response.status}`) });
+        }
+      })
+      .catch(err => {
+        console.error('Failed to trigger upload now:', err);
+        this.setState({ error: `Could not start the upload: ${err.message}. Check the server log (journalctl -u rpanion-server) if this keeps happening.` });
+      });
+  }
+
   renderTitle () {
     return 'Cloud Upload'
   }
@@ -150,8 +193,9 @@ class CloudConfig extends basePage {
                     </div>
 
                     <div className="form-group row" style={{ marginBottom: '5px' }}>
-                        <div className="col-sm-10">
+                        <div className="col-sm-10" style={{ display: 'flex', gap: '10px' }}>
                         <Button onClick={this.handleToggleUploadSubmit} className="btn btn-primary">{this.state.uploadEnabled === true ? 'Disable' : 'Enable'}</Button>
+                        <Button onClick={this.handleUploadNowSubmit} disabled={!this.state.binUploadLink} className="btn btn-secondary">Upload Now</Button>
                         </div>
                     </div>
                     <p>Status: {this.state.uploadStatus}</p>

--- a/src/cloud.jsx
+++ b/src/cloud.jsx
@@ -29,7 +29,14 @@ class CloudConfig extends basePage {
   }
 
   componentDidMount () {
-    fetch('/api/cloudinfo', {headers: {Authorization: `Bearer ${this.state.token}`}}).then(response => response.json()).then(state => { this.setState(state); this.loadDone() })
+    fetch('/api/cloudinfo', {headers: {Authorization: `Bearer ${this.state.token}`}})
+      .then(response => response.json())
+      .then(state => { this.setState(state); this.loadDone() })
+      .catch(err => {
+        console.error('Failed to load cloud info:', err);
+        this.setState({ error: err.message });
+        this.loadDone();
+      })
   }
 
   changeHandler = event => {
@@ -60,7 +67,13 @@ class CloudConfig extends basePage {
             doBinUpload: !this.state.doBinUpload,
             syncDeletions: this.state.syncDeletions,
         })
-      }).then(response => response.json()).then(state => { this.setState(state) });
+      })
+      .then(response => response.json())
+      .then(state => { this.setState(state) })
+      .catch(err => {
+        console.error('Failed to update cloud upload settings:', err);
+        this.setState({ error: err.message });
+      });
   }
 
   renderTitle () {

--- a/src/cloud.jsx
+++ b/src/cloud.jsx
@@ -11,16 +11,18 @@ class CloudConfig extends basePage {
     super(props, useSocketIO)
     this.state = {
       ...this.state,
-      doBinUpload: false,
+      uploadEnabled: false,
+      uploadLogs: true,
+      uploadMedia: true,
       binUploadLink: '',
-      binLogStatus: 'N/A',
+      uploadStatus: 'N/A',
       syncDeletions: false,
       pubkey: []
     }
 
     //Socket.io client for reading in analog update values
-    this.socket.on('CloudBinStatus', function (msg) {
-      this.setState({ binLogStatus: msg })
+    this.socket.on('CloudUploadStatus', function (msg) {
+      this.setState({ uploadStatus: msg })
     }.bind(this))
     this.socket.on('reconnect', function () {
       //refresh state
@@ -53,8 +55,16 @@ class CloudConfig extends basePage {
     this.setState({ syncDeletions: event.target.checked });
   }
 
-  handleDoBinUploadSubmit = () => {
-    //user clicked enable/disable bin file upload
+  toggleUploadLogs = event => {
+    this.setState({ uploadLogs: event.target.checked });
+  }
+
+  toggleUploadMedia = event => {
+    this.setState({ uploadMedia: event.target.checked });
+  }
+
+  handleToggleUploadSubmit = () => {
+    //user clicked enable/disable cloud upload
     fetch('/api/binlogupload', {
         method: 'POST',
         headers: {
@@ -64,7 +74,9 @@ class CloudConfig extends basePage {
         },
         body: JSON.stringify({
             binUploadLink: this.state.binUploadLink,
-            doBinUpload: !this.state.doBinUpload,
+            uploadEnabled: !this.state.uploadEnabled,
+            uploadLogs: this.state.uploadLogs,
+            uploadMedia: this.state.uploadMedia,
             syncDeletions: this.state.syncDeletions,
         })
       })
@@ -83,31 +95,37 @@ class CloudConfig extends basePage {
   renderContent () {
     return (
             <div>
-              <p><i>Automatically upload binlogs from the &quot;Flight Logs&quot; page to a remote (network) destination over an ssh connection</i></p>
-                <h3>Bin Logs Upload</h3>
-                <p>All bin logs (in Flight Logs -&gt; Bin Logs) will be synchonised to the following remote destination using rsync.</p>
-                <p>The synchonisation runs every 20 seconds.</p>
+              <p><i>Automatically upload flight logs and/or media to a remote (network) destination over an ssh connection</i></p>
+                <h3>Cloud Upload</h3>
+                <p>Selected items are synchronised to the remote destination below using rsync, every 20 seconds. Logs (Flight Logs -&gt; Bin Logs) are synced to the destination itself; Media (photos/videos) is synced to a <code>media</code> subfolder there.</p>
                 <p>Destination format is <code>username@server:/path/to/remote/dir</code>, where <code>username</code> has an ssh publickey on the remote server.</p>
                 <Form style={{ width: 700 }}>
                     <div className="form-group row" style={{ marginBottom: '5px' }}>
                         <label className="col-sm-3 col-form-label">Rsync Destination</label>
                         <div className="col-sm-7">
-                            <input type="text" className="form-control" name="binUploadLink" disabled={this.state.doBinUpload === true ? true : false} onChange={this.changeHandler} value={this.state.binUploadLink}/>
+                            <input type="text" className="form-control" name="binUploadLink" disabled={this.state.uploadEnabled === true ? true : false} onChange={this.changeHandler} value={this.state.binUploadLink}/>
                         </div>
                     </div>
                     <div className="form-group row" style={{ marginBottom: '5px' }}>
                         <label className="col-sm-3 col-form-label">Sync file deletions</label>
                         <div className="col-sm-7">
-                        <input name="syncDeletions" type="checkbox" disabled={this.state.doBinUpload === true ? true : false} checked={this.state.syncDeletions} onChange={this.toggleSyncDelete}/>
+                        <input name="syncDeletions" type="checkbox" disabled={this.state.uploadEnabled === true ? true : false} checked={this.state.syncDeletions} onChange={this.toggleSyncDelete}/>
                         </div>
                     </div>
-                    
+                    <div className="form-group row" style={{ marginBottom: '5px' }}>
+                        <label className="col-sm-3 col-form-label">Upload</label>
+                        <div className="col-sm-7" style={{ display: 'flex', gap: '24px' }}>
+                          <Form.Check inline type="checkbox" label="Logs" name="uploadLogs" disabled={this.state.uploadEnabled === true ? true : false} checked={this.state.uploadLogs} onChange={this.toggleUploadLogs}/>
+                          <Form.Check inline type="checkbox" label="Media" name="uploadMedia" disabled={this.state.uploadEnabled === true ? true : false} checked={this.state.uploadMedia} onChange={this.toggleUploadMedia}/>
+                        </div>
+                    </div>
+
                     <div className="form-group row" style={{ marginBottom: '5px' }}>
                         <div className="col-sm-10">
-                        <Button onClick={this.handleDoBinUploadSubmit} className="btn btn-primary">{this.state.doBinUpload === true ? 'Disable' : 'Enable'}</Button>
+                        <Button onClick={this.handleToggleUploadSubmit} className="btn btn-primary">{this.state.uploadEnabled === true ? 'Disable' : 'Enable'}</Button>
                         </div>
                     </div>
-                    <p>Status: {this.state.binLogStatus}</p>
+                    <p>Status: {this.state.uploadStatus}</p>
                 </Form>
                 <h3>Publickeys</h3>
                 <p><i>All publickeys on this device</i></p>


### PR DESCRIPTION
This makes various fixes and small improvements to the Cloud Upload page:

- Fix page hanging forever on load (it use to look like below)

<img width="785" height="350" alt="image" src="https://github.com/user-attachments/assets/7c35dc60-2f40-4b96-8e80-a149b003851c" />

- Media (e.g. pictures, videos) may be uploaded to the cloud
- Syncs are left running longer than 20 sec to allow larger uploads (still timesout after 5 min)
- Option to better handle sync to Windows destinations by slightly changing rsync flags
- Option to only upload while disarmed
- Fix .gitignore not actually ignoring config/settings.json

This has been fairly well tested on an RPI CM5 and lightly tested on an RPI CM4